### PR TITLE
Fix missing 'smtp_from' variable when notifications are turned off

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -70,6 +70,9 @@ module Greenlight
       config.action_mailer.default_options = {
         from: config.smtp_from
       }
+    else
+      # this needs to be set because it's always used to configure mailers
+      config.smtp_from = ""
     end
   end
 end


### PR DESCRIPTION
Application would break in production because `Rails.config.smtp_from` was not set if `GREENLIGHT_MAIL_NOTIFICATIONS` was false.

It's used by `app/mailers/notification_mailer.rb`, so it's required to be set to something, even if no email will be sent.