### PR TITLE
Don't ask for a name in the landing page, redir to the room/meeting

### DIFF
--- a/app/assets/javascripts/landing.js
+++ b/app/assets/javascripts/landing.js
@@ -34,7 +34,7 @@
     if (!nameInput.val()) {
       var lastName = localStorage.getItem('lastJoinedName');
       if (lastName !== 'undefined') {
-        nameInput.val(localStorage.getItem('lastJoinedName'));
+        nameInput.val(lastName);
       }
     }
 

--- a/app/assets/javascripts/landing.js
+++ b/app/assets/javascripts/landing.js
@@ -32,7 +32,10 @@
     Meeting.clear();
     var nameInput = $('.meeting-user-name');
     if (!nameInput.val()) {
-      nameInput.val(localStorage.getItem('lastJoinedName'));
+      var lastName = localStorage.getItem('lastJoinedName');
+      if (lastName !== 'undefined') {
+        nameInput.val(localStorage.getItem('lastJoinedName'));
+      }
     }
 
     // setup event handlers
@@ -40,18 +43,25 @@
       var name = $('.meeting-user-name').val();
       Meeting.getInstance().setName(name);
       Meeting.getInstance().setId($(".page-wrapper").data('id'));
-      var jqxhr = Meeting.getInstance().getJoinMeetingResponse();
 
-      jqxhr.done(function(data) {
-        if (data.messageKey === 'wait_for_moderator') {
-          waitForModerator(Meeting.getInstance().getURL());
-        } else {
-          $(location).attr("href", data.response.join_url);
-        }
-      });
-      jqxhr.fail(function(xhr, status, error) {
-        console.info("meeting join failed");
-      });
+      // a user name is set, join the user into the session
+      if (name !== undefined && name !== null) {
+        var jqxhr = Meeting.getInstance().getJoinMeetingResponse();
+        jqxhr.done(function(data) {
+          if (data.messageKey === 'wait_for_moderator') {
+            waitForModerator(Meeting.getInstance().getURL());
+          } else {
+            $(location).attr("href", data.response.join_url);
+          }
+        });
+        jqxhr.fail(function(xhr, status, error) {
+          console.info("meeting join failed");
+        });
+
+      // if not user name was set it means we must ask for a name
+      } else {
+        $(location).attr("href", Meeting.getInstance().getURL());
+      }
     });
 
     $('.center-panel-wrapper').on ('keypress', '.meeting-user-name', function (event) {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,6 +43,11 @@ module ApplicationHelper
     end
   end
 
+  # Whether the current page is the page of a room/meeting or not
+  def on_room_or_meeting_page?
+    params[:id].present?
+  end
+
   def version
     Greenlight::VERSION
   rescue

--- a/app/views/shared/_join_form.html.erb
+++ b/app/views/shared/_join_form.html.erb
@@ -16,12 +16,13 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 <div class="join-form-wrapper">
   <div class="center-block">
     <div class="join-form input-group input-spacing">
+
+      <!-- if the user is signed in, add a hidden input with their name -->
       <% if current_user %>
-        <% @current_user = current_user %>
-        <%= text_field :current_user, :name, class: 'form-control meeting-user-name', type: 'hidden' %>
-      <% else %>
-        <%= text_field :nil, :nil, class: 'form-control meeting-user-name', placeholder: t('enter_name') %>
+        <%= text_field_tag 'user[name]', current_user.name, class: 'form-control meeting-user-name', type: 'hidden' %>
       <% end %>
+
+      <!-- if admin means the user is signed in and owns the room -->
       <% if admin? %>
         <% if @meeting_running %>
           <div class="col-sm-6">
@@ -36,19 +37,33 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           </div>
         <% else %>
           <button type="button" class="btn btn-primary center-block meeting-join">
-            <%= t('start') %>
+            <%= t('start_meeting') %>
           </button>
         <% end %>
-      <% elsif current_user %>
-        <button type="button" class="btn btn-primary center-block meeting-join">
-          <%= t('join') %>
-        </button>
       <% else %>
-        <span class="input-group-btn">
-          <button type="button" class="btn btn-primary meeting-join">
-            <%= t('join') %>
+
+        <!-- on the page of a room/meeting, the user might have to enter a name -->
+        <% if on_room_or_meeting_page? %>
+          <% if current_user %>
+            <button type="button" class="btn btn-primary center-block meeting-join">
+              <%= t('join') %>
+            </button>
+          <% else %>
+            <%= text_field_tag 'user[name]', '', class: 'form-control meeting-user-name', placeholder: t('enter_name') %>
+            <span class="input-group-btn">
+              <button type="button" class="btn btn-primary center-block meeting-join">
+                <%= t('join') %>
+              </button>
+            </span>
+          <% end %>
+
+        <!-- on the landing page we don't ask for a name, just show the start button -->
+        <% else %>
+          <button type="button" class="btn btn-primary center-block meeting-join">
+            <%= t('start_meeting') %>
           </button>
-        </span>
+        <% end %>
+
       <% end %>
     </div>
   </div>

--- a/config/locales/en-us.yml
+++ b/config/locales/en-us.yml
@@ -98,6 +98,7 @@ en-US:
   return_to_room: Return to your personal room
   session_url_explanation: The meeting will be taking place using the following URL
   start: Start
+  start_meeting: Start Meeting
   your_personal_room: Your Personal Room
   thumbnails: Thumbnails
   unlisted: Unlisted


### PR DESCRIPTION
Instead of asking the user for a name in the landing page, it just redirects to the room/meeting page, where the user is asked to enter a name. If the user is signed in, no redirect is necessary and the user's name is used automatically.

For issue #78.