### PR TITLE
rescue on bbb create if meeting already exists

### DIFF
--- a/app/lib/bbb_api.rb
+++ b/app/lib/bbb_api.rb
@@ -95,7 +95,11 @@ module BbbApi
         end
 
         # Create the meeting
-        bbb.create_meeting(options[:meeting_name], meeting_id, meeting_options)
+        begin
+          bbb.create_meeting(options[:meeting_name], meeting_id, meeting_options)
+        rescue BigBlueButton::BigBlueButtonException => exc
+          logger.info "BBB error on create #{exc.key}: #{exc.message}"
+        end
 
         # And then get meeting info
         bbb_meeting_info = bbb.get_meeting_info( meeting_id, nil )


### PR DESCRIPTION
Fixes error when two people try to create the same meeting name at the same time