### PR TITLE
email configuration check

### DIFF
--- a/app/mailers/test_mailer.rb
+++ b/app/mailers/test_mailer.rb
@@ -1,0 +1,24 @@
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+#
+# Copyright (c) 2016 BigBlueButton Inc. and by respective authors (see below).
+#
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free Software
+# Foundation; either version 3.0 of the License, or (at your option) any later
+# version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+
+class TestMailer < ActionMailer::Base
+  default from: Rails.configuration.smtp_from
+
+  def test_email(email)
+    @email = email
+    mail(to: email, subject: t('.subject'))
+  end
+end

--- a/app/views/test_mailer/test_email.html.erb
+++ b/app/views/test_mailer/test_email.html.erb
@@ -1,0 +1,24 @@
+<%
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+# Copyright (c) 2016 BigBlueButton Inc. and by respective authors (see below).
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free Software
+# Foundation; either version 3.0 of the License, or (at your option) any later
+# version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+%>
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p><%= t('.phrase1', email: @email) %></p>
+  </body>
+</html>

--- a/config/locales/en-us.yml
+++ b/config/locales/en-us.yml
@@ -137,6 +137,10 @@ en-US:
   start: Start
   start_join: Start
   start_meeting: Start meeting
+  test_mailer:
+    test_email:
+      subject: Test Email
+      phrase1: This is a test email sent to %{email}
   thumbnails: Thumbnails
   url_copy_explanation: Copy this URL to invite others to the meeting
   user_person_room: "%{name} personal room"

--- a/lib/tasks/configuration.rake
+++ b/lib/tasks/configuration.rake
@@ -27,6 +27,31 @@ namespace :conf  do
     test_request("#{ENV['BIGBLUEBUTTON_ENDPOINT']}api/getMeetings?checksum=#{checksum}")
     passed
   end
+
+  desc "Check Email Configuration"
+  task :check_email, [:email] => :environment do |task, args|
+    ENV_VARIABLES = ['GREENLIGHT_MAIL_NOTIFICATIONS', 'GREENLIGHT_DOMAIN',
+      'SMTP_FROM', 'SMTP_SERVER', 'SMTP_PORT', 'SMTP_DOMAIN',
+      'SMTP_USERNAME', 'SMTP_PASSWORD']
+    email_address = args[:email]
+
+    print "Checking environment"
+    ENV_VARIABLES.each do |var|
+      if ENV[var].blank?
+        failed("#{var} not set correctly")
+      end
+    end
+    passed
+
+    # send a test email to specified email address
+    print "Sending Test Email"
+    if email_address
+      send_email(email_address)
+      print(": Sent\n")
+    else
+      failed("No email address specified")
+    end
+  end
 end
 
 # takes the full URL including the protocol
@@ -42,6 +67,12 @@ def test_request(url)
   rescue => exc
     failed("Error connecting to BigBlueButton server - #{exc}")
   end
+end
+
+def send_email(email_address)
+  TestMailer.test_email(email_address).deliver
+rescue => exc
+  failed("Error sending test email - #{exc}")
 end
 
 def failed(msg)


### PR DESCRIPTION
Checks that the following is set:
GREENLIGHT_MAIL_NOTIFICATIONS
GREENLIGHT_DOMAIN
SMTP_FROM
SMTP_SERVER
SMTP_PORT
SMTP_DOMAIN
SMTP_USERNAME
SMTP_PASSWORD

Then sends a test email to a specified email address

command is `rake conf:check_email`

Note this doesn't test that the `recording_ready` script was installed correctly

part of #156