### PR TITLE
skip authenticity token on errors controller

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -15,6 +15,8 @@
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 class ErrorsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
   def error
   end
 


### PR DESCRIPTION
don't need to verify authenticity on error pages