### PR TITLE
Slack Integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,5 @@ gem 'jquery-datatables-rails', '~> 3.4.0'
 gem 'rails-timeago', '~> 2.0'
 
 gem 'http_accept_language'
+
+gem 'slack-notifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slack-notifier (2.1.0)
     spring (2.0.0)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -247,6 +248,7 @@ DEPENDENCIES
   rails-timeago (~> 2.0)
   sass-rails (~> 5.0)
   simplecov
+  slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3

--- a/app/controllers/bbb_controller.rb
+++ b/app/controllers/bbb_controller.rb
@@ -91,7 +91,7 @@ class BbbController < ApplicationController
       # the user can join the meeting
       if user
         if bbb_res[:returncode] && current_user == user
-          JoinMeetingJob.perform_later(user.encrypted_id, params[:id])
+          JoinMeetingJob.perform_later(user, params[:id], base_url)
 
       # user will be waiting for a moderator
         else

--- a/app/jobs/end_meeting_job.rb
+++ b/app/jobs/end_meeting_job.rb
@@ -18,6 +18,7 @@ class EndMeetingJob < ApplicationJob
   queue_as :default
 
   def perform(room, meeting)
+    Rails.configuration.slack_notifier.ping "#{meeting} has ended." if Rails.application.config.slack_webhook
     ActionCable.server.broadcast "#{room}-#{meeting}_meeting_updates_channel",
       action: 'meeting_ended'
   end

--- a/app/jobs/end_meeting_job.rb
+++ b/app/jobs/end_meeting_job.rb
@@ -19,8 +19,8 @@ class EndMeetingJob < ApplicationJob
 
   def perform(room, meeting)
 
-    Rails.configuration.slack_notifier.ping I18n.t('slack.meeting_end', meeting: meeting) if Rails.application.config.slack_webhook
-    
+    Rails.application.config.slack_notifier.ping I18n.t('slack.meeting_end', meeting: meeting) if Rails.application.config.slack_webhook
+
     ActionCable.server.broadcast "#{room}-#{meeting}_meeting_updates_channel",
       action: 'meeting_ended'
   end

--- a/app/jobs/end_meeting_job.rb
+++ b/app/jobs/end_meeting_job.rb
@@ -18,7 +18,9 @@ class EndMeetingJob < ApplicationJob
   queue_as :default
 
   def perform(room, meeting)
-    Rails.configuration.slack_notifier.ping "#{meeting} has ended." if Rails.application.config.slack_webhook
+
+    Rails.configuration.slack_notifier.ping I18n.t('slack.meeting_end', meeting: meeting) if Rails.application.config.slack_webhook
+    
     ActionCable.server.broadcast "#{room}-#{meeting}_meeting_updates_channel",
       action: 'meeting_ended'
   end

--- a/app/jobs/join_meeting_job.rb
+++ b/app/jobs/join_meeting_job.rb
@@ -21,8 +21,8 @@ def perform(user, meeting, base_url)
 
     join_message = I18n.t('slack.meeting_join', user: user.name, meeting: meeting) + "(#{base_url})"
     formatted = Slack::Notifier::Util::LinkFormatter.format(join_message)
-    Rails.configuration.slack_notifier.ping formatted if Rails.application.config.slack_webhook
-    
+    Rails.application.config.slack_notifier.ping formatted if Rails.application.config.slack_webhook
+
     ActionCable.server.broadcast "#{user.encrypted_id}-#{meeting}_meeting_updates_channel",
       action: 'moderator_joined',
       moderator: 'joined'

--- a/app/jobs/join_meeting_job.rb
+++ b/app/jobs/join_meeting_job.rb
@@ -18,8 +18,11 @@ class JoinMeetingJob < ApplicationJob
   queue_as :default
 
 def perform(user, meeting, base_url)
-    join_message = "#{user.name} joined #{meeting}.\n[Click here join!](#{base_url})"
-    Rails.configuration.slack_notifier.ping Slack::Notifier::Util::LinkFormatter.format(join_message) if Rails.application.config.slack_webhook
+
+    join_message = I18n.t('slack.meeting_join', user: user.name, meeting: meeting) + "(#{base_url})"
+    formatted = Slack::Notifier::Util::LinkFormatter.format(join_message)
+    Rails.configuration.slack_notifier.ping formatted if Rails.application.config.slack_webhook
+    
     ActionCable.server.broadcast "#{user.encrypted_id}-#{meeting}_meeting_updates_channel",
       action: 'moderator_joined',
       moderator: 'joined'

--- a/app/jobs/recording_updates_job.rb
+++ b/app/jobs/recording_updates_job.rb
@@ -25,7 +25,7 @@ class RecordingUpdatesJob < ApplicationJob
 
     # send message about recording to a slack channel.
     slack_message = "A recording of #{recording[:metadata][:"meeting-name"]} was " + (recording[:metadata][:"gl-listed"] == "true" ? "published." : "unpublished.")
-    Rails.configuration.slack_notifier.ping slack_message
+    Rails.configuration.slack_notifier.ping slack_message if Rails.application.config.slack_webhook
 
     ActionCable.server.broadcast "#{room}_recording_updates_channel",
       action: 'update',

--- a/app/jobs/recording_updates_job.rb
+++ b/app/jobs/recording_updates_job.rb
@@ -23,8 +23,8 @@ class RecordingUpdatesJob < ApplicationJob
     recording = bbb_get_recordings({recordID: record_id})[:recordings].first
     full_id = "#{room}-#{recording[:metadata][:"meeting-name"]}"
 
-    # send message about recording to a slack channel.
-    slack_message = "A recording of #{recording[:metadata][:"meeting-name"]} was " + (recording[:metadata][:"gl-listed"] == "true" ? "published." : "unpublished.")
+    change = (recording[:metadata][:"gl-listed"] == "true") ? I18n.t('slack.published') : I18n.t('slack.unpublished')
+    slack_message = I18n.t('slack.recording_visibility', meeting: recording[:metadata][:"meeting-name"], change: change)
     Rails.configuration.slack_notifier.ping slack_message if Rails.application.config.slack_webhook
 
     ActionCable.server.broadcast "#{room}_recording_updates_channel",

--- a/app/jobs/recording_updates_job.rb
+++ b/app/jobs/recording_updates_job.rb
@@ -22,6 +22,11 @@ class RecordingUpdatesJob < ApplicationJob
   def perform(room, record_id)
     recording = bbb_get_recordings({recordID: record_id})[:recordings].first
     full_id = "#{room}-#{recording[:metadata][:"meeting-name"]}"
+
+    # send message about recording to a slack channel.
+    slack_message = "A recording of #{recording[:metadata][:"meeting-name"]} was " + (recording[:metadata][:"gl-listed"] == "true" ? "published." : "unpublished.")
+    Rails.configuration.slack_notifier.ping slack_message
+
     ActionCable.server.broadcast "#{room}_recording_updates_channel",
       action: 'update',
       id: record_id,

--- a/app/jobs/recording_updates_job.rb
+++ b/app/jobs/recording_updates_job.rb
@@ -25,7 +25,7 @@ class RecordingUpdatesJob < ApplicationJob
 
     change = (recording[:metadata][:"gl-listed"] == "true") ? I18n.t('slack.published') : I18n.t('slack.unpublished')
     slack_message = I18n.t('slack.recording_visibility', meeting: recording[:metadata][:"meeting-name"], change: change)
-    Rails.configuration.slack_notifier.ping slack_message if Rails.application.config.slack_webhook
+    Rails.application.config.slack_notifier.ping slack_message if Rails.application.config.slack_webhook
 
     ActionCable.server.broadcast "#{room}_recording_updates_channel",
       action: 'update',

--- a/config/initializers/slack.rb
+++ b/config/initializers/slack.rb
@@ -14,14 +14,11 @@
 # You should have received a copy of the GNU Lesser General Public License along
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
-class JoinMeetingJob < ApplicationJob
-  queue_as :default
+Rails.application.config.slack_webhook = ENV['SLACK_WEBHOOK'].present?
 
-def perform(user, meeting, base_url)
-    join_message = "#{user.name} joined #{meeting}.\n[Click here join!](#{base_url})"
-    Rails.configuration.slack_notifier.ping Slack::Notifier::Util::LinkFormatter.format(join_message) if Rails.application.config.slack_webhook
-    ActionCable.server.broadcast "#{user.encrypted_id}-#{meeting}_meeting_updates_channel",
-      action: 'moderator_joined',
-      moderator: 'joined'
-  end
+# Initialize the slack notifier.
+Rails.application.config.slack_notifier = Slack::Notifier.new ENV['SLACK_WEBHOOK'] do
+  defaults channel: ENV['SLACK_CHANNEL'],
+           username: "BigBlueButton",
+           icon_url: 'https://avatars3.githubusercontent.com/u/230228?v=3&s=200'
 end

--- a/config/locales/en-us.yml
+++ b/config/locales/en-us.yml
@@ -134,6 +134,12 @@ en-US:
   return_to_room: Return to main page
   session_url_explanation: The meeting will be taking place using the following URL
   signin_text: Log in with %{provider}
+  slack:
+    meeting_end: "%{meeting} has ended."
+    meeting_join: "%{user} joined %{meeting}.\n[Click here join!]"
+    recording_visibility: "A recording of %{meeting} was %{change}"
+    published: published
+    unpublished: unpublished
   start: Start
   start_join: Start
   start_meeting: Start meeting

--- a/env
+++ b/env
@@ -37,6 +37,17 @@ TWITTER_SECRET=
 GOOGLE_OAUTH2_ID=
 GOOGLE_OAUTH2_SECRET=
 
+# Slack Integration (optional)
+#
+#   You will need to register a incoming-webhook for your slack channel
+#   in order for GreenLight to post to it. You can do this by going
+#   to https://slack.com/apps/A0F7XDUAZ-incoming-webhooks, selecting your
+#   team and then selecting "Add Incoming WebHooks integration" on the
+#   desired channel. You will then need to paste the webhook below.
+#
+SLACK_WEBHOOK=
+SLACK_CHANNEL=
+
 # If "true", GreenLight will register a webhook callback for each meeting
 # created. This callback is called for all events that happen in the meeting,
 # including the processing of its recording. These events are used to update


### PR DESCRIPTION
Added the ability to configure a slack group and channel to have Greenlight send messages about recordings being published/unpublished, users joining meetings, and meetings ending.