### PR TITLE
Fix Google authentication and update Omniauth to 1.6.1.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'omniauth', '1.3.1'
+gem 'omniauth', '1.6.1'
 gem 'omniauth-twitter', '1.2.1'
 gem 'omniauth-google-oauth2', '0.4.1'
 gem 'omniauth-ldap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,9 +139,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.3.1)
-      hashie (>= 1.2, < 4)
-      rack (>= 1.0, < 3)
+    omniauth (1.6.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
     omniauth-google-oauth2 (0.4.1)
       jwt (~> 1.5.2)
       multi_json (~> 1.3)
@@ -292,7 +292,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   lograge
   mocha
-  omniauth (= 1.3.1)
+  omniauth (= 1.6.1)
   omniauth-google-oauth2 (= 0.4.1)
   omniauth-ldap
   omniauth-twitter (= 1.2.1)
@@ -317,4 +317,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -12,7 +12,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     scope: ENV['ENABLE_YOUTUBE_UPLOADING'] && ENV['ENABLE_YOUTUBE_UPLOADING'] == "true" ? ['profile', 'email', 'youtube', 'youtube.upload'] : ['profile', 'email'] ,
     access_type: 'online',
     name: 'google',
-    hd: ENV['GOOGLE_OAUTH2_HD']
+    hd: ENV['GOOGLE_OAUTH2_HD'].blank? ? nil : ENV['GOOGLE_OAUTH2_HD']
   provider :ldap,
     host: ENV['LDAP_SERVER'],
     port: ENV['LDAP_PORT'] || '389',


### PR DESCRIPTION
This fixes a bug introduced in #183 that defaulted the GOOGLE_OAUTH2_HD environment variable to an empty string. This prevented all Google authentication.

It also updates the omniauth gem to the latest release, 1.6.1. This fixes many warnings that popped up when a user authenticates.