### PR TITLE
Add support for HTML5 client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,6 @@ gem 'yt', '~> 0.28.0'
 
 # Simple HTTP client.
 gem 'faraday'
+
+# For device detection to determine BigBlueButton client.
+gem 'browser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
       sass (~> 3.2)
     bootstrap-social-rails (4.12.0)
       railties (>= 3.1)
+    browser (2.5.1)
     builder (3.2.3)
     byebug (9.0.6)
     climate_control (0.2.0)
@@ -279,6 +280,7 @@ DEPENDENCIES
   bigbluebutton-api-ruby
   bootstrap-sass (= 3.3.0.0)
   bootstrap-social-rails (~> 4.12)
+  browser
   byebug
   coffee-rails (~> 4.2)
   dotenv-rails

--- a/app/assets/javascripts/active_meetings.js
+++ b/app/assets/javascripts/active_meetings.js
@@ -117,8 +117,8 @@ var initialPopulate = function(){
       
       // Populate waiting meetings.
       Object.keys(data['waiting']).forEach(function(key) { 
-        WAITING[name] = {'name': key, 'users': data['waiting'][key]}
-        updateMeetingText(WAITING[name])
+        WAITING[key] = {'name': key, 'users': data['waiting'][key]}
+        updateMeetingText(WAITING[key])
       })
       
       // Add the meetings to the active meetings list.

--- a/app/assets/javascripts/channels/meeting_updates.js
+++ b/app/assets/javascripts/channels/meeting_updates.js
@@ -55,6 +55,8 @@
               body: I18n.user_waiting_body.replace(/%{user}/, data.user).replace(/%{meeting}/, '"'+data.meeting_name+'"')
             });
           }
+        } else if(data.action === 'unable_to_join') {
+          showAlert(I18n.unable_to_join_mobile, 6000)
         }
       }
     });

--- a/app/assets/javascripts/landing.js
+++ b/app/assets/javascripts/landing.js
@@ -60,7 +60,7 @@
           jqxhr.done(function(data) {
             if (data.messageKey === 'wait_for_moderator') {
               waitForModerator(Meeting.getInstance().getURL());
-            } else {
+            } else if (data.messageKey === 'ok') {
               $(location).attr("href", data.response.join_url);
             }
           });

--- a/app/assets/javascripts/shared.js.erb
+++ b/app/assets/javascripts/shared.js.erb
@@ -69,7 +69,8 @@ var showNotification = function(title, options) {
   if (Notification.permission === "granted") {
     var icon = '<%= asset_path("bbb-logo.png") %>';
     options = $.extend(options, {
-      icon: icon
+      icon: icon,
+      tag: 'UserWaiting'
     });
     var notification = new Notification(title, options);
     notification.onclick = function() {

--- a/app/controllers/bbb_controller.rb
+++ b/app/controllers/bbb_controller.rb
@@ -93,7 +93,10 @@ class BbbController < ApplicationController
         if bbb_res[:returncode] && current_user == user
           JoinMeetingJob.perform_later(user, params[:id], base_url)
           WaitingList.empty(options[:room_owner], options[:meeting_name])
-      # user will be waiting for a moderator
+        # the user can't join because they are on mobile and HTML5 is not enabled.
+        elsif bbb_res[:messageKey] == 'unable_to_join'
+          NotifyUserCantJoinJob.perform_later(user.encrypted_id, params[:id], params[:name])
+        # user will be waiting for a moderator
         else
           NotifyUserWaitingJob.perform_later(user.encrypted_id, params[:id], params[:name])
         end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,13 +19,19 @@ class UsersController < ActionController::Base
   # For updating a users background image.
   def update
 
-    # Make sure they actually select a file.
-    if params[:user] then
+    if params[:commit] == t('upload')
+      # Make sure they actually select a file.
+      if params[:user] then
+        @user = User.find(params[:id])
+        @user.assign_attributes(background: user_params[:background])
+        flash[:danger] = t('invalid_file') unless @user.save
+      else
+        flash[:danger] = t('no_file')
+      end
+    elsif params[:commit] == t('switch_clients')
+      # Switch the users default client.
       @user = User.find(params[:id])
-      @user.assign_attributes(background: user_params[:background])
-      flash[:danger] = t('invalid_file') unless @user.save
-    else
-      flash[:danger] = t('no_file')
+      @user.update_attributes(use_html5: !@user.use_html5)
     end
 
     # Reload the page to apply changes and show flash messages.

--- a/app/jobs/notify_user_cant_join_job.rb
+++ b/app/jobs/notify_user_cant_join_job.rb
@@ -14,10 +14,11 @@
 # You should have received a copy of the GNU Lesser General Public License along
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
-module LandingHelper
+class NotifyUserCantJoinJob < ApplicationJob
+  queue_as :default
 
-  def html5_enabled?
-    Rails.configuration.html5_enabled
+  def perform(room, meeting, user)
+    payload = { action: 'unable_to_join', user: user, meeting_name: meeting }
+    ActionCable.server.broadcast "#{room}-#{meeting}_meeting_updates_channel", payload
   end
-
 end

--- a/app/views/landing/preferences.html.erb
+++ b/app/views/landing/preferences.html.erb
@@ -35,9 +35,13 @@
         <br>
         <div class="html5-check">
           <h3><%= t('prefered_client') %></h3>
-          <p><%= t('currently_joining_with', client: @user.use_html5 ? t('client_html5') : t('client_flash')) %></p>
-          <%= form_for @user do |f| %>
-            <%= f.submit t('switch_clients'), class: 'btn btn-info' %>
+          <% if html5_enabled? %>
+            <p><%= t('currently_joining_with', client: @user.use_html5 ? t('client_html5') : t('client_flash')) %></p>
+            <%= form_for @user do |f| %>
+              <%= f.submit t('switch_clients'), class: 'btn btn-info' %>
+            <% end %>
+          <% else %>
+            <p><%= t('html5_not_enabled') %></p>
           <% end %>
         </div>
       <% else %>

--- a/app/views/landing/preferences.html.erb
+++ b/app/views/landing/preferences.html.erb
@@ -23,12 +23,21 @@
 
       <% if @user %>
         <div class="upload-form">
+          <h3><%= t('background_image') %></h3>
           <p> <%= t('background_image') + ": " + (@user.background_file_name || '')  %> </p>
           <%= form_for @user, :html => { :multipart => true } do |f| %>
             <div class="form-group">
               <%= f.file_field :background, class: 'form-control'%>
             </div>
             <%= f.submit t('upload'), class: 'btn btn-info' %>
+          <% end %>
+        </div>
+        <br>
+        <div class="html5-check">
+          <h3><%= t('prefered_client') %></h3>
+          <p><%= t('currently_joining_with', client: @user.use_html5 ? t('client_html5') : t('client_flash')) %></p>
+          <%= form_for @user do |f| %>
+            <%= f.submit t('switch_clients'), class: 'btn btn-info' %>
           <% end %>
         </div>
       <% else %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,6 +48,7 @@ module Greenlight
     config.disable_guest_access = ENV['DISABLE_GUEST_ACCESS'] && ENV['DISABLE_GUEST_ACCESS'] == "true"
     config.enable_youtube_uploading = ENV['ENABLE_YOUTUBE_UPLOADING'] && ENV['ENABLE_YOUTUBE_UPLOADING'] == "true"
     config.enable_qrcode_generation = ENV['ENABLE_QRCODE_GENERATION'] && ENV['ENABLE_QRCODE_GENERATION'] == "true"
+    config.use_html5_by_default = ENV['USE_HTML5_BY_DEFAULT'] == "true"
 
     # SMTP and action mailer
     if config.mail_notifications

--- a/config/initializers/html5_client.rb
+++ b/config/initializers/html5_client.rb
@@ -14,10 +14,6 @@
 # You should have received a copy of the GNU Lesser General Public License along
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
-module LandingHelper
-
-  def html5_enabled?
-    Rails.configuration.html5_enabled
-  end
-
-end
+# Send a request to check if the HTML5 client is enabled on the BigBlueButton server.
+res = Faraday.get(Rails.configuration.bigbluebutton_endpoint.gsub('bigbluebutton/', 'html5client/check'))
+Rails.application.config.html5_enabled = res.status == 200

--- a/config/locales/en-us.yml
+++ b/config/locales/en-us.yml
@@ -70,6 +70,7 @@ en-US:
     recording_unpublished: Recording was unpublished
     share: Share
     successful_upload: Recording successfully uploaded to Youtube!
+    unable_to_join_mobile: This BigBlueButton server does not use the HTML5 client, which means you are unable to join on mobile.
     unpublish_recording: Hide recording
     unlisted: Unlisted
     unpublished: No one
@@ -80,7 +81,7 @@ en-US:
   client_flash: Flash
   copied: Copied
   copy_error: Use Ctrl-c to copy
-  currently_joining_with: Currently joining with %{client} client.
+  currently_joining_with: Currently prefering the %{client} client.
   create_your_session: Create your own meeting
   date_recorded: Date
   disallowed_characters_msg: Characters not allowed in meeting name $&,
@@ -97,6 +98,7 @@ en-US:
   hi_all: Hi Everyone
   home_page: Home page
   home_title: Welcome to BigBlueButton
+  html5_not_enabled: This server is not HTML5 enabled, so you must use the Flash client.
   invalid_file: You may only upload an image file (jpg, gif, png).
   invalid_login: Invalid log in credentials.
   invite: Invite

--- a/config/locales/en-us.yml
+++ b/config/locales/en-us.yml
@@ -76,8 +76,11 @@ en-US:
     upload_youtube: Youtube
     user_waiting_body: "%{user} is waiting to join %{meeting}!"
     user_waiting_title: A user is waiting
+  client_html5: HTML5
+  client_flash: Flash
   copied: Copied
   copy_error: Use Ctrl-c to copy
+  currently_joining_with: Currently joining with %{client} client.
   create_your_session: Create your own meeting
   date_recorded: Date
   disallowed_characters_msg: Characters not allowed in meeting name $&,
@@ -157,6 +160,7 @@ en-US:
   past_recordings: Past Recordings
   preferences: Preferences
   preferences_logged: You must be logged in to edit preferences.
+  prefered_client: Prefered Client
   presentation: Presentation
   previous_meetings: (previous meetings)
   qrcode:
@@ -176,6 +180,7 @@ en-US:
   start: Start
   start_join: Start
   start_meeting: Start meeting
+  switch_clients: Switch Clients
   test_mailer:
     test_email:
       subject: Test Email

--- a/db/migrate/20170928183010_add_use_html5_to_users.rb
+++ b/db/migrate/20170928183010_add_use_html5_to_users.rb
@@ -1,0 +1,5 @@
+class AddUseHtml5ToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :use_html5, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,22 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170518190442) do
+ActiveRecord::Schema.define(version: 20170928183010) do
 
   create_table "users", force: :cascade do |t|
-    t.string   "provider",                null: false
-    t.string   "uid",                     null: false
+    t.string   "provider",                               null: false
+    t.string   "uid",                                    null: false
     t.string   "name"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.string   "username"
-    t.string   "encrypted_id",            null: false
+    t.string   "encrypted_id",                           null: false
     t.string   "email"
     t.string   "background_file_name"
     t.string   "background_content_type"
     t.integer  "background_file_size"
     t.datetime "background_updated_at"
     t.string   "token"
+    t.boolean  "use_html5",               default: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["encrypted_id"], name: "index_users_on_encrypted_id", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,20 +13,20 @@
 ActiveRecord::Schema.define(version: 20170928183010) do
 
   create_table "users", force: :cascade do |t|
-    t.string   "provider",                               null: false
-    t.string   "uid",                                    null: false
+    t.string   "provider",                                null: false
+    t.string   "uid",                                     null: false
     t.string   "name"
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
     t.string   "username"
-    t.string   "encrypted_id",                           null: false
+    t.string   "encrypted_id",                            null: false
     t.string   "email"
     t.string   "background_file_name"
     t.string   "background_content_type"
     t.integer  "background_file_size"
     t.datetime "background_updated_at"
     t.string   "token"
-    t.boolean  "use_html5",               default: true
+    t.boolean  "use_html5",               default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["encrypted_id"], name: "index_users_on_encrypted_id", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true

--- a/sample.env
+++ b/sample.env
@@ -23,6 +23,17 @@ SECRET_KEY_BASE=
 # BIGBLUEBUTTON_ENDPOINT=
 # BIGBLUEBUTTON_SECRET=
 
+# Set default client (optional)
+#
+# By default, GreenLight will join users to a BigBlueButton session using the Flash
+# client. By setting USE_HTML5_BY_DEFAULT to true, you can configure GreenLight to
+# use the HTML5 client by default. GreenLight will only use the default for
+# non-authenticated users. Users who have authenticated are able to set their
+# prefered client under preferences. Also note that if the HTML5 client is not
+# running on a BigBlueButton server, all clients will be joined using Flash
+# regardless on any settings. 
+USE_HTML5_BY_DEFAULT=false
+
 # Twitter Login Provider (optional)
 #
 #   You will need to register the app at https://apps.twitter.com/

--- a/scripts/greenlight_recording_notify.rb
+++ b/scripts/greenlight_recording_notify.rb
@@ -49,7 +49,7 @@ def getParticipantsInfo(events_xml)
 end
 
 def get_id_from_event(event)
-  (event.xpath('externalUserId').empty?) ? event.xpath('userId').text.split('_')[0] : event.xpath('externalUserId').text
+  (event.xpath('externalUserId').empty?) ? event.xpath('userId').text : event.xpath('externalUserId').text
 end
 
 # Gets the join and leave times for each user, as well as total duration of stay.


### PR DESCRIPTION
This pull requests adds support for the BigBlueButton HTML5 client to GreenLight. The way GreenLight chooses which client to use is a little complex.

If a user is **not authenticated** then their client will be determined by what the server owner has configured. GreenLight now has a `USE_HTML5_BY_DEFAULT` environment variable. When set to true, all unauthenticated users with join using the HTML5 client. If it is false (or not set), they will join using the Flash client.

If a user is **authenticated**, they have the final decision in which client they use. By default, authenticated users will join using the Flash client. However, under their preferences they have the ability to toggle between the Flash and HTML5 clients.

There are three specials scenarios where the two options above are overridden.

If the HTML5 client is not running on a server, all users will be joined using the Flash client regardless of settings (and users will not have the option to toggle between clients).

If a user joins on a mobile device and the HTML5 client is running, they will always use the HTML5 client as the Flash client doesn't work on mobile devices.

If a user joins on a mobile device and the HTML5 client is not running, the user will  be provided with a message stating that they are unable to join.

It also contains a few minor bugfixes introduced in BigBlueButton 2.0.