### PR TITLE
Fix Greenlight accounts unable to update settings.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -58,7 +58,7 @@ class UsersController < ApplicationController
       end
 
       if errors.empty? && @user.save
-        # Notify the use that their account has been updated.
+        # Notify the user that their account has been updated.
         redirect_to edit_user_path(@user), notice: "Information successfully updated."
       else
         # Append custom errors.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
                     uniqueness: { case_sensitive: false },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
 
-  validates :password, length: { minimum: 6 }, confirmation: true, if: :greenlight_account?
+  validates :password, length: { minimum: 6 }, confirmation: true, if: :greenlight_account?, on: :create
 
   # We don't want to require password validations on all accounts.
   has_secure_password(validations: false)


### PR DESCRIPTION
Update action was previously requiring a password for Greenlight accounts, preventing updating basic account into. This is a quick fix for the problem that will fix it in the meantime, but in the future we should probably take a second look at `users_controller#update`.