### PR TITLE
Fix missing locales and bump name/email max.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,10 +45,14 @@ a {
   height: $header-height;
 }
 
-.page {
+.wrapper {
   position: relative;
   height: auto;
   min-height: calc(100% - #{$header-height} - #{$footer-height});
+}
+
+.flex-center {
+  transform: translateY(25%);
 }
 
 .footer {

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -163,7 +163,7 @@ class Room < ApplicationRecord
 
   # Generates a random room uid that uses the users name.
   def random_room_uid
-    [owner.firstname, uid_chunk, uid_chunk].join('-').downcase
+    [owner.name_chunk, uid_chunk, uid_chunk].join('-').downcase
   end
 
   # Rereives the loadbalanced BigBlueButton credentials for a user.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,10 +7,10 @@ class User < ApplicationRecord
   has_many :rooms
   belongs_to :main_room, class_name: 'Room', foreign_key: :room_id, required: false
 
-  validates :name, length: { maximum: 32 }, presence: true
+  validates :name, length: { maximum: 256 }, presence: true
   validates :provider, presence: true
   validates :image, format: { with: /\.(png|jpg)\Z/i }, allow_blank: true
-  validates :email, length: { maximum: 60 }, allow_blank: true,
+  validates :email, length: { maximum: 256 }, allow_blank: true,
                     uniqueness: { case_sensitive: false },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
 
@@ -73,8 +73,8 @@ class User < ApplicationRecord
     sorted + no_session
   end
 
-  def firstname
-    name.split(' ').first
+  def name_chunk
+    name[0...3].downcase
   end
 
   def greenlight_account?
@@ -86,7 +86,7 @@ class User < ApplicationRecord
   # Initializes a room for the user and assign a BigBlueButton user id.
   def initialize_main_room
     self.uid = "gl-#{(0...12).map { (65 + rand(26)).chr }.join.downcase}"
-    self.main_room = Room.create!(owner: self, name: firstname + "'s Room")
+    self.main_room = Room.create!(owner: self, name: I18n.t("home_room"))
     save
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,9 +18,9 @@
   </head>
 
   <body class="app-background" data-controller="<%= params[:controller] %>" data-action="<%= params[:action] %>">
-          <%= render "shared/header" %>
+    <%= render "shared/header" %>
 
-    <div class="page">
+    <div class="wrapper">
       <% if bigbluebutton_endpoint_default? %>
         <%= render "shared/error_banner" do %>
           <i class="fas fa-exclamation-triangle"></i>

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 <% end %>
 
-<div class="container">
+<div class="container pt-9 pb-4">
   <div class="row pb-8">
     <div class="col-md-8 col-sm-12">
       <p id="main-text" class="font-weight-400 display-4"><%= t("landing.welcome").html_safe %></p>

--- a/app/views/shared/_room_event.html.erb
+++ b/app/views/shared/_room_event.html.erb
@@ -15,7 +15,7 @@
         <% else %>
           <span class="avatar" style="background-image: url(<%= @room.owner.image %>)"></span>
         <% end %>
-        <h5 class="font-weight-normal ml-4 mt-3"><%= @room.owner.name %> (<%= t("room.invited") %>)</h5>
+        <h5 class="font-weight-normal ml-4 mt-3"><%= @room.owner.name %> (<%= t("room.owner") %>)</h5>
       </div>
 
       <div class="col-lg-6 col-md-4 col-sm-12">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,16 +39,17 @@ en:
     create_room: Create Room
     dropdown:
       help: Need help?
-      home: Home room
+      home: Home Room
       settings: Settings
       signout: Sign out
+  home_room: Home Room
   info_update_success: Information successfully updated.
   invalid_credentials: Login failed due to invalid credentials. Are you sure you entered them correctly?
   invite_message: "To invite someone to the meeting, send them this link:"
   landing:
     about: Greenlight is a simple front-end for your %{href} open-source web conferencing server. You can create your own rooms to host sessions, or join others using a short and convenient link.
     welcome: Welcome to <span class="green-grad">Greenlight</span>.
-    video: Checkout our tutorial on using Greenlight
+    video: Watch our tutorial on using Greenlight
     upgrade: Show me how to upgrade to 2.0!
     version: We've released a new version of Greenlight, but your database isn't compatible.
   ldap_error: Unable to connect to the LDAP server. Please check your LDAP configuration in the env file and ensure your server is running.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,12 +9,12 @@ describe User, type: :model do
 
   context 'validations' do
     it { should validate_presence_of(:name) }
-    it { should validate_length_of(:name).is_at_most(32) }
+    it { should validate_length_of(:name).is_at_most(256) }
 
     it { should validate_presence_of(:provider) }
 
     it { should validate_uniqueness_of(:email).case_insensitive }
-    it { should validate_length_of(:email).is_at_most(60) }
+    it { should validate_length_of(:email).is_at_most(256) }
     it { should allow_value("", nil).for(:email) }
     it { should allow_value("valid@email.com").for(:email) }
     it { should_not allow_value("invalid_email").for(:email) }
@@ -85,10 +85,10 @@ describe User, type: :model do
     end
   end
 
-  context '#first_name' do
-    it 'properly finds the users first name' do
+  context '#name_chunk' do
+    it 'properly finds the first three characters of the users name' do
       user = create(:user, name: "Example User")
-      expect(user.firstname).to eq("Example")
+      expect(user.name_chunk).to eq("exa")
     end
   end
 end


### PR DESCRIPTION
With the addition of LDAP support we're seeing full names when logging in. To combat this, we're bumping the name and email fields up to 256 characters to prevent people having issues using some of the functionality.

In addition, we don't attempt to determine first name anymore (this was only for testing purposes). A user's main room is now called "Home Room".

This also fixes a couple of missing locales or ones that needed rewording.