### PR TITLE
Fix error when loading recordings that contain "statistics" format.

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -130,7 +130,12 @@ class RoomsController < ApplicationController
   helper_method :recording_date
 
   # Helper for converting BigBlueButton dates into a nice length string.
-  def recording_length(len)
+  def recording_length(playbacks)
+    # Stats format currently doesn't support length.
+    playbacks.reject! { |p| p[:type] == "statistics" }
+    return "0 min" if playbacks.empty?
+
+    len = playbacks.first[:length]
     if len > 60
       "#{(len / 60).round} hrs"
     elsif len == 0

--- a/app/views/shared/components/_public_recording_row.html.erb
+++ b/app/views/shared/components/_public_recording_row.html.erb
@@ -32,7 +32,7 @@
     <div class="small text-muted text-uppercase">
       <%= t("recording.table.length") %>
     </div>
-    <%= recording_length(recording[:playbacks].first[:length]) %>
+    <%= recording_length(recording[:playbacks]) %>
   </td>
   <td class="text-left">
     <div class="small text-muted text-uppercase">

--- a/app/views/shared/components/_recording_row.html.erb
+++ b/app/views/shared/components/_recording_row.html.erb
@@ -32,7 +32,7 @@
     <div class="small text-muted text-uppercase">
       <%= t("recording.table.length") %>
     </div>
-    <%= recording_length(recording[:playbacks].first[:length]) %>
+    <%= recording_length(recording[:playbacks]) %>
   </td>
   <td class="text-left">
     <div class="small text-muted text-uppercase">


### PR DESCRIPTION
Recordings that have the statistics format don't have a length. In the rare case where is was ordered first, Greenlight would attempt to grab a length from it. This removes the stats format from all length calculations.