### PR TITLE
Add option to disable recording thumbnails.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,6 +70,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :loadbalanced_configuration?
 
+  def recording_thumbnails?
+    Rails.configuration.recording_thumbnails
+  end
+  helper_method :recording_thumbnails?
+
   def allow_greenlight_users?
     Rails.configuration.greenlight_accounts
   end

--- a/app/views/shared/_sessions.html.erb
+++ b/app/views/shared/_sessions.html.erb
@@ -25,7 +25,9 @@
               <thead>
                 <tr>
                   <th><%= t("recording.table.name") %></th>
-                  <th><%= t("recording.table.thumbnails") %></th>
+                  <% if recording_thumbnails? %>
+                    <th><%= t("recording.table.thumbnails") %></th>
+                  <% end %>
                   <th class="text-left"><%= t("recording.table.length") %></th>
                   <th class="text-left"><%= t("recording.table.users") %></th>
                   <th class="text-left"><%= t("recording.table.visibility") %></th>

--- a/app/views/shared/components/_public_recording_row.html.erb
+++ b/app/views/shared/components/_public_recording_row.html.erb
@@ -22,7 +22,7 @@
   </td>
   <td>
     <% p = recording[:playbacks].find do |p| p[:type] == "presentation" end %>
-    <% if p %>
+    <% if p && p.key?(:preview) && recording_thumbnails? %>
       <% p[:preview][:images][:image].each do |img| %>
         <%= image_tag(img[:content].strip, class: "thumbnail px-2") %>
       <% end %>

--- a/app/views/shared/components/_recording_row.html.erb
+++ b/app/views/shared/components/_recording_row.html.erb
@@ -20,14 +20,14 @@
       <%= t("recording.recorded_on", date: recording_date(recording[:startTime])) %>
     </div>
   </td>
-  <td>
-    <% p = recording[:playbacks].find do |p| p[:type] == "presentation" end %>
-    <% if p %>
+  <% p = recording[:playbacks].find do |p| p[:type] == "presentation" end %>
+  <% if p && p.key?(:preview) && recording_thumbnails? %>
+    <td>
       <% safe_recording_images(p[:preview][:images][:image]).each do |img| %>
         <%= image_tag(img[:content].strip, class: "thumbnail px-2") %>
       <% end %>
-    <% end %>
-  </td>
+    </td>
+  <% end %>
   <td class="text-left">
     <div class="small text-muted text-uppercase">
       <%= t("recording.table.length") %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -76,5 +76,8 @@ module Greenlight
 
     # Configure custom branding image.
     config.branding_image = ENV['BRANDING_IMAGE']
+
+    # Enable/disable recording thumbnails.
+    config.recording_thumbnails = (ENV['RECORDING_THUMBNAILS'] != "false")
   end
 end


### PR DESCRIPTION
Some configuration don't generate recording thumbnails. Instead of having a blank column, you can disable it all together.