### PR TITLE
Allow for specification of email sender

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -17,7 +17,7 @@
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 class UserMailer < ApplicationMailer
-  default from: 'notifications@example.com'
+  default from: Rails.configuration.email_sender
 
   def verify_email(user, url)
     @user = user

--- a/config/application.rb
+++ b/config/application.rb
@@ -68,6 +68,8 @@ module Greenlight
       config.bigbluebutton_endpoint += "api/" unless config.bigbluebutton_endpoint.ends_with?('api/')
     end
 
+    config.email_sender = ENV['EMAIL_SENDER'].present? ? ENV['EMAIL_SENDER'] : "notifications@example.com"
+
     # Determine if GreenLight should enable email verification
     config.enable_email_verification = (ENV['ALLOW_MAIL_NOTIFICATIONS'] == "true")
 

--- a/sample.env
+++ b/sample.env
@@ -93,6 +93,9 @@ SMTP_PASSWORD=
 SMTP_AUTH=
 SMTP_STARTTLS_AUTO=
 
+# Specify the email address that all mail is sent from
+EMAIL_SENDER=
+
 # Prefix for the applications root URL.
 # Useful for deploying the application to a subdirectory, which is highly recommended
 # if deploying on a BigBlueButton server. Keep in mind that if you change this, you'll


### PR DESCRIPTION
This feature allows a user to specify the email address outgoing mail is sent from and is necessary to set up aws ses.