### PR TITLE
Fixed #318 Allow multiple domains when using Google as OAuth provider (GRN-38)

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -70,7 +70,7 @@ module SessionsHelper
 
   def google_omniauth_hd(env, hd)
     hd_opts = hd.split(',')
-    env['omniauth.strategy'].options[:hd] = 
+    env['omniauth.strategy'].options[:hd] =
       if hd_opts.empty?
         nil
       elsif hd_opts.length == 1

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -67,4 +67,15 @@ module SessionsHelper
     env['omniauth.strategy'].options[:checksum] = generate_checksum parse_customer_name(env["SERVER_NAME"]),
       gl_redirect_url, Rails.configuration.launcher_secret
   end
+
+  def google_omniauth_hd(env, hd)
+    hd_opts = hd.split(',')
+    if hd_opts.empty?
+      env['omniauth.strategy'].options[:hd] = nil
+    elsif hd_opts.length() == 1
+      env['omniauth.strategy'].options[:hd] = hd_opts[0]
+    else
+      env['omniauth.strategy'].options[:hd] = hd_opts
+    end
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -70,12 +70,13 @@ module SessionsHelper
 
   def google_omniauth_hd(env, hd)
     hd_opts = hd.split(',')
-    if hd_opts.empty?
-      env['omniauth.strategy'].options[:hd] = nil
-    elsif hd_opts.length() == 1
-      env['omniauth.strategy'].options[:hd] = hd_opts[0]
-    else
-      env['omniauth.strategy'].options[:hd] = hd_opts
-    end
+    env['omniauth.strategy'].options[:hd] = 
+      if hd_opts.empty?
+        nil
+      elsif hd_opts.length == 1
+        hd_opts[0]
+      else
+        hd_opts
+      end
   end
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -17,7 +17,12 @@ Rails.application.config.omniauth_bn_launcher = Rails.configuration.loadbalanced
 Rails.application.config.allow_user_signup = false if Rails.application.config.omniauth_ldap
 
 SETUP_PROC = lambda do |env|
-  SessionsController.helpers.omniauth_options env
+  provider = env['omniauth.strategy'].options[:name]
+  if provider == "google"
+    SessionsController.helpers.google_omniauth_hd env, ENV['GOOGLE_OAUTH2_HD']
+  else
+    SessionsController.helpers.omniauth_options env
+  end
 end
 
 # Setup the Omniauth middleware.
@@ -35,7 +40,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     scope: %w(profile email),
     access_type: 'online',
     name: 'google',
-    hd: ENV['GOOGLE_OAUTH2_HD'].blank? ? nil : ENV['GOOGLE_OAUTH2_HD']
+    setup: SETUP_PROC
 
   provider :microsoft_office365, ENV['OFFICE365_KEY'], ENV['OFFICE365_SECRET']
 

--- a/sample.env
+++ b/sample.env
@@ -22,9 +22,10 @@ BIGBLUEBUTTON_SECRET=
 #
 #   http://docs.bigbluebutton.org/install/greenlight-v2.html#google-oauth2
 #
-# The GOOGLE_OAUTH2_HD variable is used to limit sign-in to a particular Google Apps hosted
-# domain. This can be a string such as, 'domain.com'. If left blank, GreenLight will allow
-# sign-in from all Google Apps hosted domains.
+# The GOOGLE_OAUTH2_HD variable is used to limit sign-ins to a particular set of Google Apps hosted
+# domains. This can be a string with separating commas such as, 'domain.com, example.com' or 
+# a string that specifies a single domain restriction such as, 'domain.com'.
+# If left blank, GreenLight will allow sign-in from all Google Apps hosted domains.
 GOOGLE_OAUTH2_ID=
 GOOGLE_OAUTH2_SECRET=
 GOOGLE_OAUTH2_HD=

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -143,6 +143,29 @@ describe UsersController, type: :controller do
     end
   end
 
+  describe "DELETE #user" do
+    before { allow(Rails.configuration).to receive(:allow_user_signup).and_return(true) }
+
+    it "properly deletes user" do
+      user = create(:user)
+
+      delete :destroy, params: { user_uid: user.uid }
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "GET | POST #terms" do
+    before { allow(Rails.configuration).to receive(:allow_user_signup).and_return(true) }
+    before { allow(Rails.configuration).to receive(:terms).and_return(false) }
+
+    it "Redirects to 404 if terms is disabled" do
+      post :terms, params: { accept: "false" }
+
+      expect(response).to redirect_to('/404')
+    end
+  end
+
   describe "GET | POST #resend" do
     before { allow(Rails.configuration).to receive(:allow_user_signup).and_return(true) }
     before { allow(Rails.configuration).to receive(:enable_email_verification).and_return(true) }


### PR DESCRIPTION
Added ability to allow multiple domains when applying restrictions in google oauth:
https://github.com/bigbluebutton/greenlight/issues/318