### PR TITLE
Fixed #332 Allow users to reset their password

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -34,6 +34,9 @@ class PasswordResetsController < ApplicationController
     else
       redirect_to new_password_reset_path, notice: I18n.t("no_user_email_exists")
     end
+  rescue => e
+    logger.error "Error in email delivery: #{e}"
+    redirect_to root_path, notice: I18n.t(params[:message], default: I18n.t("delivery_error"))
   end
 
   def edit

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+#
+# Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+#
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free Software
+# Foundation; either version 3.0 of the License, or (at your option) any later
+# version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+
+class PasswordResetsController < ApplicationController
+  before_action :disable_password_reset, unless: -> { Rails.configuration.enable_email_verification }
+  before_action :find_user,   only: [:edit, :update]
+  before_action :valid_user, only: [:edit, :update]
+  before_action :check_expiration, only: [:edit, :update]
+
+  def index
+  end
+
+  def create
+    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email(request.base_url)
+      redirect_to root_url, notice: I18n.t("email_sent")
+    else
+      redirect_to new_password_reset_path, notice: I18n.t("no_user_email_exists")
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if params[:user][:password].empty?
+      @user.errors.add(:password, "can't be empty")
+      render 'edit'
+    elsif @user.update_attributes(user_params)
+      redirect_to root_path, notice: I18n.t("password_reset_success")
+    else
+      render 'edit'
+    end
+  end
+
+  private
+
+  def find_user
+    @user = User.find_by(email: params[:email])
+  end
+
+  def user_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
+
+  # Checks expiration of reset token.
+  def check_expiration
+    if @user.password_reset_expired?
+      redirect_to new_password_reset_url, notice: I18n.t("expired_reset_token")
+    end
+  end
+
+  # Confirms a valid user.
+  def valid_user
+    unless @user&.email_verified && @user.authenticated?(:reset, params[:id])
+      redirect_to root_url
+    end
+  end
+
+  def disable_password_reset
+    redirect_to '/404'
+  end
+end

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -16,18 +16,5 @@
 # You should have received a copy of the GNU Lesser General Public License along
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
-class UserMailer < ApplicationMailer
-  default from: Rails.configuration.email_sender
-
-  def verify_email(user, url)
-    @user = user
-    @url = url
-    mail(to: @user.email, subject: t('landing.welcome'))
-  end
-
-  def password_reset(user, url)
-    @user = user
-    @url = url
-    mail to: user.email, subject: t('reset_password.subtitle')
-  end
+module PasswordResetsHelper
 end

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,50 @@
+<%
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+# Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free Software
+# Foundation; either version 3.0 of the License, or (at your option) any later
+# version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+%>
+
+<% unless flash.empty? %>
+  <%= render "shared/error_banner" do %>
+    <% flash.each do |key, value| %>
+      <%= content_tag :div, value, class: "flash #{key} d-inline" %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<div class="container">
+  <div class="row pt-7">
+    <div class="col col-4 offset-4">
+      <div class="card">
+        <div class="card-header background">
+          <h4 class="mt-2"><%= t("reset_password.subtitle") %></h4>
+        </div>
+        <div class="card-body background">
+          <%= form_for(@user, url: password_reset_path(params[:id])) do |f| %>
+
+            <%= hidden_field_tag :email, @user.email %>
+
+            <%= f.label t('reset_password.password'), class: "form-label" %>
+            <%= f.password_field :password, class: 'form-control' %>
+            <br>
+
+            <%= f.label t('reset_password.confirm'), class: "form-label" %>
+            <%= f.password_field :password_confirmation, class: 'form-control' %>
+            <br>
+
+            <%= f.submit t('reset_password.update'), class: "btn btn-primary" %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,43 @@
+<%
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+# Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free Software
+# Foundation; either version 3.0 of the License, or (at your option) any later
+# version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+%>
+
+<% unless flash.empty? %>
+  <%= render "shared/error_banner" do %>
+    <% flash.each do |key, value| %>
+      <%= content_tag :div, value, class: "flash #{key} d-inline" %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<div class="container">
+  <div class="row pt-7">
+    <div class="col col-4 offset-4">
+      <div class="card">
+        <div class="card-header background">
+          <h4 class="mt-2"><%= t("forgot_password.subtitle") %></h4>
+        </div>
+        <div class="card-body background">
+          <%= form_for(:password_reset, url: password_resets_path) do |f| %>
+            <%= f.label t("forgot_password.email"), class: "form-label" %>
+            <%= f.email_field :email, class: "form-control" %>
+            <br>
+      
+            <%= f.submit t("forgot_password.submit"), class: "btn btn-primary" %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/modals/_login_modal.html.erb
+++ b/app/views/shared/modals/_login_modal.html.erb
@@ -58,7 +58,7 @@
             <% if Rails.configuration.enable_email_verification %>
               <div class="form-group">
                 <div class="input-icon">
-                  <%= link_to t("login.forgot_password"), new_password_reset_path %>
+                  <%= link_to t("modal.login.forgot_password"), new_password_reset_path %>
                 </div>
               </div>
             <% end %>

--- a/app/views/shared/modals/_login_modal.html.erb
+++ b/app/views/shared/modals/_login_modal.html.erb
@@ -55,6 +55,13 @@
                 <%= f.password_field :password, class: "form-control", placeholder: t("password"), value: "" %>
               </div>
             </div>
+            <% if Rails.configuration.enable_email_verification %>
+              <div class="form-group">
+                <div class="input-icon">
+                  <%= link_to t("login.forgot_password"), new_password_reset_path %>
+                </div>
+              </div>
+            <% end %>
             <div class="form-footer">
               <%= f.submit t("login"), class: "btn btn-outline-primary btn-block btn-pill" %>
             </div>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,5 +1,4 @@
-# frozen_string_literal: true
-
+<%
 # BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
 #
 # Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
@@ -15,19 +14,19 @@
 #
 # You should have received a copy of the GNU Lesser General Public License along
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+%>
 
-class UserMailer < ApplicationMailer
-  default from: Rails.configuration.email_sender
+<h1>Password reset</h1>
 
-  def verify_email(user, url)
-    @user = user
-    @url = url
-    mail(to: @user.email, subject: t('landing.welcome'))
-  end
+<p>Please click the link below to reset your password:</p>
 
-  def password_reset(user, url)
-    @user = user
-    @url = url
-    mail to: user.email, subject: t('reset_password.subtitle')
-  end
-end
+<%= link_to "Reset password", edit_password_reset_url(@user.reset_token,
+                                                      email: @user.email,
+                                                      host: @url) %>
+
+<p>This link will expire in two hours.</p>
+
+<p>
+If you did not request your password to be reset, please ignore this email and
+your password will not be changed.
+</p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,5 +1,4 @@
-# frozen_string_literal: true
-
+<%
 # BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
 #
 # Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
@@ -15,19 +14,13 @@
 #
 # You should have received a copy of the GNU Lesser General Public License along
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+%>
 
-class UserMailer < ApplicationMailer
-  default from: Rails.configuration.email_sender
+Please click the link below to reset your password:
 
-  def verify_email(user, url)
-    @user = user
-    @url = url
-    mail(to: @user.email, subject: t('landing.welcome'))
-  end
+<%= edit_password_reset_url(@user.reset_token, email: @user.email, host: @url) %>
 
-  def password_reset(user, url)
-    @user = user
-    @url = url
-    mail to: user.email, subject: t('reset_password.subtitle')
-  end
-end
+This link will expire in two hours.
+
+If you did not request your password to be reset, please ignore this email and
+your password will not be changed.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,7 +124,9 @@ en:
   no_user_email_exists: There is no existing user with the email specified. Please make sure you typed it correctly.
   omniauth_error: An error occured while authenticating with omniauth. Please try again or contact an administrator!
   password: Password
+  password_empty_notice: Password cannot be empty.
   password_reset_success: Password has been reset.
+  password_different_notice: Password Confirmation does not match.
   provider:
     google: Google
     microsoft_office365: Office 365

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
   delivery_error: An error occured during email delivery. Please contact an administrator!
   docs: Documentation
   email: Email
+  email_sent: Email Sent!
   enter_your_name: Enter your name!
   errors:
     internal:
@@ -49,6 +50,7 @@ en:
     unprocessable:
       message: Oops! Request is unprocessable.
       help: Unforunately this isn't a valid request.
+  expired_reset_token: Password reset link has expired!
   features:
     title: Features
     rooms: Personalized Rooms
@@ -57,6 +59,10 @@ en:
     authentication: User Authentication
   footer:
     powered_by: Powered by %{href}.
+  forgot_password:
+    subtitle: Forgot Password
+    email: Email
+    submit: Submit
   go_back: Go back
   greenlight: Greenlight
   header:
@@ -109,13 +115,16 @@ en:
     login:
       or: or
       with: Sign in with %{provider}
+      forgot_password: Forgot Password?
     rename_recording:
 
     rename_room:
       name_placeholder: Enter a new room name...
   name_update_success: Room name successfully changed!
+  no_user_email_exists: There is no existing user with the email specified. Please make sure you typed it correctly.
   omniauth_error: An error occured while authenticating with omniauth. Please try again or contact an administrator!
   password: Password
+  password_reset_success: Password has been reset.
   provider:
     google: Google
     microsoft_office365: Office 365
@@ -136,6 +145,11 @@ en:
       public: Public
       unlisted: Unlisted
   rename: Rename
+  reset_password:
+    subtitle: Reset Password
+    password: New Password
+    confirm: New Password Confirmation
+    update: Update Password
   room:
     invited: You have been invited to join
     invite_participants: Invite Participants

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,9 @@ Rails.application.routes.draw do
   # Redirect to terms page
   match '/terms', to: 'users#terms', via: [:get, :post]
 
+  # Password reset resources.
+  resources :password_resets, only: [:new, :create, :edit, :update]
+
   # User resources.
   scope '/u' do
     # Verification Routes

--- a/db/migrate/20181217142710_add_reset_to_users.rb
+++ b/db/migrate/20181217142710_add_reset_to_users.rb
@@ -16,18 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License along
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
-class UserMailer < ApplicationMailer
-  default from: Rails.configuration.email_sender
-
-  def verify_email(user, url)
-    @user = user
-    @url = url
-    mail(to: @user.email, subject: t('landing.welcome'))
-  end
-
-  def password_reset(user, url)
-    @user = user
-    @url = url
-    mail to: user.email, subject: t('reset_password.subtitle')
+class AddResetToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181113174230) do
+ActiveRecord::Schema.define(version: 20181217142710) do
 
   create_table "rooms", force: :cascade do |t|
     t.integer  "user_id"
@@ -40,10 +40,13 @@ ActiveRecord::Schema.define(version: 20181113174230) do
     t.string   "image"
     t.string   "password_digest"
     t.boolean  "accepted_terms",  default: false
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.boolean  "email_verified",  default: false
     t.string   "language",        default: "default"
+    t.string   "role",            default: "moderator"
+    t.string   "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["password_digest"], name: "index_users_on_password_digest", unique: true
     t.index ["room_id"], name: "index_users_on_room_id"
   end

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+#
+# Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+#
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free Software
+# Foundation; either version 3.0 of the License, or (at your option) any later
+# version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+
+require "rails_helper"
+
+def random_valid_user_params
+  pass = Faker::Internet.password(8)
+  {
+    user: {
+      name: Faker::Name.first_name,
+      email: Faker::Internet.email,
+      password: pass,
+      password_confirmation: pass,
+      accepted_terms: true,
+      email_verified: true,
+    },
+  }
+end
+
+describe PasswordResetsController, type: :controller do
+
+  it "starts a new password reset flow" do
+    get :new
+    expect(response).to have_http_status(:ok)
+  end
+
+  describe "POST #create" do
+    context "allow mail notifications" do
+      before { allow(Rails.configuration).to receive(:enable_email_verification).and_return(true) }
+
+      it "redirects to root url if email is sent" do
+        user = create(:user)
+
+        params = {
+          password_reset: {
+            email: user.email
+          }
+        }
+
+        post :create, params: params
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "reloads the page if no email exists in the database" do
+        params = {
+          password_reset: {
+            email: nil
+          }
+        }
+
+        post :create, params: params
+        expect(response).to redirect_to(new_password_reset_path)
+      end
+    end
+
+    context "does not allow mail notifications" do
+      before { allow(Rails.configuration).to receive(:enable_email_verification).and_return(false) }
+      
+      it "renders a 404 page upon if email notifications are disabled" do
+        get :create
+        expect(response).to redirect_to("/404")
+      end
+    end
+  end
+
+  describe "PATCH #update" do
+    before { allow(Rails.configuration).to receive(:enable_email_verification).and_return(true) }
+
+    context "valid user" do
+      
+      it "reloads page with notice if password is empty" do
+        token = "reset_token"
+
+        controller.stub(:valid_user).and_return(nil)
+        controller.stub(:check_expiration).and_return(nil)
+
+        params = {
+          id: token,
+          user: {
+            password: nil
+          }
+        }
+
+        patch :update, params: params
+        expect(response).to render_template(:edit)
+      end
+      
+      it "reloads page with notice if password is confirmation doesn't match" do
+        token = "reset_token"
+
+        controller.stub(:valid_user).and_return(nil)
+        controller.stub(:check_expiration).and_return(nil)
+
+        params = {
+          id: token,
+          user: {
+            password: :password,
+            password_confirmation: nil
+          }
+        }
+
+        patch :update, params: params
+        expect(response).to render_template(:edit)
+      end
+
+      it "updates attributes if the password update is a success" do
+        user = create(:user)
+        token = "reset_token"
+
+        cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
+        user.reset_digest = BCrypt::Password.create(token, cost: cost)
+
+        controller.stub(:valid_user).and_return(nil)
+        controller.stub(:check_expiration).and_return(nil)
+        controller.stub(:current_user).and_return(user)
+
+        params = {
+          id: token,
+          user: {
+            password: :password,
+            password_confirmation: :password
+          }
+        }
+
+        patch :update, params: params
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -33,12 +33,6 @@ def random_valid_user_params
 end
 
 describe PasswordResetsController, type: :controller do
-
-  it "starts a new password reset flow" do
-    get :new
-    expect(response).to have_http_status(:ok)
-  end
-
   describe "POST #create" do
     context "allow mail notifications" do
       before { allow(Rails.configuration).to receive(:enable_email_verification).and_return(true) }
@@ -48,8 +42,8 @@ describe PasswordResetsController, type: :controller do
 
         params = {
           password_reset: {
-            email: user.email
-          }
+            email: user.email,
+          },
         }
 
         post :create, params: params
@@ -59,8 +53,8 @@ describe PasswordResetsController, type: :controller do
       it "reloads the page if no email exists in the database" do
         params = {
           password_reset: {
-            email: nil
-          }
+            email: nil,
+          },
         }
 
         post :create, params: params
@@ -70,7 +64,7 @@ describe PasswordResetsController, type: :controller do
 
     context "does not allow mail notifications" do
       before { allow(Rails.configuration).to receive(:enable_email_verification).and_return(false) }
-      
+
       it "renders a 404 page upon if email notifications are disabled" do
         get :create
         expect(response).to redirect_to("/404")
@@ -82,7 +76,6 @@ describe PasswordResetsController, type: :controller do
     before { allow(Rails.configuration).to receive(:enable_email_verification).and_return(true) }
 
     context "valid user" do
-      
       it "reloads page with notice if password is empty" do
         token = "reset_token"
 
@@ -92,14 +85,14 @@ describe PasswordResetsController, type: :controller do
         params = {
           id: token,
           user: {
-            password: nil
-          }
+            password: nil,
+          },
         }
 
         patch :update, params: params
         expect(response).to render_template(:edit)
       end
-      
+
       it "reloads page with notice if password is confirmation doesn't match" do
         token = "reset_token"
 
@@ -110,8 +103,8 @@ describe PasswordResetsController, type: :controller do
           id: token,
           user: {
             password: :password,
-            password_confirmation: nil
-          }
+            password_confirmation: nil,
+          },
         }
 
         patch :update, params: params
@@ -133,8 +126,8 @@ describe PasswordResetsController, type: :controller do
           id: token,
           user: {
             password: :password,
-            password_confirmation: :password
-          }
+            password_confirmation: :password,
+          },
         }
 
         patch :update, params: params

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -109,4 +109,22 @@ describe User, type: :model do
       expect(user.name_chunk).to eq("exa")
     end
   end
+
+  context 'password reset' do
+
+    it 'creates token and respective reset digest' do
+      user = create(:user)
+
+      reset_digest_success = user.create_reset_digest
+      expect(reset_digest_success).to eq(true)
+    end
+
+    it 'verifies if password reset link expired' do
+      user = create(:user)
+      user.create_reset_digest
+
+      expired = user.password_reset_expired?
+      expect(expired).to be_in([true, false])
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -111,7 +111,6 @@ describe User, type: :model do
   end
 
   context 'password reset' do
-
     it 'creates token and respective reset digest' do
       user = create(:user)
 


### PR DESCRIPTION
Set ALLOW_MAIL_NOTIFICATIONS=true to enable the ability to reset your password
![image](https://user-images.githubusercontent.com/24597281/50184968-85142600-02e4-11e9-8ad0-5e9ebe8a446a.png)

Added the following feature:
https://github.com/bigbluebutton/greenlight/issues/332