### PR TITLE
Fixed #359 - I Agree button from cookie warning now works on all pages (GRN-55)

### DIFF
--- a/app/assets/javascripts/cookies.js
+++ b/app/assets/javascripts/cookies.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License along
 // with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
-$(document).ready(function() {
+$(document).on('turbolinks:load', function(){
   $("#cookies-agree-button").click(function() {
     //create a cookie that lasts 1 year
     var cookieDate = new Date();


### PR DESCRIPTION
fixes #359 