### PR TITLE
Room creation auth

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -23,7 +23,7 @@ class AdminsController < ApplicationController
 
   manage_users = [:edit_user, :promote, :demote, :ban_user, :unban_user, :approve]
   site_settings = [:branding, :coloring, :coloring_lighten, :coloring_darken,
-                   :registration_method, :room_authentication]
+                   :registration_method, :room_authentication, :room_creation_auth]
 
   authorize_resource class: false
   before_action :find_user, only: manage_users
@@ -135,6 +135,12 @@ class AdminsController < ApplicationController
   # POST /admins/room_authentication
   def room_authentication
     @settings.update_value("Room Authentication", params[:value])
+    redirect_to admins_path, flash: { success: I18n.t("administrator.flash.settings") }
+  end
+
+  # POST /admins/room_creation_auth
+  def room_creation_auth
+    @settings.update_value("Room Creation Auth", params[:value])
     redirect_to admins_path, flash: { success: I18n.t("administrator.flash.settings") }
   end
 

--- a/app/helpers/admins_helper.rb
+++ b/app/helpers/admins_helper.rb
@@ -43,6 +43,14 @@ module AdminsHelper
     end
   end
 
+  def room_creation_auth_string
+    if Setting.find_or_create_by!(provider: user_settings_provider).get_value("Room Creation Auth") == "admins"
+      I18n.t("administrator.site_settings.room_creation_auth.options.admins")
+    else
+      I18n.t("administrator.site_settings.room_creation_auth.options.authenticated")
+    end
+  end
+
   def registration_method_string
     case registration_method
     when Rails.configuration.registration_methods[:open]

--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -27,4 +27,13 @@ module RoomsHelper
     Setting.find_or_create_by!(provider: user_settings_provider).get_value("Room Authentication") == "true" &&
       current_user.nil?
   end
+
+  def can_create_rooms?
+    room_creation_auth = Setting.find_or_create_by!(provider: user_settings_provider).get_value("Room Creation Auth")
+    if room_creation_auth == "authenticated"
+      current_user
+    else
+      current_user.has_role?(:super_admin) || current_user.has_role?(:admin)     
+    end
+  end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -41,6 +41,8 @@ class Setting < ApplicationRecord
         Rails.configuration.registration_method_default
       when "Room Authentication"
         false
+      when "Room Creation Auth"
+        Rails.configuration.room_creation_auth_default
       end
     end
   end

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -81,7 +81,9 @@
           <%= render "shared/modals/delete_room_modal", room: room %>
         <% end %>
       <% end %>
-      <%= render "shared/components/create_room_block"%>
+      <% if can_create_rooms? %>
+        <%= render "shared/components/create_room_block"%>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/shared/admin_settings/_site_settings.html.erb
+++ b/app/views/shared/admin_settings/_site_settings.html.erb
@@ -99,4 +99,25 @@
       </div>
     </div>
   </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="form-group">
+        <label class="form-label"><%= t("administrator.site_settings.room_creation_auth.title") %></label>
+        <label class="form-label text-muted"><%= t("administrator.site_settings.room_creation_auth.info") %></label>
+        <div class="dropdown">
+          <button class="btn btn-primary dropdown-toggle" type="button" id="room-creation-auth" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= room_creation_auth_string %>
+          </button>
+          <div class="dropdown-menu" aria-labelledby="room-creation-auth">
+            <%= button_to admin_room_creation_auth_path(value: "authenticated"), class: "dropdown-item" do %>
+              <%= t("administrator.site_settings.room_creation_auth.options.authenticated") %>
+            <% end %>
+            <%= button_to admin_room_creation_auth_path(value: "admins"), class: "dropdown-item" do %>
+              <%= t("administrator.site_settings.room_creation_auth.options.admins") %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -134,6 +134,9 @@ module Greenlight
     # Default registration method if the user does not specify one
     config.registration_method_default = config.registration_methods[:open]
 
+    # Default permission needed to create rooms
+    config.room_creation_auth_default = :authenticated
+
     # Default admin password
     config.admin_password_default = ENV['ADMIN_PASSWORD'] || 'administrator'
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -341,6 +341,7 @@ en:
     create_room: Create a Room
     create_room_error: There was an error creating the room
     create_room_success: Room created successfully
+    create_room_unauthorized: You are not allowed to create rooms
     invited: You have been invited to join
     invite_participants: Invite Participants
     join: Join

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,12 @@ en:
           approval: Approve/Decline
           invite: Join by Invitation
           open: Open Registration
+      room_creation_auth:
+        title: Permission needed to create rooms
+        info: Which users should be allowed to create rooms?
+        options:
+          authenticated: Authenticated Users (Default)
+          admins: Admin users
       subtitle: Customize Greenlight
       title: Site Settings
     flash:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
     post '/branding', to: 'admins#branding', as: :admin_branding
     post '/coloring', to: 'admins#coloring', as: :admin_coloring
     post '/room_authentication', to: 'admins#room_authentication', as: :admin_room_authentication
+    post '/room_creation_auth', to: 'admins#room_creation_auth', as: :admin_room_creation_auth
     post '/coloring_lighten', to: 'admins#coloring_lighten', as: :admin_coloring_lighten
     post '/coloring_darken', to: 'admins#coloring_darken', as: :admin_coloring_darken
     post '/signup', to: 'admins#signup', as: :admin_signup


### PR DESCRIPTION
This PR adds a preference setting for which users are allowed to create rooms.

By default it preserves current behavior in that anyone authorized is allowed to create rooms. However, it also adds the option that only users with the admin (and super_admin) role create rooms.