### PR TITLE
GRN2-164: Change Docker-compose to use Postgres as the default DB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,19 +18,15 @@ services:
     volumes:
       - ./log:/usr/src/app/log
 # When using sqlite3 as the database
-      - ./db/production:/usr/src/app/db/production
+#      - ./db/production:/usr/src/app/db/production
 # When using postgresql as the database
-#    links:
-#      - db
-#  db:
-#    image: postgres:9.5
-#    restart: on-failure
-#    ports:
-#      - 127.0.0.1:5432:5432
-#    volumes:
-#      - ./db/production:/var/lib/postgresql/data
-#    environment:
-#      - PGHOST=postgres
-#      - PGDATABASE=postgres
-#      - PGUSER=postgres
-#      - PGPASSWORD=password
+    links:
+      - db
+  db:
+    image: postgres:9.5
+    restart: on-failure
+    ports:
+      - 127.0.0.1:5432:5432
+    volumes:
+      - ./db/production:/var/lib/postgresql/data
+    env_file: .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,4 +29,9 @@ services:
       - 127.0.0.1:5432:5432
     volumes:
       - ./db/production:/var/lib/postgresql/data
-    env_file: .env
+    environment:
+      PGHOST: localhost
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+

--- a/sample.env
+++ b/sample.env
@@ -188,13 +188,6 @@ ENABLE_GOOGLE_CALENDAR_BUTTON=
 # DB_USERNAME=postgres
 # DB_PASSWORD=password
 #
-# These are the settings for the postgres db. They must match the db settings for greenlight when using postgres
-#
-# PGHOST=localhost
-# POSTGRES_DB=postgres
-# POSTGRES_USER=postgres
-# POSTGRES_PASSWORD=password
-#
 # For deployments based on the docker-compose script also included, the HOST should be set with the Docker container id.
 #
 DB_ADAPTER=postgresql
@@ -203,7 +196,3 @@ DB_NAME=greenlight_production
 DB_USERNAME=postgres
 DB_PASSWORD=password
 
-PGHOST=localhost
-POSTGRES_DB=postgres
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=password

--- a/sample.env
+++ b/sample.env
@@ -188,10 +188,22 @@ ENABLE_GOOGLE_CALENDAR_BUTTON=
 # DB_USERNAME=postgres
 # DB_PASSWORD=password
 #
+# These are the settings for the postgres db. They must match the db settings for greenlight when using postgres
+#
+# PGHOST=localhost
+# POSTGRES_DB=postgres
+# POSTGRES_USER=postgres
+# POSTGRES_PASSWORD=password
+#
 # For deployments based on the docker-compose script also included, the HOST should be set with the Docker container id.
 #
-# DB_ADAPTER=postgresql
-# DB_HOST=db
-# DB_NAME=greenlight_production
-# DB_USERNAME=postgres
-# DB_PASSWORD=password
+DB_ADAPTER=postgresql
+DB_HOST=db
+DB_NAME=greenlight_production
+DB_USERNAME=postgres
+DB_PASSWORD=password
+
+PGHOST=localhost
+POSTGRES_DB=postgres
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password


### PR DESCRIPTION
Note changing the postgres username/password in the .env file won't have any effect if a postgres database has already been initialized in the db volume