### PR TITLE
Add custom ldap sign in

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,8 +82,8 @@ end
 gem 'rubocop'
 
 group :development, :test do
-# Call 'byebug' anywhere in the code to stop execution and get a debugger console
-gem 'byebug', platform: :mri
+  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'byebug', platform: :mri
   # Environment configuration.
   gem 'dotenv-rails'
   # Use a sqlite database in test and development.

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'omniauth'
 gem 'omniauth-twitter'
 gem 'omniauth-google-oauth2'
 gem 'azure-ad-omniauth', git: 'https://github.com/blindsidenetworks/omniauth-azure-ad.git'
-gem 'omniauth-ldap'
+gem 'net-ldap', '~> 0.16.1'
 gem 'omniauth-saml'
 
 # BigBlueButton API wrapper.
@@ -82,8 +82,8 @@ end
 gem 'rubocop'
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platform: :mri
+# Call 'byebug' anywhere in the code to stop execution and get a debugger console
+gem 'byebug', platform: :mri
   # Environment configuration.
   gem 'dotenv-rails'
   # Use a sqlite database in test and development.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,11 +154,6 @@ GEM
       jwt (>= 2.0)
       omniauth (>= 1.1.1)
       omniauth-oauth2 (>= 1.5)
-    omniauth-ldap (1.0.5)
-      net-ldap (~> 0.12)
-      omniauth (~> 1.0)
-      pyu-ruby-sasl (~> 0.0.3.2)
-      rubyntlm (~> 0.3.4)
     omniauth-oauth (1.1.0)
       oauth
       omniauth (~> 1.0)
@@ -179,7 +174,6 @@ GEM
     popper_js (1.14.5)
     public_suffix (3.0.3)
     puma (3.12.1)
-    pyu-ruby-sasl (0.0.3.3)
     rack (2.0.7)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -250,7 +244,6 @@ GEM
     ruby-progressbar (1.10.0)
     ruby-saml (1.10.2)
       nokogiri (>= 1.5.10)
-    rubyntlm (0.3.4)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -345,9 +338,9 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   mini_racer
+  net-ldap (~> 0.16.1)
   omniauth
   omniauth-google-oauth2
-  omniauth-ldap
   omniauth-saml
   omniauth-twitter
   pagy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -64,6 +64,10 @@ class UsersController < ApplicationController
   def signin
   end
 
+  # GET /ldap_signin
+  def ldap_signin
+  end
+
   # GET /signup
   def new
     return redirect_to root_path unless Rails.configuration.allow_user_signup

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,11 +36,15 @@ module ApplicationHelper
 
   # Generates the login URL for a specific provider.
   def omniauth_login_url(provider)
-    if provider == :bn_launcher
+    if provider == :load_balancer
       customer = parse_user_domain(request.host)
       customer_info = retrieve_provider_info(customer, 'api2', 'getUserGreenlightCredentials')
 
-      "#{Rails.configuration.relative_url_root}/auth/#{customer_info['provider']}"
+      if customer_info['provider'] == 'ldap'
+        ldap_signin_path
+      else
+        "#{Rails.configuration.relative_url_root}/auth/#{customer_info['provider']}"
+      end
     else
       "#{Rails.configuration.relative_url_root}/auth/#{provider}"
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,7 @@ class User < ApplicationRecord
 
   class << self
     # Generates a user from omniauth.
-    def from_omniauth(auth)
+    def from_external_provider(auth)
       # Provider is the customer name if in loadbalanced config mode
       provider = Rails.configuration.loadbalanced_configuration ? auth['info']['customer'] : auth['provider']
       find_or_initialize_by(social_uid: auth['uid'], provider: provider).tap do |u|

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -73,11 +73,11 @@
         <% else %>
           <% allow_greenlight_accounts = allow_greenlight_accounts? %>
           <% if Rails.configuration.omniauth_ldap %>
-            <%= link_to t("login"), omniauth_login_url(:ldap), :class => "btn btn-outline-primary mx-2 sign-in-button" %>
+            <%= link_to t("login"), ldap_signin_path, :class => "btn btn-outline-primary mx-2 sign-in-button" %>
           <% elsif allow_greenlight_accounts %>
             <%= link_to t("login"), signin_path, :class => "btn btn-outline-primary mx-2 sign-in-button" %>
           <% elsif Rails.configuration.loadbalanced_configuration %>
-            <%= link_to t("login"), omniauth_login_url(:bn_launcher), :class => "btn btn-outline-primary mx-2 sign-in-button" %>
+            <%= link_to t("login"), omniauth_login_url(:load_balancer), :class => "btn btn-outline-primary mx-2 sign-in-button" %>
           <% else %>
             <%= link_to t("login"), signin_path, :class => "btn btn-outline-primary mx-2 sign-in-button" %>
           <% end %>

--- a/app/views/users/ldap_signin.html.erb
+++ b/app/views/users/ldap_signin.html.erb
@@ -1,0 +1,34 @@
+<div class="container">
+    <div class="row pt-7">
+        <div class="col col-lg-6 offset-lg-3">
+            <div class="card">
+                <div class="card-header background">
+                    <h4 class="mt-2"><%= t("login_title") %></h4>
+                </div>
+                <div class="card-body background">
+                    <%= form_for(:session, url: ldap_callback_path) do |f| %>
+                        <div class="form-group">
+                            <div class="input-icon">
+                                <span class="input-icon-addon">
+                                    <i class="fas fa-user"></i>
+                                </span>
+                                <%= f.text_field :username, class: "form-control", placeholder: t("signin.username"), value: "" %>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="input-icon">
+                                <span class="input-icon-addon">
+                                    <i class="fas fa-key"></i>
+                                </span>
+                                <%= f.password_field :password, class: "form-control", placeholder: t("password"), value: "" %>
+                            </div>
+                        </div>
+                        <div class="card-footer px-0">
+                            <%= f.submit t("login"), class: "btn btn-primary btn-block signin-button" %>
+                        </div>
+                    <% end %>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -136,5 +136,19 @@ module Greenlight
 
     # Default admin password
     config.admin_password_default = ENV['ADMIN_PASSWORD'] || 'administrator'
+
+    config.ldap_host = ENV['LDAP_SERVER']
+    config.ldap_port = ENV['LDAP_PORT'] || 389
+    config.ldap_bind_dn = ENV['LDAP_BIND_DN']
+    config.ldap_password = ENV['LDAP_PASSWORD']
+    config.ldap_base = ENV['LDAP_BASE']
+    config.ldap_uid = ENV['LDAP_UID']
+
+    # To keep the configuration values the same as the old omniauth ldap provider
+    config.ldap_encryption = if ENV['LDAP_METHOD'] == 'ssl'
+      'simple_tls'
+    elsif ENV['LDAP_METHOD'] == 'tls'
+      'start_tls'
+    end
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,4 +49,6 @@ Rails.application.configure do
   # Use standalone BigBlueButton server.
   config.bigbluebutton_endpoint = config.bigbluebutton_endpoint_default
   config.bigbluebutton_secret = config.bigbluebutton_secret_default
+
+  config.loadbalanced_configuration = false
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -375,6 +375,8 @@ en:
       title: Password
     title: Profile
     search: Search
+  signin:
+    username: Username
   signup:
     password_confirm: Password Confirmation
     subtitle: Create an Account

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
 
   # Signin/Signup routes.
   get '/signin', to: 'users#signin', as: :signin
+  get '/ldap_signin', to: 'users#ldap_signin', as: :ldap_signin
   get '/signup', to: 'users#new', as: :signup
   post '/signup', to: 'users#create', as: :create_user
 
@@ -87,6 +88,7 @@ Rails.application.routes.draw do
   # Handles Omniauth authentication.
   match '/auth/:provider/callback', to: 'sessions#omniauth', via: [:get, :post], as: :omniauth_session
   get '/auth/failure', to: 'sessions#omniauth_fail'
+  post '/auth/ldap', to: 'sessions#ldap', as: :ldap_callback
 
   # Room resources.
   resources :rooms, only: [:create, :show, :destroy], param: :room_uid, path: '/'

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -107,6 +107,13 @@ describe UsersController, type: :controller do
     end
   end
 
+  describe "GET #ldap_signin" do
+    it "should render ldap signin page" do
+      get :ldap_signin
+      expect(response).to render_template(:ldap_signin)
+    end
+  end
+
   describe "POST #create" do
     context "allow greenlight accounts" do
       before { allow(Rails.configuration).to receive(:allow_user_signup).and_return(true) }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -41,6 +41,24 @@ describe ApplicationHelper do
 
       expect(helper.omniauth_login_url(provider)).to eql("/b/auth/#{provider}")
     end
+
+    it "returns the correct omniauth login url from the loadbalancer" do
+      allow(Rails.configuration).to receive(:relative_url_root).and_return("/b")
+      allow_any_instance_of(BbbApi).to receive(:retrieve_provider_info).and_return('provider' => 'google')
+
+      provider = :load_balancer
+
+      expect(helper.omniauth_login_url(provider)).to eql("/b/auth/google")
+    end
+
+    it "returns the correct ldap login url from the loadbalancer" do
+      allow(Rails.configuration).to receive(:relative_url_root).and_return("/b")
+      allow_any_instance_of(BbbApi).to receive(:retrieve_provider_info).and_return('provider' => 'ldap')
+
+      provider = :load_balancer
+
+      expect(helper.omniauth_login_url(provider)).to eql(ldap_signin_path)
+    end
   end
 
   describe "#allow_greenlight_accounts" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,7 +76,7 @@ describe User, type: :model do
     end
   end
 
-  context '#from_omniauth' do
+  context '#from_external_provider' do
     let(:auth) do
       {
         "uid" => "123456789",
@@ -93,7 +93,7 @@ describe User, type: :model do
     it "should create user from omniauth" do
       expect do
         allow(Rails.configuration).to receive(:loadbalanced_configuration).and_return(false)
-        user = User.from_omniauth(auth)
+        user = User.from_external_provider(auth)
 
         expect(user.name).to eq("Test Name")
         expect(user.email).to eq("test@example.com")


### PR DESCRIPTION
This PR removes the omniauth-ldap gem and switches to using net/ldap. This allows us to customize the ldap sign in page so it matches Greenlight's styling.