### PR TITLE
credentials through rails credentials

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -54,13 +54,13 @@ module Greenlight
     config.bigbluebutton_endpoint = if ENV["BIGBLUEBUTTON_ENDPOINT"].present?
        ENV["BIGBLUEBUTTON_ENDPOINT"]
     else
-      config.bigbluebutton_endpoint_default
+      Rails.application.credentials.dig(:bigbluebutton, :endpoint) || config.bigbluebutton_endpoint_default
     end
 
     config.bigbluebutton_secret = if ENV["BIGBLUEBUTTON_SECRET"].present?
       ENV["BIGBLUEBUTTON_SECRET"]
     else
-      config.bigbluebutton_secret_default
+      Rails.application.credentials.dig(:bigbluebutton, :secret) || config.bigbluebutton_secret_default
     end
 
     # Fix endpoint format if required.


### PR DESCRIPTION
Rails 5.2 replaces secrets.yml and secrets.yml.enc with encrypted credentials. You cannot use plain text credentials. There's only credentials.yml.enc. Encrypted credentials offer a few advantages over plaintext credentials or environment variables. For detail see [here](https://github.com/rails/rails/pull/30067) and [here](https://blog.eq8.eu/til/rails-52-credentials-tricks.html)
So.
To add bigbluebutton credentials run `EDITOR=vi bin/rais credentials:edit` and add credentials in yml format:
```
bigbluebutton:
  endpoint: "http://test-install.blindsidenetworks.com/bigbluebutton/api/"
  secret: "8cd8ef52e8e101574e400365b55e11a6"
```
Using of credentials.yml.enc is trend in rails. Rails 6 has added support for Multi Environment credentials. With this change, credentials that belong to different environments can be stored in separate files with their own encryption key. [PR](https://github.com/rails/rails/pull/33521)
 
