### PR TITLE
GRN2-xx: LDAP Images are now ignored if the actual image is passed (instead of a url) (Fixed #841)

### DIFF
--- a/app/models/concerns/auth_values.rb
+++ b/app/models/concerns/auth_values.rb
@@ -48,6 +48,9 @@ module AuthValues
     case auth['provider']
     when :twitter
       auth['info']['image'].gsub("http", "https").gsub("_normal", "")
+    when :ldap
+      return auth['info']['image'] if auth['info']['image']&.starts_with?("http")
+      ""
     else
       auth['info']['image']
     end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -444,6 +444,51 @@ describe SessionsController, type: :controller do
       expect(@request.session[:user_id]).to eql(u.id)
     end
 
+    it "should defaults the users image to blank if actual image is provided" do
+      entry = Net::LDAP::Entry.new("cn=Test User,ou=people,dc=planetexpress,dc=com")
+      entry[:cn] = "Test User"
+      entry[:givenName] = "Test"
+      entry[:sn] = "User"
+      entry[:mail] = "test@example.com"
+      entry[:jpegPhoto] = "\FF\F8" # Pretend image
+      allow_any_instance_of(Net::LDAP).to receive(:bind_as).and_return([entry])
+
+      post :ldap, params: {
+        session: {
+          user: "test",
+          password: 'password',
+        },
+      }
+
+      u = User.last
+      expect(u.provider).to eql("ldap")
+      expect(u.image).to eql("")
+      expect(@request.session[:user_id]).to eql(u.id)
+    end
+
+    it "uses the users image if a url is provided" do
+      image = Faker::Internet.url
+      entry = Net::LDAP::Entry.new("cn=Test User,ou=people,dc=planetexpress,dc=com")
+      entry[:cn] = "Test User"
+      entry[:givenName] = "Test"
+      entry[:sn] = "User"
+      entry[:mail] = "test@example.com"
+      entry[:jpegPhoto] = image
+      allow_any_instance_of(Net::LDAP).to receive(:bind_as).and_return([entry])
+
+      post :ldap, params: {
+        session: {
+          user: "test",
+          password: 'password',
+        },
+      }
+
+      u = User.last
+      expect(u.provider).to eql("ldap")
+      expect(u.image).to eql(image)
+      expect(@request.session[:user_id]).to eql(u.id)
+    end
+
     it "should redirect to signin on invalid credentials" do
       allow_any_instance_of(Net::LDAP).to receive(:bind_as).and_return(false)
 


### PR DESCRIPTION
fixes #841 

Although this is not the ideal solution, it is the only possible solution until Greenlight supports storing actual images instead of image urls