### PR TITLE
GRN2-241: Moved assets precompile to start script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ FROM ruby:2.5.1-alpine
 
 # Set a variable for the install location.
 ARG RAILS_ROOT=/usr/src/app
-ARG PACKAGES="tzdata postgresql-client sqlite-libs yarn nodejs bash"
+ARG PACKAGES="tzdata curl postgresql-client sqlite-libs yarn nodejs bash"
 
 ENV RAILS_ENV=production
 ENV BUNDLE_APP_CONFIG="$RAILS_ROOT/.bundle"

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,8 @@ RUN bundle config --global frozen 1 \
 # Adding project files.
 COPY . .
 
-RUN SECRET_KEY_BASE="1" bin/rails assets:precompile
-
 # Remove folders not needed in resulting image
-RUN rm -rf tmp/cache app/assets vendor/assets spec
+RUN rm -rf tmp/cache spec
 
 ############### Build step done ###############
 
@@ -42,7 +40,7 @@ FROM ruby:2.5.1-alpine
 
 # Set a variable for the install location.
 ARG RAILS_ROOT=/usr/src/app
-ARG PACKAGES="tzdata postgresql-client sqlite-libs nodejs bash"
+ARG PACKAGES="tzdata postgresql-client sqlite-libs yarn nodejs bash"
 
 ENV RAILS_ENV=production
 ENV BUNDLE_APP_CONFIG="$RAILS_ROOT/.bundle"

--- a/bin/start
+++ b/bin/start
@@ -19,4 +19,6 @@ else
   bundle exec rake db:schema:load
 fi
 
+bundle exec rake assets:precompile
+
 exec bundle exec puma -C config/puma.rb


### PR DESCRIPTION
Had to move the assets precompile back to the start script in order for the precompiled assets to have the correct relative root.