### PR TITLE
GRN2-xx: Having only one authentication method no longer causes a 500 (Fixed #936)

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -30,11 +30,13 @@ class SessionsController < ApplicationController
   def signin
     check_if_twitter_account
 
+    @providers = configured_providers
+
     if one_provider
       provider_path = if Rails.configuration.omniauth_ldap
         ldap_signin_path
       else
-        "#{Rails.configuration.relative_url_root}/auth/#{providers.first}"
+        "#{Rails.configuration.relative_url_root}/auth/#{@providers.first}"
       end
 
       return redirect_to provider_path
@@ -156,9 +158,7 @@ class SessionsController < ApplicationController
   end
 
   def one_provider
-    providers = configured_providers
-
-    (!allow_user_signup? || !allow_greenlight_accounts?) && providers.count == 1 &&
+    (!allow_user_signup? || !allow_greenlight_accounts?) && @providers.count == 1 &&
       !Rails.configuration.loadbalanced_configuration
   end
 


### PR DESCRIPTION
fixes #936 