### PR TITLE
Fixes to allow me to use Greenlight

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -214,7 +214,7 @@ class SessionsController < ApplicationController
     logger.info "Support: Auth user #{user.email} is attempting to login."
 
     # Add pending role if approval method and is a new user
-    if approval_registration && !@user_exists
+    if approval_registration && !@user_exists && @auth['provider'] != :ldap
       user.add_role :pending
 
       # Inform admins that a user signed up if emails are turned on

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,22 +83,22 @@ Rails.application.configure do
   config.action_mailer.delivery_method = ENV['SMTP_SERVER'].present? ? :smtp : :sendmail
 
   if ENV['SMTP_AUTH'].present? && ENV['SMTP_AUTH'] != "none"
-          ActionMailer::Base.smtp_settings = {
-            address: ENV['SMTP_SERVER'],
-            port: ENV["SMTP_PORT"],
-            domain: ENV['SMTP_DOMAIN'],
-	    user_name: ENV['SMTP_USERNAME'],
-	    password: ENV['SMTP_PASSWORD'],
-	    authentication: ENV['SMTP_AUTH'],
-            enable_starttls_auto: ENV['SMTP_STARTTLS_AUTO'],
-          }
+    ActionMailer::Base.smtp_settings = {
+      address: ENV['SMTP_SERVER'],
+      port: ENV["SMTP_PORT"],
+      domain: ENV['SMTP_DOMAIN'],
+      user_name: ENV['SMTP_USERNAME'],
+      password: ENV['SMTP_PASSWORD'],
+      authentication: ENV['SMTP_AUTH'],
+      enable_starttls_auto: ENV['SMTP_STARTTLS_AUTO'],
+    }
   else
-	  ActionMailer::Base.smtp_settings = {
-	    address: ENV['SMTP_SERVER'],
-	    port: ENV["SMTP_PORT"],
-	    domain: ENV['SMTP_DOMAIN'],
-	    enable_starttls_auto: ENV['SMTP_STARTTLS_AUTO'],
-	  }
+    ActionMailer::Base.smtp_settings = {
+      address: ENV['SMTP_SERVER'],
+      port: ENV["SMTP_PORT"],
+      domain: ENV['SMTP_DOMAIN'],
+      enable_starttls_auto: ENV['SMTP_STARTTLS_AUTO'],
+    }
   end
 
   # Don't care if the mailer can't send.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,15 +82,24 @@ Rails.application.configure do
   # Tell Action Mailer to use smtp server, if configured
   config.action_mailer.delivery_method = ENV['SMTP_SERVER'].present? ? :smtp : :sendmail
 
-  ActionMailer::Base.smtp_settings = {
-    address: ENV['SMTP_SERVER'],
-    port: ENV["SMTP_PORT"],
-    domain: ENV['SMTP_DOMAIN'],
-    user_name: ENV['SMTP_USERNAME'],
-    password: ENV['SMTP_PASSWORD'],
-    authentication: ENV['SMTP_AUTH'],
-    enable_starttls_auto: ENV['SMTP_STARTTLS_AUTO'],
-  }
+  if ENV['SMTP_AUTH'].present? && ENV['SMTP_AUTH'] != "none"
+          ActionMailer::Base.smtp_settings = {
+            address: ENV['SMTP_SERVER'],
+            port: ENV["SMTP_PORT"],
+            domain: ENV['SMTP_DOMAIN'],
+	    user_name: ENV['SMTP_USERNAME'],
+	    password: ENV['SMTP_PASSWORD'],
+	    authentication: ENV['SMTP_AUTH'],
+            enable_starttls_auto: ENV['SMTP_STARTTLS_AUTO'],
+          }
+  else
+	  ActionMailer::Base.smtp_settings = {
+	    address: ENV['SMTP_SERVER'],
+	    port: ENV["SMTP_PORT"],
+	    domain: ENV['SMTP_DOMAIN'],
+	    enable_starttls_auto: ENV['SMTP_STARTTLS_AUTO'],
+	  }
+  end
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true


### PR DESCRIPTION
perhaps they are useful to others?

Our (internal) Mail gateway doesn't support authentication, so I needed to remove auth support. For this pull request I made it depend on "SMTP_AUTH" existing or being set to "none". This isn't yet reflected in the tests.

The other commit fixes #1012 for me: I'm just bypassing Approval process when a new user is signed in via LDAP. This could of course be made to be configurable - for those out there that want to approve each ldap user manually for Greenlight. I think I'd rather work with the role attribute if I want a subset of ldap users allowed into Greenlight...