### PR TITLE
Updated documentation urls

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -20,7 +20,7 @@ BIGBLUEBUTTON_SECRET=
 #
 # For in-depth steps on setting up a Google Login Provider, see:
 #
-#   https://docs.bigbluebutton.org/greenlight/gl-customize.html#google-oauth2
+#   https://docs.bigbluebutton.org/greenlight/gl-config.html#google-oauth2
 #
 # The GOOGLE_OAUTH2_HD variable is used to limit sign-ins to a particular set of Google Apps hosted
 # domains. This can be a string with separating commas such as, 'domain.com, example.com' or
@@ -38,7 +38,7 @@ GOOGLE_OAUTH2_HD=
 #
 # For in-depth steps on setting up a Office 365 Login Provider, see:
 #
-#   https://docs.bigbluebutton.org/greenlight/gl-customize.html#office365-oauth2
+#   https://docs.bigbluebutton.org/greenlight/gl-config.html#office365-oauth2
 #
 OFFICE365_KEY=
 OFFICE365_SECRET=
@@ -50,7 +50,7 @@ OFFICE365_HD=
 # Configuring LDAP authentication will take precedence over all other providers.
 # For information about setting up LDAP, see:
 #
-#   https://docs.bigbluebutton.org/greenlight/gl-customize.html#ldap-auth
+#   https://docs.bigbluebutton.org/greenlight/gl-config.html#ldap-auth
 #
 #   LDAP_SERVER=ldap.example.com
 #   LDAP_PORT=389


### PR DESCRIPTION
The urls for the Auth settings were pointing towards the customise page these have been moved to the config page.