### PR TITLE
Revert "Fixed issue with duplicate roles from LDAP sigin (#1090)"

### DIFF
--- a/app/models/concerns/auth_values.rb
+++ b/app/models/concerns/auth_values.rb
@@ -57,14 +57,13 @@ module AuthValues
   end
 
   def auth_roles(user, auth)
-    auth['info']['roles'] = "Viewer"
     unless auth['info']['roles'].nil?
       roles = auth['info']['roles'].split(',')
 
       role_provider = auth['provider'] == "bn_launcher" ? auth['info']['customer'] : "greenlight"
       roles.each do |role_name|
-        role = Role.find_by(provider: role_provider, name: role_name)
-        user.roles << role if !role.nil? && !user.has_role?(role_name)
+        role = Role.where(provider: role_provider, name: role_name).first
+        user.roles << role unless role.nil?
       end
     end
   end


### PR DESCRIPTION
This reverts commit fab3b479c9015b8c6e0187099cbb63b0fedc7c47.

With this fix I no longer get an LDAP role at the first login of the user which is declared in the .env file with "LDAP_ROLE_FIELD".

Without the code the role will be retrieved directly at login (no matter if new or existing).