### PR TITLE
Set the number of puma workers via the WEB_CONCURRENCY environment variable

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,7 +23,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/sample.env
+++ b/sample.env
@@ -232,3 +232,8 @@ DB_PASSWORD=password
 #   invite - For invite only registration
 #   approval - For approve/decline registration
 DEFAULT_REGISTRATION=open
+
+# For busy sites, increase the number of concurrent web processes
+WEB_CONCURRENCY=1
+# If WEB_CONCURRENCY > 1, use postgresql for CABLE_ADAPTER
+CABLE_ADAPTER=async


### PR DESCRIPTION
This allows setting WEB_CONCURRENCY in .env to scale up greenlight performance.