### PR TITLE
add option to customize app title

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,8 +28,8 @@
       </script>
     <% end %>
 
-    <title><%= t("bigbluebutton") %></title>
-    <meta property="og:title" content="<%= t("bigbluebutton", locale: :en) %>" />
+    <title><%= ENV["APP_TITLE"] || t("bigbluebutton") %></title>
+    <meta property="og:title" content="<%= ENV["APP_TITLE"] || t("bigbluebutton", locale: :en) %>" />
     <meta property="og:type" content="website" />
     <meta property="og:description" content="<%= t("landing.about", href: "Greenlight", locale: :en) %>" />
     <meta property="og:url" content="<%= request.base_url %>" />

--- a/sample.env
+++ b/sample.env
@@ -172,6 +172,10 @@ MAINTENANCE_WINDOW=
 # Button can be disabled by setting the value to blank
 REPORT_ISSUE_URL=https://github.com/bigbluebutton/greenlight/issues/new
 
+# Overwrites the html title of every page
+# If not set the default translation for bigbluebutton is used
+#APP_TITLE=BigBlueButton
+
 # Comment this out to send logs to STDOUT in production instead of log/production.log .
 #
 # RAILS_LOG_TO_STDOUT=true


### PR DESCRIPTION
I know the recommended way to customize the look and feel is to create your own docker image, but I think for the most common use cases that's way to much. App title is a good example.