### PR TITLE
Freezing sprocket dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ end
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
 
+gem 'sprockets', '< 4.0.0'
+
 # Use Puma as the app server
 gem 'puma', '~> 3.12'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,6 +392,7 @@ DEPENDENCIES
   shoulda-matchers (~> 3.1)
   spring
   spring-watcher-listen (~> 2.0.0)
+  sprockets (< 4.0.0)
   sqlite3 (~> 1.3.6)
   tabler-rubygem!
   turbolinks (~> 5)
@@ -399,3 +400,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webmock
+


### PR DESCRIPTION
Version 4.0.0 introduces breaking behavior for this project.

Freeze is needed until migration is done as in: https://github.com/rails/sprockets/blob/master/UPGRADING.md

Solves #899 