### PR TITLE
fix cookie banner height

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -134,12 +134,12 @@ a {
 }
 
 .cookies-banner {
-  height: $footer-height;
   color: white;
   background-color: $button-color-blue;
 
   #cookies-agree-button {
     background-color: green !important;
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
On mobile devices the agree button was partially hidden.
![2020-04-05 09 21 41 teaching drk-tettnang de bb93ee04f37a](https://user-images.githubusercontent.com/2974196/78469282-f10bdf00-771f-11ea-91b6-9adf8fbc93eb.png)

This small change, fixes the issue:
![2020-04-05 09 27 15 teaching drk-tettnang de dd4ae71182af](https://user-images.githubusercontent.com/2974196/78469285-fb2ddd80-771f-11ea-80f2-6539a53dd3a4.png)

