### PR TITLE
Dutch translation: 'Aanmelden' was used for both Sign-in and Sign-up. I fixed this.

### DIFF
--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -266,14 +266,14 @@ nl:
     version: "We hebben een nieuwe versie van Greenlight uitgebracht, maar uw database is niet compatibel."
   language_default: Standaard (browsertaal)
   ldap_error: Kan geen verbinding maken met de LDAP-server. Controleer uw LDAP-configuratie in het env-bestand en zorg ervoor dat uw server actief is.
-  login: Aanmelden
+  login: Inloggen
   login_title: Meld u aan bij uw account
   mailer:
     user:
       approve:
         info: Uw account is goedgekeurd.
         signin: "Om toegang te krijgen tot uw persoonlijke kamers, klikt u op de onderstaande knop en logt u in."
-        signin_link: Aanmelden
+        signin_link: Inloggen
         signup:
           info: Een nieuwe gebruiker heeft zich aangemeld om Greenlight te gebruiken.
           more-info: "Om deze gebruiker toegang te geven tot Greenlight, moet u zijn account goedkeuren in de organisatie-instellingen."
@@ -285,12 +285,12 @@ nl:
       demoted:
         info: "U bent niet langer een %{role} op %{url}."
         more-info: U hebt nu dezelfde rechten als een gewone gebruiker.
-        root_link: Aanmelden
+        root_link: Inloggen
         subtitle: "%{role} rechten ingetrokken"
       invite:
         info: "Je bent uitgenodigd voor je eigen persoonlijke ruimte door %{name}"
         signup_info: Klik op de onderstaande knop om u aan te melden met uw e-mail en volg de stappen.
-        signup_link: Aanmelden
+        signup_link: Registreren
         signup:
           info: Een uitgenodigde gebruiker heeft zich aangemeld om Greenlight te gebruiken.
           admins_link: Bezoek de organisatiepagina
@@ -443,8 +443,8 @@ nl:
       fail: U hebt geen toegang tot deze applicatie. Neem contact op met uw beheerder als u denkt dat dit een vergissing is. 
     deprecated:
       new_signin: Selecteer een nieuwe inlogmethode voor uw account. Al uw kamers van uw oude account worden gemigreerd naar het nieuwe account
-      twitter_signin: "Aanmelden via Twitter is verouderd en wordt in de volgende release verwijderd. Klik <a href=\"%{link}\"> hier </a> om uw account naar een nieuwe authenticatiemethode te verplaatsen"
-      twitter_signup: Aanmelden via Twitter is verouderd. Gebruik een andere aanmeldingsmethode
+      twitter_signin: "Inloggen via Twitter is verouderd en wordt in de volgende release verwijderd. Klik <a href=\"%{link}\"> hier </a> om uw account naar een nieuwe authenticatiemethode te verplaatsen"
+      twitter_signup: Registreren via Twitter is verouderd. Gebruik een andere aanmeldingsmethode
       merge_success: Uw Twitter-account is succesvol samengevoegd met uw nieuwe account. Je oude twitter-account is verwijderd
     invite:
       fail: Uw token is ongeldig of is verlopen. Neem contact op met uw beheerder als u denkt dat dit een vergissing is.


### PR DESCRIPTION
To avoid this confusion, I changed it to Inloggen (Sign-in) and Registreren (Sign-up)

In below screenshot you see why I did this change (top right corner).
![image](https://user-images.githubusercontent.com/41594439/78689441-a0021380-78f6-11ea-99ce-827a6f85e193.png)
