### PR TITLE
Allow to set a filter for LDAP authentication

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -138,6 +138,7 @@ class SessionsController < ApplicationController
                                     'start_tls'
                                 end
     ldap_config[:base] = ENV['LDAP_BASE']
+    ldap_config[:filter] = ENV['LDAP_FILTER']
     ldap_config[:uid] = ENV['LDAP_UID']
 
     if params[:session][:username].blank? || session_params[:password].blank?

--- a/sample.env
+++ b/sample.env
@@ -65,6 +65,7 @@ OAUTH2_REDIRECT=
 #   LDAP_BIND_DN=cn=admin,dc=example,dc=com
 #   LDAP_PASSWORD=password
 #   LDAP_ROLE_FIELD=ou
+#   LDAP_FILTER=(&(attr1=value1)(attr2=value2))
 LDAP_SERVER=
 LDAP_PORT=
 LDAP_METHOD=
@@ -74,6 +75,7 @@ LDAP_BIND_DN=
 LDAP_AUTH=
 LDAP_PASSWORD=
 LDAP_ROLE_FIELD=
+LDAP_FILTER=
 
 # Set this to true if you want GreenLight to support user signup and login without
 # Omniauth. For more information, see:


### PR DESCRIPTION
Not everybody can use a LDAP group for filtering their users (https://github.com/bigbluebutton/greenlight/issues/1083, https://github.com/bigbluebutton/greenlight/issues/439#issuecomment-522026774).

This patch allows to define an addtionnal environment variable for the [blindsidenetworks/bn-ldap-authentication](https://github.com/blindsidenetworks/bn-ldap-authentication) dependency. This is dependent of the acceptance of this pull request https://github.com/blindsidenetworks/bn-ldap-authentication/pull/3. 