### PR TITLE
Access code as part of the URL

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -66,6 +66,11 @@ class RoomsController < ApplicationController
     @room_running = room_running?(@room.bbb_id)
     @shared_room = room_shared_with_user
 
+    # Accept access code as part of the URL
+    if params.key?(:code)
+      session[:access_code] = params[:code]
+    end
+
     # If its the current user's room
     if current_user && (@room.owned_by?(current_user) || @shared_room)
       if current_user.highest_priority_role.get_permission("can_create_rooms")

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -67,9 +67,7 @@ class RoomsController < ApplicationController
     @shared_room = room_shared_with_user
 
     # Accept access code as part of the URL
-    if params.key?(:code)
-      session[:access_code] = params[:code]
-    end
+    session[:access_code] = params[:code] if params.key?(:code)
 
     # If its the current user's room
     if current_user && (@room.owned_by?(current_user) || @shared_room)

--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -37,4 +37,13 @@ module RoomsHelper
     @diff = current_user.rooms.count - limit
     @diff.positive? && current_user.rooms.pluck(:id).index(room.id) + 1 > limit
   end
+
+  def room_join_url
+    if @room.access_code.nil? || @room.access_code.empty?
+      return request.base_url + @room.invite_path
+    else
+      return request.base_url + @room.invite_path + "?code=" + @room.access_code
+    end
+  end
+
 end

--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -40,10 +40,9 @@ module RoomsHelper
 
   def room_join_url
     if @room.access_code.nil? || @room.access_code.empty?
-      return request.base_url + @room.invite_path
+      request.base_url + @room.invite_path
     else
-      return request.base_url + @room.invite_path + "?code=" + @room.access_code
+      request.base_url + @room.invite_path + "?code=" + @room.access_code
     end
   end
-
 end

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -41,7 +41,7 @@
                 <span class="input-icon-addon">
                   <i class="fas fa-link"></i>
                 </span>
-                <input id="invite-url" type="text" class="form-control w-100" value="<%= request.base_url + @room.invite_path %>" readonly="">
+                <input id="invite-url" type="text" class="form-control w-100" value="<%= room_join_url %>" readonly="">
               </div>
             </div>
             <div class="col-lg-5 col-md-12">


### PR DESCRIPTION
- Allow access code to be passed as part of the URL query string (`?code=`)
- Include access code in the copyable URL

Uses `code` as the query parameter in the `GET` request instead of `access_code` as some users will have to type it in, so preferring a shorter string.

Fixes #1303