### PR TITLE
Fixed CSS class of sign-up button

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -107,7 +107,7 @@
           <% end %>
 
           <% if allow_user_signup? && allow_greenlight_accounts %>
-            <%= link_to t("signup.title"), signup_path, :class => "btn btn-outline-primary mx-2 sign-in-button" %>
+            <%= link_to t("signup.title"), signup_path, :class => "btn btn-outline-primary mx-2 sign-up-button" %>
           <% end %>
         <% end %>
       </div>


### PR DESCRIPTION
The CSS class of the sign-up button is called `sign-in-button`. This makes it harder to style the button because the same class is used for both, the sign-in button _and_ the sign-up button.