### PR TITLE
Configuration of default guest policy and fix guest params

### DIFF
--- a/app/controllers/concerns/bbb_server.rb
+++ b/app/controllers/concerns/bbb_server.rb
@@ -54,7 +54,10 @@ module BbbServer
     join_opts = {}
     join_opts[:userID] = uid if uid
     join_opts[:join_via_html5] = true
-    join_opts[:guest] = true if options[:require_moderator_approval] && !options[:user_is_moderator]
+    if options.key?(:guest)
+      join_opts[:guest] = options[:guest]
+      join_opts[:auth] = !options[:guest]
+    end
 
     bbb_server.join_meeting_url(room.bbb_id, name, password, join_opts)
   end
@@ -74,7 +77,7 @@ module BbbServer
       "meta_bbb-origin-server-name": options[:host]
     }
 
-    create_options[:guestPolicy] = "ASK_MODERATOR" if options[:require_moderator_approval]
+    create_options[:guestPolicy] = options[:require_moderator_approval] ? "ASK_MODERATOR" : Rails.configuration.guest_policy
 
     # Send the create request.
     begin

--- a/app/controllers/concerns/joiner.rb
+++ b/app/controllers/concerns/joiner.rb
@@ -59,8 +59,10 @@ module Joiner
       opts[:mute_on_start] = room_setting_with_config("muteOnStart")
 
       if current_user
+        opts[:guest] = false
         redirect_to join_path(@room, current_user.name, opts, current_user.uid)
       else
+        opts[:guest] = true
         join_name = params[:join_name] || params[@room.invite_path][:join_name]
 
         redirect_to join_path(@room, join_name, opts, fetch_guest_id)

--- a/config/application.rb
+++ b/config/application.rb
@@ -159,5 +159,8 @@ module Greenlight
 
     # Default admin password
     config.admin_password_default = ENV['ADMIN_PASSWORD'] || 'administrator'
+
+    # Default guest policy
+    config.guest_policy = ENV['GUEST_POLICY'] || 'ALWAYS_ACCEPT'
   end
 end

--- a/spec/concerns/bbb_server_spec.rb
+++ b/spec/concerns/bbb_server_spec.rb
@@ -52,6 +52,25 @@ describe BbbServer do
 
       expect(@room.last_session).not_to be nil
     end
+
+    it "should set guestPolicy ASK_MODERATOR if require_moderator_approval is set" do
+      allow_any_instance_of(BigBlueButton::BigBlueButtonApi).to receive(:create_meeting) do |_api, _name, _bbb_id, create_options|
+        expect(create_options[:guestPolicy]).to eql("ASK_MODERATOR")
+        { messageKey: "" }
+      end
+
+      start_session(@room, require_moderator_approval: true)
+    end
+
+    it "should set guestPolicy from config if require_moderator_approval is not set" do
+      allow_any_instance_of(BigBlueButton::BigBlueButtonApi).to receive(:create_meeting) do |_api, _name, _bbb_id, create_options|
+        expect(create_options[:guestPolicy]).to eql("ALWAYS_ACCEPT_AUTH")
+        { messageKey: "" }
+      end
+
+      Rails.configuration.guest_policy = "ALWAYS_ACCEPT_AUTH"
+      start_session(@room)
+    end
   end
 
   context "#join_path" do

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -308,7 +308,9 @@ describe RoomsController, type: :controller do
       @request.session[:user_id] = @user.id
       post :join, params: { room_uid: room, join_name: @user.name }
 
-      expect(response).to redirect_to(join_path(room, @user.name, { user_is_moderator: true }, @user.uid))
+      expect(response).to redirect_to(
+        join_path(room, @user.name, { guest: false, auth: true, user_is_moderator: true }, @user.uid)
+      )
     end
 
     it "joins the room as moderator if room has the all_join_moderator setting" do
@@ -340,7 +342,9 @@ describe RoomsController, type: :controller do
       @request.session[:user_id] = @user.id
       post :join, params: { room_uid: room, join_name: @user.name }
 
-      expect(response).to redirect_to(join_path(room, @user.name, { user_is_moderator: true }, @user.uid))
+      expect(response).to redirect_to(
+        join_path(room, @user.name, { guest: false, auth: true, user_is_moderator: true }, @user.uid)
+      )
     end
 
     it "doesn't join the room as moderator if room has the all_join_moderator setting but config is set to disabled" do
@@ -355,7 +359,9 @@ describe RoomsController, type: :controller do
       @request.session[:user_id] = @user.id
       post :join, params: { room_uid: room, join_name: @user.name }
 
-      expect(response).to redirect_to(join_path(room, @user.name, { user_is_moderator: false }, @user.uid))
+      expect(response).to redirect_to(
+        join_path(room, @user.name, { guest: false, auth: true, user_is_moderator: false }, @user.uid)
+      )
     end
 
     it "should render wait if the correct access code is supplied" do

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -241,14 +241,18 @@ describe RoomsController, type: :controller do
       @request.session[:user_id] = @user.id
       post :join, params: { room_uid: @room, join_name: @user.name }
 
-      expect(response).to redirect_to(join_path(@owner.main_room, @user.name, {}, @user.uid))
+      expect(response).to redirect_to(
+        join_path(@owner.main_room, @user.name, { guest: false, auth: true }, @user.uid)
+      )
     end
 
     it "should use join name if user is not logged in and meeting running" do
       allow_any_instance_of(BigBlueButton::BigBlueButtonApi).to receive(:is_meeting_running?).and_return(true)
       post :join, params: { room_uid: @room, join_name: "Join Name" }
 
-      expect(response).to redirect_to(join_path(@owner.main_room, "Join Name", {}, response.cookies["guest_id"]))
+      expect(response).to redirect_to(
+        join_path(@owner.main_room, "Join Name", { guest: true, auth: false }, response.cookies["guest_id"])
+      )
     end
 
     it "should render wait if meeting isn't running" do
@@ -272,7 +276,9 @@ describe RoomsController, type: :controller do
       @request.session[:user_id] = @user.id
       post :join, params: { room_uid: room, join_name: @user.name }
 
-      expect(response).to redirect_to(join_path(room, @user.name, { user_is_moderator: false }, @user.uid))
+      expect(response).to redirect_to(
+        join_path(room, @user.name, { guest: false, auth: true, user_is_moderator: false }, @user.uid)
+      )
     end
 
     it "doesn't join the room if the room has the anyone_can_start setting but config is disabled" do
@@ -317,7 +323,9 @@ describe RoomsController, type: :controller do
       @request.session[:user_id] = @user.id
       post :join, params: { room_uid: room, join_name: @user.name }
 
-      expect(response).to redirect_to(join_path(room, @user.name, { user_is_moderator: true }, @user.uid))
+      expect(response).to redirect_to(
+        join_path(room, @user.name, { guest: false, auth: true, user_is_moderator: true }, @user.uid)
+      )
     end
 
     it "joins the room as moderator if room doesn't have all_join_moderator but config is set to enabled" do
@@ -382,7 +390,9 @@ describe RoomsController, type: :controller do
       @request.session[:user_id] = @owner.id
       post :join, params: { room_uid: @room, join_name: @owner.name }
 
-      expect(response).to redirect_to(join_path(@owner.main_room, @owner.name, { user_is_moderator: true }, @owner.uid))
+      expect(response).to redirect_to(
+        join_path(@owner.main_room, @owner.name, { guest: false, auth: true, user_is_moderator: true }, @owner.uid)
+      )
     end
 
     it "redirects to root if owner of room is not verified" do


### PR DESCRIPTION
Our company has needs to control guest policy at greenlight side. It also fixes inconsistent guest params.

## Features

* Can configure `default guest policy` to other than "ALWAYS_ACCEPT" (Our company needs "ALWAYS_ACCEPT_AUTH")

## Fix

* Fix `guest` parameter for join url