### PR TITLE
Legal and privpolicy link

### DIFF
--- a/app/assets/javascripts/admins.js
+++ b/app/assets/javascripts/admins.js
@@ -122,9 +122,9 @@ function changeBrandingImage(path) {
   $.post(path, {value: url})
 }
 
-// Change the Imprint URL to the one provided
-function changeImprintURL(path) {
-  var url = $("#imprint-url").val()
+// Change the Legal URL to the one provided
+function changeLegalURL(path) {
+  var url = $("#legal-url").val()
   $.post(path, {value: url})
 }
 

--- a/app/assets/javascripts/admins.js
+++ b/app/assets/javascripts/admins.js
@@ -122,6 +122,18 @@ function changeBrandingImage(path) {
   $.post(path, {value: url})
 }
 
+// Change the Imprint URL to the one provided
+function changeImprintURL(path) {
+  var url = $("#imprint-url").val()
+  $.post(path, {value: url})
+}
+
+// Change the Privacy Policy URL to the one provided
+function changePrivacyPolicyURL(path) {
+  var url = $("#privpolicy-url").val()
+  $.post(path, {value: url})
+}
+
 function mergeUsers() {
   let userToMerge = $("#from-uid").text()
   $.post($("#merge-save-access").data("path"), {merge: userToMerge})

--- a/app/helpers/theming_helper.rb
+++ b/app/helpers/theming_helper.rb
@@ -22,9 +22,9 @@ module ThemingHelper
     @settings.get_value("Branding Image") || Rails.configuration.branding_image_default
   end
 
-  # Returns the imprint URL based on user's provider
-  def imprint_url
-    @settings.get_value("Imprint URL") || ""
+  # Returns the legal URL based on user's provider
+  def legal_url
+    @settings.get_value("Legal URL") || ""
   end
 
   # Returns the logo based on user's provider

--- a/app/helpers/theming_helper.rb
+++ b/app/helpers/theming_helper.rb
@@ -22,6 +22,16 @@ module ThemingHelper
     @settings.get_value("Branding Image") || Rails.configuration.branding_image_default
   end
 
+  # Returns the imprint URL based on user's provider
+  def imprint_url
+    @settings.get_value("Imprint URL") || ""
+  end
+
+  # Returns the logo based on user's provider
+  def privpolicy_url
+    @settings.get_value("Privacy Policy URL") || ""
+  end
+
   # Returns the primary color based on user's provider
   def user_color
     @settings.get_value("Primary Color") || Rails.configuration.primary_color_default

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -48,7 +48,7 @@ class Setting < ApplicationRecord
     case name
     when "Branding Image"
       Rails.configuration.branding_image_default
-    when "Imprint URL"
+    when "Legal URL"
       nil
     when "Privacy Policy URL"
       nil

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -48,6 +48,10 @@ class Setting < ApplicationRecord
     case name
     when "Branding Image"
       Rails.configuration.branding_image_default
+    when "Imprint URL"
+      nil
+    when "Privacy Policy URL"
+      nil
     when "Primary Color"
       Rails.configuration.primary_color_default
     when "Registration Method"

--- a/app/views/admins/components/_settings.html.erb
+++ b/app/views/admins/components/_settings.html.erb
@@ -31,12 +31,12 @@
   <div class="row">
     <div class="col-12">
       <div class="mb-6 form-group">
-        <label class="form-label"><%= t("administrator.site_settings.imprint.title") %></label>
-        <label class="form-label text-muted"><%= t("administrator.site_settings.imprint.info") %></label>
+        <label class="form-label"><%= t("administrator.site_settings.legal.title") %></label>
+        <label class="form-label text-muted"><%= t("administrator.site_settings.legal.info") %></label>
         <div class="input-group">
-          <input id="imprint-url" type="text" class="form-control" value="<%= imprint_url %>">
+          <input id="legal-url" type="text" class="form-control" value="<%= legal_url %>">
           <span class="input-group-append">
-            <button id="imprint-url" onclick="changeImprintURL('<%= admin_update_settings_path(setting: 'Imprint URL') %>')" class="btn btn-primary" type="button"><%= t("administrator.site_settings.imprint.change") %></button>
+            <button id="legal-url" onclick="changeLegalURL('<%= admin_update_settings_path(setting: 'Legal URL') %>')" class="btn btn-primary" type="button"><%= t("administrator.site_settings.legal.change") %></button>
           </span>
         </div>
       </div>

--- a/app/views/admins/components/_settings.html.erb
+++ b/app/views/admins/components/_settings.html.erb
@@ -31,6 +31,34 @@
   <div class="row">
     <div class="col-12">
       <div class="mb-6 form-group">
+        <label class="form-label"><%= t("administrator.site_settings.imprint.title") %></label>
+        <label class="form-label text-muted"><%= t("administrator.site_settings.imprint.info") %></label>
+        <div class="input-group">
+          <input id="imprint-url" type="text" class="form-control" value="<%= imprint_url %>">
+          <span class="input-group-append">
+            <button id="imprint-url" onclick="changeImprintURL('<%= admin_update_settings_path(setting: 'Imprint URL') %>')" class="btn btn-primary" type="button"><%= t("administrator.site_settings.imprint.change") %></button>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="mb-6 form-group">
+        <label class="form-label"><%= t("administrator.site_settings.privpolicy.title") %></label>
+        <label class="form-label text-muted"><%= t("administrator.site_settings.privpolicy.info") %></label>
+        <div class="input-group">
+          <input id="privpolicy-url" type="text" class="form-control" value="<%= privpolicy_url %>">
+          <span class="input-group-append">
+            <button id="privpolicy-url" onclick="changePrivacyPolicyURL('<%= admin_update_settings_path(setting: 'Privacy Policy URL') %>')" class="btn btn-primary" type="button"><%= t("administrator.site_settings.privpolicy.change") %></button>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="mb-6 form-group">
         <label class="form-label"><%= t("administrator.site_settings.color.title") %></label>
         <label class="form-label text-muted"><%= t("administrator.site_settings.color.info") %></label>
           <div class="color-inputs">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -15,7 +15,7 @@
 
 <footer class="footer pt-3">
   <p class="text-center mb-1"><%= t("footer.powered_by", href: link_to(t("greenlight"), "https://bigbluebutton.org/2018/07/09/greenlight-2-0/", target: "_blank", rel: "noopener")).html_safe %> <%= Greenlight::Application::VERSION %>
-  <%= link_to( ' | ' + t("footer.imprint"), imprint_url ) if imprint_url.present? %><%= link_to( ' | ' + t("footer.privpolicy"), privpolicy_url) if privpolicy_url.present? %></p>
+  <%= link_to( ' | ' + t("footer.legal"), legal_url ) if legal_url.present? %><%= link_to( ' | ' + t("footer.privpolicy"), privpolicy_url) if privpolicy_url.present? %></p>
 </footer>
 
 <%= render "shared/components/cookie_warning" %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -14,7 +14,8 @@
 %>
 
 <footer class="footer pt-3">
-  <p class="text-center mb-1"><%= t("footer.powered_by", href: link_to(t("greenlight"), "https://bigbluebutton.org/2018/07/09/greenlight-2-0/", target: "_blank", rel: "noopener")).html_safe %> <%= Greenlight::Application::VERSION %></p>
+  <p class="text-center mb-1"><%= t("footer.powered_by", href: link_to(t("greenlight"), "https://bigbluebutton.org/2018/07/09/greenlight-2-0/", target: "_blank", rel: "noopener")).html_safe %> <%= Greenlight::Application::VERSION %>
+  <%= link_to( ' | ' + t("footer.imprint"), imprint_url ) if imprint_url.present? %><%= link_to( ' | ' + t("footer.privpolicy"), privpolicy_url) if privpolicy_url.present? %></p>
 </footer>
 
 <%= render "shared/components/cookie_warning" %>

--- a/config/locales/de_DE.yml
+++ b/config/locales/de_DE.yml
@@ -43,6 +43,18 @@ de_DE:
         placeholder: Bild URL...
         title: Logo
         invalid: Ungültige URL
+      imprint:
+        change: URL ändern
+        info: Die URL für den Link zum Impressum am Seitenende ändern
+        placeholder: Impressums-URL...
+        title: Impressum
+        invalid: Ungültige URL
+      privpolicy:
+        change: URL ändern
+        info: Die URL für den Link zur Datenschutzerklärung am Seitenende ändern
+        placeholder: Datenschutzerklärungs-URL...
+        title: Datenschutzerklärung
+        invalid: Ungültige URL
       cache:
         info: "Löscht den Provider-Zwischenspeicher, wodurch bei einer neuen Anfrage Informationen neu eingegeben werden müssen "
         title: Provider-Zwischenspeicher löschen
@@ -245,6 +257,8 @@ de_DE:
     designs: Eigene Designs
     authentication: Nutzerauthentifizierung
   footer:
+    imprint: Impressum
+    privpolicy: Datenschutzerklärung
     powered_by: "Bereitgestellt durch %{href}."
   forgot_password:
     subtitle: Passwort vergessen

--- a/config/locales/de_DE.yml
+++ b/config/locales/de_DE.yml
@@ -43,18 +43,6 @@ de_DE:
         placeholder: Bild URL...
         title: Logo
         invalid: Ungültige URL
-      legal:
-        change: URL ändern
-        info: Die URL für den Link zum Impressum am Seitenende ändern
-        placeholder: Impressums-URL...
-        title: Impressum
-        invalid: Ungültige URL
-      privpolicy:
-        change: URL ändern
-        info: Die URL für den Link zur Datenschutzerklärung am Seitenende ändern
-        placeholder: Datenschutzerklärungs-URL...
-        title: Datenschutzerklärung
-        invalid: Ungültige URL
       cache:
         info: "Löscht den Provider-Zwischenspeicher, wodurch bei einer neuen Anfrage Informationen neu eingegeben werden müssen "
         title: Provider-Zwischenspeicher löschen
@@ -257,8 +245,6 @@ de_DE:
     designs: Eigene Designs
     authentication: Nutzerauthentifizierung
   footer:
-    legal: Impressum
-    privpolicy: Datenschutzerklärung
     powered_by: "Bereitgestellt durch %{href}."
   forgot_password:
     subtitle: Passwort vergessen

--- a/config/locales/de_DE.yml
+++ b/config/locales/de_DE.yml
@@ -43,7 +43,7 @@ de_DE:
         placeholder: Bild URL...
         title: Logo
         invalid: Ungültige URL
-      imprint:
+      legal:
         change: URL ändern
         info: Die URL für den Link zum Impressum am Seitenende ändern
         placeholder: Impressums-URL...
@@ -257,7 +257,7 @@ de_DE:
     designs: Eigene Designs
     authentication: Nutzerauthentifizierung
   footer:
-    imprint: Impressum
+    legal: Impressum
     privpolicy: Datenschutzerklärung
     powered_by: "Bereitgestellt durch %{href}."
   forgot_password:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,11 +43,11 @@ en:
         placeholder: Image Url...
         title: Branding Image
         invalid: Invalid URL
-      imprint:
+      legal:
         change: Change URL
-        info: Change the Imprint Link that appears in the bottom of the page
-        placeholder: Imprint URL...
-        title: Imprint
+        info: Change the Legal Link that appears in the bottom of the page
+        placeholder: Legal URL...
+        title: Legal
         invalid: Invalid URL
       privpolicy:
         change: Change URL
@@ -258,7 +258,7 @@ en:
     designs: Custom Designs
     authentication: User Authentication
   footer:
-    imprint: Imprint
+    legal: Legal
     privpolicy: Privacy Policy
     powered_by: Powered by %{href}.
   forgot_password:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,18 @@ en:
         placeholder: Image Url...
         title: Branding Image
         invalid: Invalid URL
+      imprint:
+        change: Change URL
+        info: Change the Imprint Link that appears in the bottom of the page
+        placeholder: Imprint URL...
+        title: Imprint
+        invalid: Invalid URL
+      privpolicy:
+        change: Change URL
+        info: Change the Privacy Policy Link that appears in the bottom of the page
+        placeholder: Privacy Policy URL...
+        title: Privacy Policy
+        invalid: Invalid URL
       cache:
         info: Clears the stored provider cache which forces a new request for the updated info
         title: Clear Provider Cache
@@ -246,6 +258,8 @@ en:
     designs: Custom Designs
     authentication: User Authentication
   footer:
+    imprint: Imprint
+    privpolicy: Privacy Policy
     powered_by: Powered by %{href}.
   forgot_password:
     subtitle: Forgot Password

--- a/spec/controllers/admins_controller_spec.rb
+++ b/spec/controllers/admins_controller_spec.rb
@@ -299,17 +299,17 @@ describe AdminsController, type: :controller do
       end
     end
 
-    context "POST #imprint" do
-      it "changes the imprint link on the page" do
+    context "POST #legal" do
+      it "changes the legal link on the page" do
         allow(Rails.configuration).to receive(:loadbalanced_configuration).and_return(true)
         allow_any_instance_of(User).to receive(:greenlight_account?).and_return(true)
 
         @request.session[:user_id] = @admin.id
         fake_url = "example.com"
 
-        post :update_settings, params: { setting: "Imprint URL", value: fake_url }
+        post :update_settings, params: { setting: "Legal URL", value: fake_url }
 
-        feature = Setting.find_by(provider: "provider1").features.find_by(name: "Imprint URL")
+        feature = Setting.find_by(provider: "provider1").features.find_by(name: "Legal URL")
 
         expect(feature[:value]).to eq(fake_url)
         expect(response).to redirect_to(admin_site_settings_path)

--- a/spec/controllers/admins_controller_spec.rb
+++ b/spec/controllers/admins_controller_spec.rb
@@ -299,6 +299,40 @@ describe AdminsController, type: :controller do
       end
     end
 
+    context "POST #imprint" do
+      it "changes the imprint link on the page" do
+        allow(Rails.configuration).to receive(:loadbalanced_configuration).and_return(true)
+        allow_any_instance_of(User).to receive(:greenlight_account?).and_return(true)
+
+        @request.session[:user_id] = @admin.id
+        fake_url = "example.com"
+
+        post :update_settings, params: { setting: "Imprint URL", value: fake_url }
+
+        feature = Setting.find_by(provider: "provider1").features.find_by(name: "Imprint URL")
+
+        expect(feature[:value]).to eq(fake_url)
+        expect(response).to redirect_to(admin_site_settings_path)
+      end
+    end
+
+    context "POST #privpolicy" do
+      it "changes the privacy policy on the page" do
+        allow(Rails.configuration).to receive(:loadbalanced_configuration).and_return(true)
+        allow_any_instance_of(User).to receive(:greenlight_account?).and_return(true)
+
+        @request.session[:user_id] = @admin.id
+        fake_url = "example.com"
+
+        post :update_settings, params: { setting: "Privacy Policy URL", value: fake_url }
+
+        feature = Setting.find_by(provider: "provider1").features.find_by(name: "Imprint URL")
+
+        expect(feature[:value]).to eq(fake_url)
+        expect(response).to redirect_to(admin_site_settings_path)
+      end
+    end
+
     context "POST #coloring" do
       it "changes the primary on the page" do
         allow(Rails.configuration).to receive(:loadbalanced_configuration).and_return(true)

--- a/spec/controllers/admins_controller_spec.rb
+++ b/spec/controllers/admins_controller_spec.rb
@@ -326,7 +326,7 @@ describe AdminsController, type: :controller do
 
         post :update_settings, params: { setting: "Privacy Policy URL", value: fake_url }
 
-        feature = Setting.find_by(provider: "provider1").features.find_by(name: "Imprint URL")
+        feature = Setting.find_by(provider: "provider1").features.find_by(name: "Privacy Policy URL")
 
         expect(feature[:value]).to eq(fake_url)
         expect(response).to redirect_to(admin_site_settings_path)


### PR DESCRIPTION
I added two items in "site settings" as suggested in #1268.
When you put an URL in there it gets added as "legal" or privacy policy link, respectively, in the page footer. If left empty, it doesn't display.