### PR TITLE
fixed spelling error that was bugging me :) - sep a rat e

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -368,7 +368,7 @@ en:
       warning: You will <b>not</b> be able to recover this room
       recording_warning: or any of its %{recordings_num} associated recordings.
     invite_user:
-      email_placeholder: Enter the users' emails (seperated by commas)
+      email_placeholder: Enter the users' emails (separated by commas)
       footer: The user will receive an email with instructions on how to sign up
       send: Send Invite
       title: Invite User


### PR DESCRIPTION
This typo was getting under my skin - separate has "a rat" in it :) - so I've taken the time to fix it and submit a friendly amendment/pull request. 