### PR TITLE
Make Greenlight work with Ruby 2.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     bindex (0.8.1)
     bn-ldap-authentication (0.1.2)
       net-ldap (~> 0)
-    bootsnap (1.4.4)
+    bootsnap (1.4.6)
       msgpack (~> 1.0)
     bootstrap (4.3.1)
       autoprefixer-rails (>= 9.1.0)
@@ -150,7 +150,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    msgpack (1.3.0)
+    msgpack (1.3.3)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -382,3 +382,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webmock
+
+BUNDLED WITH
+   2.1.4


### PR DESCRIPTION
Greenlight's failure to start up with Ruby 2.7 seems to be caused by [an
issue in bootsnap](https://github.com/Shopify/bootsnap/issues/258).
Updating that library makes Greenlight work again.

However, there are still a lot of deprecation warnings. But that's
something to deal with separately.

This fixes #1558