### PR TITLE
Fix rake task user:create so that users can be created when terms are present

### DIFF
--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -10,7 +10,7 @@ namespace :user do
       password: args[:password],
       email: args[:email],
       role: args[:role] || "user",
-      provider: args[:provider] || "greenlight",
+      provider: args[:provider] || "greenlight"
     }
 
     if u[:role] == "admin"

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -10,7 +10,7 @@ namespace :user do
       password: args[:password],
       email: args[:email],
       role: args[:role] || "user",
-      provider: args[:provider] || "greenlight"
+      provider: args[:provider] || "greenlight",
     }
 
     if u[:role] == "admin"
@@ -28,7 +28,7 @@ namespace :user do
     # Create account if it doesn't exist
     if !User.exists?(email: u[:email], provider: u[:provider])
       user = User.create(name: u[:name], email: u[:email], password: u[:password],
-        provider: u[:provider], email_verified: true)
+        provider: u[:provider], email_verified: true, accepted_terms: true)
 
       unless user.valid?
         puts "Invalid Arguments"


### PR DESCRIPTION
This fixes #1564 

Similar to email_verified, accepted_terms: true was added to the rake task user:create.