### PR TITLE
fix for user stuck on waiting room after meeting starts

### DIFF
--- a/greenlight.nginx
+++ b/greenlight.nginx
@@ -15,7 +15,6 @@ location /b/cable {
   proxy_pass          http://127.0.0.1:5000;
   proxy_set_header    Host              $host;
   proxy_set_header    X-Forwarded-For   $proxy_add_x_forwarded_for;
-  proxy_set_header    X-Forwarded-Proto $scheme;
   proxy_set_header    Upgrade           $http_upgrade;
   proxy_set_header    Connection        "Upgrade";
   proxy_http_version  1.1;


### PR DESCRIPTION
This resolves issue #1259 where user is stuck in waiting room even after the moderator has started the meeting.