### PR TITLE
table-responsive overflow problem

### DIFF
--- a/app/views/admins/components/_rooms.html.erb
+++ b/app/views/admins/components/_rooms.html.erb
@@ -15,7 +15,7 @@
 
 <div class="row">
   <div class="col-12">
-    <div class="table-responsive">
+    <div class="table-responsive" style="overflow-x: scroll;">
       <table id="rooms-table" class="table table-hover table-outline table-vcenter text-nowrap card-table">
         <thead>
           <tr>


### PR DESCRIPTION
table-responsive, by default, hides the overflow which is not ideal in this situation where when room names or user names are lengthier, the manage button (three vertical dots) disappears from the page.