### PR TITLE
Enhance Room OpenGraph Metadata

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
 %>
 
 <!DOCTYPE html>
-<html>
+<html prefix="og: http://ogp.me/ns#">
   <head>
     <% if Rails.configuration.google_analytics %>
       <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -28,8 +28,9 @@
       </script>
     <% end %>
 
-    <title><%= t("bigbluebutton") %></title>
-    <meta property="og:title" content="<%= t("bigbluebutton", locale: :en) %>" />
+    <title><%= (yield(:page_title) + " - ") if content_for?(:page_title) + t("bigbluebutton") %></title>
+
+    <meta property="og:title" content="<%= (yield(:page_title) + " - ") if content_for?(:page_title) + t("bigbluebutton", locale: :en) %>" />
     <meta property="og:type" content="website" />
     <meta property="og:description" content="<%= t("landing.about", href: "Greenlight", locale: :en) %>" />
     <meta property="og:url" content="<%= request.base_url %>" />

--- a/app/views/rooms/components/_room_event.html.erb
+++ b/app/views/rooms/components/_room_event.html.erb
@@ -13,6 +13,8 @@
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 %>
 
+<% content_for :page_title do %><%= @room.name %><% end %>
+
 <div class="background pb-9" room="<%= @room.uid %>" user="<%= current_user ? current_user.uid : "anonymous" %>" join-name="<%= @join_name %>">
   <div class="container">
     <div class="row pt-9">

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -13,6 +13,8 @@
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 %>
 
+<% content_for :page_title do %><%= @room.name %><% end %>
+
 <% exceeds_limit = current_room_exceeds_limit(@room)%>
 <% if exceeds_limit%>
   <div class="alert alert-danger alert-dismissible text-center mb-0">


### PR DESCRIPTION
This seeks to improve the Rich Preview that most instant messaging services show when you post an url:
![photo_2020-05-15_14-11-11](https://user-images.githubusercontent.com/228095/82049032-f9a7eb80-96b5-11ea-8a3d-091dab093364.jpg)
For a first iteration, I chose to just add the room name to the title tags but I am open for feedback on this (both in terms of the actual title string but also the technical implementation part - not a RoR expert).

I would also like to change the description string into something more appropriate for the average end user that will see this (who supposedly doesn't really care about "Greenlight [being] a simple front-end for your BigBlueButton open-source web conferencing server [...]").

Does anyone have thoughts or feedback for this?