### PR TITLE
2.6alpha see only shared rooms further limit

### DIFF
--- a/app/views/rooms/components/_shared_room_block.html.erb
+++ b/app/views/rooms/components/_shared_room_block.html.erb
@@ -30,6 +30,7 @@
             <%= t("room.shared_by", email: room.owner.name) %>
           </div>
         </td>
+        <% if current_user.role.get_permission("can_create_rooms") %>
         <td class="text-right">
           <div class="item-action dropdown" data-display="static">
             <a href="javascript:void(0)" data-toggle="dropdown" data-display="static" class="icon">
@@ -42,6 +43,7 @@
             </div>
           </div>
         </td>
+        <% end %>
       </tbody>
     </table>
   </div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -23,10 +23,10 @@
   <div class="container">
     <div class="row pt-7 pt-sm-9">
       <div class="col-lg-8 col-sm-12">
-        <div id="room-title" class="display-3 form-inline <%= 'edit_hover_class' if current_user.main_room != @room %>" data-path="<%= update_settings_path(@room) %>">
-          <% if current_user.main_room == @room %>
+        <div id="room-title" class="display-3 form-inline <%= 'edit_hover_class' if current_user.shared_rooms != @room %>" data-path="<%= update_settings_path(@room) %>">
+          <% if current_user.shared_rooms == @room %>
             <h1 contenteditable=false id="user-text" class="display-3 text-left mb-3 font-weight-400"><%= @room.name %></h1>
-            <a class="disable-click"><i class="fas fa-home align-top home-indicator ml-2"></i></a>
+            <a class="disable-click"><i class="fas fa-share-alt align-top home-indicator ml-2"></i></a>
           <% else %>
             <h1 contenteditable=false id="user-text" class="display-3 text-left mb-3 font-weight-400"><%= @room.name %></h1>
             <a><i id="edit-room" class="fa fa-edit align-top home-indicator ml-2" data-edit-room="<%= @room.uid %>"></i></a>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -23,8 +23,8 @@
   <div class="container">
     <div class="row pt-7 pt-sm-9">
       <div class="col-lg-8 col-sm-12">
-        <div id="room-title" class="display-3 form-inline <%= 'edit_hover_class' if current_user.main_room != @room %>" data-path="<%= update_settings_path(@room) %>">
-          <% if current_user.main_room == @room %>
+        <div id="room-title" class="display-3 form-inline <%= 'edit_hover_class' if current_user.shared_room != @room %>" data-path="<%= update_settings_path(@room) %>">
+          <% if current_user.shared_room == @room %>
             <h1 contenteditable=false id="user-text" class="display-3 text-left mb-3 font-weight-400"><%= @room.name %></h1>
             <a class="disable-click"><i class="fas fa-home align-top home-indicator ml-2"></i></a>
           <% else %>
@@ -34,6 +34,7 @@
         </div>
         <h4 class="text-left mb-6"><%= @room.sessions %> <%= t("room.sessions") %> | <%= @recordings.length %> <%= t("room.recordings") %></h4>
         <% unless exceeds_limit %>
+        <% if current_user.role.get_permission("can_create_rooms") %>
           <label class="form-label"><%= t("room.invite_participants") %></label>
           <div class="row">
             <div class="col-lg-7 col-md-12 mt-2">
@@ -63,6 +64,7 @@
               </div>
             </div>
           </div>
+        <% end %>
         <% end %>
       </div>
       <div class="offset-lg-1 col-lg-3 col-sm-12 force-bottom mt-5">

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -24,10 +24,10 @@
     <div class="row pt-7 pt-sm-9">
       <div class="col-lg-8 col-sm-12">
         <div id="room-title" class="display-3 form-inline <%= 'edit_hover_class' if current_user.main_room != @room %>" data-path="<%= update_settings_path(@room) %>">
-          <% if current_user.main_room == @room || !(defined?(shared_room) && shared_room)%>
+          <% if current_user.main_room == @room %>
             <h1 contenteditable=false id="user-text" class="display-3 text-left mb-3 font-weight-400"><%= @room.name %></h1>
             <a class="disable-click"><i class="fas fa-home align-top home-indicator ml-2"></i></a>
-          <% else %>
+          <% elseif !(defined?(shared_room) && shared_room) %>
             <h1 contenteditable=false id="user-text" class="display-3 text-left mb-3 font-weight-400"><%= @room.name %></h1>
             <a><i id="edit-room" class="fa fa-edit align-top home-indicator ml-2" data-edit-room="<%= @room.uid %>"></i></a>
           <% end %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -32,10 +32,10 @@
             <a><i id="edit-room" class="fa fa-edit align-top home-indicator ml-2" data-edit-room="<%= @room.uid %>"></i></a>
           <% end %>
         </div>
-        <h4 class="text-left mb-6"><%= @room.sessions %> <%= t("room.sessions") %> | <%= @recordings.length %> <%= t("room.recordings") %></h4>
+        <h4 class="text-left mb-0"><%= @room.sessions %> <%= t("room.sessions") %> | <%= @recordings.length %> <%= t("room.recordings") %></h4>
         <% unless exceeds_limit %>
         <% if current_user.role.get_permission("can_create_rooms") %>
-          <label class="form-label"><%= t("room.invite_participants") %></label>
+          <label class="form-label mt-6"><%= t("room.invite_participants") %></label>
           <div class="row">
             <div class="col-lg-7 col-md-12 mt-2">
               <div class="input-icon invite-link-input">

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -23,8 +23,8 @@
   <div class="container">
     <div class="row pt-7 pt-sm-9">
       <div class="col-lg-8 col-sm-12">
-        <div id="room-title" class="display-3 form-inline <%= 'edit_hover_class' if current_user.shared_rooms != @room %>" data-path="<%= update_settings_path(@room) %>">
-          <% if current_user.shared_rooms == @room %>
+        <div id="room-title" class="display-3 form-inline <%= 'edit_hover_class' if current_user.main_room != @room %>" data-path="<%= update_settings_path(@room) %>">
+          <% if current_user.main_room == @room %>
             <h1 contenteditable=false id="user-text" class="display-3 text-left mb-3 font-weight-400"><%= @room.name %></h1>
             <a class="disable-click"><i class="fas fa-share-alt align-top home-indicator ml-2"></i></a>
           <% else %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -23,8 +23,8 @@
   <div class="container">
     <div class="row pt-7 pt-sm-9">
       <div class="col-lg-8 col-sm-12">
-        <div id="room-title" class="display-3 form-inline <%= 'edit_hover_class' if current_user.shared_room != @room %>" data-path="<%= update_settings_path(@room) %>">
-          <% if current_user.shared_room == @room %>
+        <div id="room-title" class="display-3 form-inline <%= 'edit_hover_class' if current_user.main_room != @room %>" data-path="<%= update_settings_path(@room) %>">
+          <% if current_user.main_room == @room %>
             <h1 contenteditable=false id="user-text" class="display-3 text-left mb-3 font-weight-400"><%= @room.name %></h1>
             <a class="disable-click"><i class="fas fa-home align-top home-indicator ml-2"></i></a>
           <% else %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -26,7 +26,7 @@
         <div id="room-title" class="display-3 form-inline <%= 'edit_hover_class' if current_user.main_room != @room %>" data-path="<%= update_settings_path(@room) %>">
           <% if current_user.main_room == @room %>
             <h1 contenteditable=false id="user-text" class="display-3 text-left mb-3 font-weight-400"><%= @room.name %></h1>
-            <a class="disable-click"><i class="fas fa-share-alt align-top home-indicator ml-2"></i></a>
+            <a class="disable-click"><i class="fas fa-home align-top home-indicator ml-2"></i></a>
           <% else %>
             <h1 contenteditable=false id="user-text" class="display-3 text-left mb-3 font-weight-400"><%= @room.name %></h1>
             <a><i id="edit-room" class="fa fa-edit align-top home-indicator ml-2" data-edit-room="<%= @room.uid %>"></i></a>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -24,7 +24,7 @@
     <div class="row pt-7 pt-sm-9">
       <div class="col-lg-8 col-sm-12">
         <div id="room-title" class="display-3 form-inline <%= 'edit_hover_class' if current_user.main_room != @room %>" data-path="<%= update_settings_path(@room) %>">
-          <% if current_user.main_room == @room %>
+          <% if current_user.main_room == @room || !(defined?(shared_room) && shared_room)%>
             <h1 contenteditable=false id="user-text" class="display-3 text-left mb-3 font-weight-400"><%= @room.name %></h1>
             <a class="disable-click"><i class="fas fa-home align-top home-indicator ml-2"></i></a>
           <% else %>

--- a/sample.env
+++ b/sample.env
@@ -5,7 +5,7 @@
 #
 #   docker run --rm bigbluebutton/greenlight:v2 bundle exec rake secret
 #
-SECRET_KEY_BASE=
+SECRET_KEY_BASE=xD
 
 # The endpoint and secret for your BigBlueButton server.
 # Set these if you are running GreenLight on a single BigBlueButton server.

--- a/sample.env
+++ b/sample.env
@@ -5,7 +5,7 @@
 #
 #   docker run --rm bigbluebutton/greenlight:v2 bundle exec rake secret
 #
-SECRET_KEY_BASE=xD
+SECRET_KEY_BASE=
 
 # The endpoint and secret for your BigBlueButton server.
 # Set these if you are running GreenLight on a single BigBlueButton server.


### PR DESCRIPTION
based on #1649 
<img width="449" alt="image" src="https://user-images.githubusercontent.com/8763656/82617227-b70f7300-9bcf-11ea-8d49-5a6be9d319c1.png">
-removed copy link
-removed "remove room" from list

or am I wrong in assuming that it makes little sense for students to share and delete them? 

i have also tried to remove the change icon for room names in the title. This should be instead of the defaultroom icon