### PR TITLE
Puma Worker Configuration

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,14 +23,14 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 1 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart

--- a/sample.env
+++ b/sample.env
@@ -268,7 +268,7 @@ CABLE_ADAPTER=postgresql
 DEFAULT_REGISTRATION=open
 
 # Preupload Presentation Storage
-# 
+#
 # By default, if Preupload Presentation is enabled for rooms, presentations are uploaded locally to ~/greenlight/storage
 # If you prefer to use AWS S3 or GCS Storage, you can set the variables below
 #
@@ -287,3 +287,15 @@ DEFAULT_REGISTRATION=open
 # GCS_CLIENT_CERT=
 # GCS_PROJECT=
 # GCS_BUCKET=
+
+# Web server settings
+#
+# The size of the thread pool per worker used by Greenlight's web server.
+# For details, see: https://github.com/puma/puma#thread-pool
+# Default: 5
+#RAILS_MAX_THREADS=5
+
+# The amount of workers (separate processes) used by the web server.
+# For details, see: https://github.com/puma/puma#clustered-mode
+# Default: 1
+#WEB_CONCURRENCY=1


### PR DESCRIPTION
We noticed that the current default settings perform very poorly under
load. We managed to literally take down Greenlight during a larger event
when people were accessing the landing page for rooms and when doing
some tests, I was more or less able to DoS Greenlight on my own.

This patch adds a default worker configuration which significantly
improves the situation. The small, 4 core machine I was testing on could
handle about thrice the number of requests.

While the new default configuration should be reasonably well suited for
most deployments, this patch further allows users to easily configure
the worker pool on their own in the environment file.

---

This pull request is identical to #1332 which got reverted for lack of testing but should still hopefully go into Greenlight at some point.