### PR TITLE
Allow the rails log level to be set in .env for production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -132,7 +132,7 @@ Rails.application.configure do
     "#{severity}: #{msg} \n"
   end
 
-  config.log_level = :info
+  config.log_level = ENV["RAILS_LOG_LEVEL"].present? ? ENV["RAILS_LOG_LEVEL"].to_sym : :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/sample.env
+++ b/sample.env
@@ -190,6 +190,12 @@ MAINTENANCE_WINDOW=
 # Button can be disabled by setting the value to blank
 HELP_URL=https://docs.bigbluebutton.org/greenlight/gl-overview.html
 
+# Set the rails log level in production
+# The available log levels are: debug, info, warn, error, fatal, and unknown
+# Defaults to info
+#
+# RAILS_LOG_LEVEL=warn
+#
 # Comment this out to send logs to STDOUT in production instead of log/production.log .
 #
 # RAILS_LOG_TO_STDOUT=true


### PR DESCRIPTION
**Problem**

Greenlight sets the rails log level to "info" for production. The log level needs to be lower for privacy reasons or set to debug for debugging.

**Solution**

This PR adds a RAILS_LOG_LEVEL to .env that can be set to the desired log level, it is only used in production and defaults to "info" as before.