### PR TITLE
Clickable and selectable thumbnails 

### DIFF
--- a/app/controllers/recordings_controller.rb
+++ b/app/controllers/recordings_controller.rb
@@ -24,9 +24,12 @@ class RecordingsController < ApplicationController
 
   # POST /:meetingID/:record_id
   def update
-    meta = {
-      "meta_#{META_LISTED}" => (params[:state] == "public"),
-    }
+    meta = {}
+    if params[:state]
+      meta["meta_#{META_LISTED}"] = (params[:state] == "public")
+    elsif params[:thumbnails]
+      meta["meta_imagesel"] = params[:thumbnails]
+    end
 
     res = update_recording(params[:record_id], meta)
 

--- a/app/views/shared/components/_public_recording_row.html.erb
+++ b/app/views/shared/components/_public_recording_row.html.erb
@@ -16,13 +16,14 @@
 <tr>
   <td>
     <div id="recording-title" class="edit_hover_class" data-recordid="<%= recording[:recordID] %>" data-room-uid="<%= room_uid_from_bbb(recording[:meetingID]) %>" data-path="<%= rename_recording_path(meetingID: recording[:meetingID], record_id: recording[:recordID]) %>">
-      <span id="recording-text" title="<%= recording[:name] %>">
-        <% if recording[:metadata][:name] %>
+      <% if recording[:metadata][:name] %>
+        <span id="recording-text" title="<%= recording[:metadata][:name] %>">
           <%= recording[:metadata][:name] %>
-        <% else %>
+      <% else %>
+        <span id="recording-text" title="<%= recording[:name] %>">
           <%= recording[:name] %>
-        <% end %>
-      </span>
+      <% end %>
+        </span>
     </div>
     <div class="small text-muted">
       <%= t("recording.recorded_on", date: recording_date(recording[:startTime])) %>

--- a/app/views/shared/components/_public_recording_row.html.erb
+++ b/app/views/shared/components/_public_recording_row.html.erb
@@ -30,11 +30,20 @@
   </td>
   <% if recording_thumbnails? %>
     <td class="overflow-hidden">
+      <% if id_p = recording[:playbacks].find_index{|p| p[:type]=="presentation"} %>
+        <a href="<%= recording[:playbacks][id_p][:url] %>" target="_blank">
+      <% end %>
       <% p = recording[:playbacks].find do |p| p.key?(:preview) end %>
       <% if p %>
-        <% safe_recording_images(p[:preview][:images][:image]).each do |img| %>
-          <%= image_tag(img[:content].strip, class: "thumbnail px-2") %>
+        <% imagesel = if recording[:metadata][:imagesel]; recording[:metadata][:imagesel].split("-").collect{|x| x.to_i} else [0,1,2] end %>
+        <% if p[:preview][:images][:image] %>
+          <% imagesel.collect{|i| safe_recording_images(p[:preview][:images][:image])[i]}.each do |img| %>
+            <%= image_tag(img[:content].strip, class: "thumbnail px-2") %>
+          <% end %>
         <% end %>
+      <% end %>
+      <% if id_p %>
+        </a>
       <% end %>
     </td>
   <% end %>

--- a/app/views/shared/components/_recording_row.html.erb
+++ b/app/views/shared/components/_recording_row.html.erb
@@ -32,9 +32,27 @@
   <% if recording_thumbnails? %>
     <td class="overflow-hidden">
       <% p = recording[:playbacks].find do |p| p.key?(:preview) end %>
-      <% if p %>
-        <% safe_recording_images(p[:preview][:images][:image]).each do |img| %>
-          <%= image_tag(img[:content].strip, class: "thumbnail px-2") %>
+      <% if p %> 
+        <% imagesel = if recording[:metadata][:imagesel]; recording[:metadata][:imagesel].split(/-/).collect{|x| x.to_i} else [0,1,2] end %>
+        <% if p[:preview][:images][:image] %>
+          <% imagesel.collect{|i| safe_recording_images(p[:preview][:images][:image])[i]}.each_with_index do |img, imgidxdsp| %>
+            <div class="dropdown" style="position:unset;">
+              <button class="btn btn-sm btn-secondary dropdown-toggle" data-toggle="dropdown"><%= image_tag(img[:content].strip, class: "thumbnail") %></button>
+              <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+              <% safe_recording_images(p[:preview][:images][:image]).each_with_index do |img,imgidx| %>
+                <% imgselary = imagesel.dup %>
+                <% imgselary[imgidxdsp] = imgidx %>
+                <% activecls = if imagesel[imgidxdsp] == imgidx ; "dropdown-item active" else "dropdown-item" end %>
+                <%= button_to update_recording_path(meetingID: recording[:meetingID], record_id: recording[:recordID], thumbnails: "#{imgselary.join("-")}"), class: "#{activecls}", "data-disable": "" do %>
+                <%= image_tag(img[:content].strip, class: "thumbnail") %>
+                <span class="small text-muted">
+                <%= img[:alt].strip[0..20] %>
+                </span>
+                <% end %>
+              <% end %>
+              </div>
+            </div>
+          <% end %>
         <% end %>
       <% end %>
     </td>


### PR DESCRIPTION
![thumb](https://user-images.githubusercontent.com/45039819/84587565-33a61200-ae5b-11ea-9310-8754239b7360.jpg)
Related to #1752 and #1767 , I implemented clickable thumbnails for public viewers and selectable thumbnail dropdown for a room owner. In accordance with this, I closed the PR #1752 . 
I needed to create a new meta parameter "imagesel" to remember the room owner's choice. If Greenlight does not find this parameter, it automatically select the first 3 thumbnails as currently implemented. 
So far, the owner can select a thumbnail out of three candidates, for each of three thumbnail windows (i.e. you can only change the order). This is a restriction of BBB which registers only three slides for thumbnails. This needs to be expanded in BBB. Moreover, a seemingly bug prevents BBB to create thumbnails from the presentation file uploaded by the user. See -> https://github.com/bigbluebutton/bigbluebutton/pull/9570

I will send a PR in BBB to fix the problems separately. 

