### PR TITLE
GRN2-xx: Small changes/improvements to the recording settings

### DIFF
--- a/app/assets/javascripts/room.js
+++ b/app/assets/javascripts/room.js
@@ -202,7 +202,7 @@ function updateCurrentSettings(settings_path){
     $("#room_require_moderator_approval").prop("checked", $("#room_require_moderator_approval").data("default") || settings.requireModeratorApproval)
     $("#room_anyone_can_start").prop("checked", $("#room_anyone_can_start").data("default") || settings.anyoneCanStart)
     $("#room_all_join_moderator").prop("checked", $("#room_all_join_moderator").data("default") || settings.joinModerator)
-    $("#room_recording").prop("checked", $("#room_recording").data("default") || settings.recording)
+    $("#room_recording").prop("checked", $("#room_recording").data("default") || Boolean(settings.recording))
   })
 }
 

--- a/app/assets/javascripts/room.js
+++ b/app/assets/javascripts/room.js
@@ -155,9 +155,6 @@ function showCreateRoom(target) {
     $(this).attr('style',"display:none !important")
     if($(this).children().length > 0) { $(this).children().attr('style',"display:none !important") }
   })
-
-  runningSessionWarningVisibilty(false)
-
 }
 
 function showUpdateRoom(target) {
@@ -190,9 +187,6 @@ function showUpdateRoom(target) {
     $("#create-room-access-code").text(getLocalizedString("modal.create_room.access_code_placeholder"))
     $("#room_access_code").val(null)
   }
-
-  runningSessionWarningVisibilty(false)
-
 }
 
 function showDeleteRoom(target) {
@@ -209,9 +203,6 @@ function updateCurrentSettings(settings_path){
     $("#room_anyone_can_start").prop("checked", $("#room_anyone_can_start").data("default") || settings.anyoneCanStart)
     $("#room_all_join_moderator").prop("checked", $("#room_all_join_moderator").data("default") || settings.joinModerator)
     $("#room_recording").prop("checked", $("#room_recording").data("default") || settings.recording)
-
-    runningSessionWarningVisibilty(settings.running)
-
   })
 }
 
@@ -272,15 +263,4 @@ function removeSharedUser(target) {
     parentLI.removeChild(target)
     parentLI.classList.add("remove-shared")
   }
-}
-
-// Show a "Session Running warning" for each room setting, which cannot be changed during a running session
-function runningSessionWarningVisibilty(isRunning) {
-    if(isRunning) {
-        $(".running-only").show()
-        $(".not-running-only").hide()
-    } else {
-        $(".running-only").hide()
-        $(".not-running-only").show()
-    }
 }

--- a/app/assets/stylesheets/rooms.scss
+++ b/app/assets/stylesheets/rooms.scss
@@ -118,3 +118,7 @@
   word-break: break-all;
   white-space: normal;
 }
+
+#room-owner-name {
+  line-height: 12px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -182,6 +182,12 @@ class ApplicationController < ActionController::Base
   end
   helper_method :shared_access_allowed
 
+  # Indicates whether users are allowed to share rooms
+  def recording_consent_required?
+    @settings.get_value("Require Recording Consent") == "true"
+  end
+  helper_method :recording_consent_required?
+
   # Returns the page that the logo redirects to when clicked on
   def home_page
     return admins_path if current_user.has_role? :super_admin

--- a/app/controllers/concerns/bbb_server.rb
+++ b/app/controllers/concerns/bbb_server.rb
@@ -61,7 +61,7 @@ module BbbServer
   # Creates a meeting on the BigBlueButton server.
   def start_session(room, options = {})
     create_options = {
-      record: options[:meeting_recorded].to_s,
+      record: options[:record].to_s,
       logoutURL: options[:meeting_logout_url] || '',
       moderatorPW: room.moderator_pw,
       attendeePW: room.attendee_pw,

--- a/app/controllers/concerns/joiner.rb
+++ b/app/controllers/concerns/joiner.rb
@@ -87,7 +87,7 @@ module Joiner
     {
       user_is_moderator: false,
       meeting_logout_url: request.base_url + logout_room_path(@room),
-      meeting_recorded: @room.recording?,
+      meeting_recorded: true,
       moderator_message: "#{invite_msg}\n\n#{request.base_url + room_path(@room)}",
       host: request.host,
       recording_default_visibility: @settings.get_value("Default Recording Visibility") == "public"

--- a/app/controllers/concerns/joiner.rb
+++ b/app/controllers/concerns/joiner.rb
@@ -30,8 +30,6 @@ module Joiner
       ""
     end
 
-    flash.now[:info] = t("room.recording_present") if room_setting_with_config("recording")
-
     @search, @order_column, @order_direction, pub_recs =
       public_recordings(@room.bbb_id, params.permit(:search, :column, :direction), true)
 

--- a/app/controllers/concerns/joiner.rb
+++ b/app/controllers/concerns/joiner.rb
@@ -30,6 +30,8 @@ module Joiner
       ""
     end
 
+    flash.now[:info] = t("room.recording_present") if room_setting_with_config("recording")
+
     @search, @order_column, @order_direction, pub_recs =
       public_recordings(@room.bbb_id, params.permit(:search, :column, :direction), true)
 

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -261,10 +261,8 @@ class RoomsController < ApplicationController
   # GET /:room_uid/room_settings
   def room_settings
     # Respond with JSON object of the room_settings
-    status = { running: room_running?(@room.bbb_id) }
-    settings = @room.settings_hash
     respond_to do |format|
-      format.json { render body: status.merge(settings).to_json }
+      format.json { render body: @room.room_settings.to_json }
     end
   end
 

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -171,7 +171,8 @@ class RoomsController < ApplicationController
     @room_settings = JSON.parse(@room[:room_settings])
     opts[:mute_on_start] = room_setting_with_config("muteOnStart")
     opts[:require_moderator_approval] = room_setting_with_config("requireModeratorApproval")
-    opts[:record] = room_setting_with_config("recording")
+    opts[:record] = record_meeting
+
     begin
       redirect_to join_path(@room, current_user.name, opts, current_user.uid)
     rescue BigBlueButton::BigBlueButtonException => e
@@ -262,7 +263,7 @@ class RoomsController < ApplicationController
   def room_settings
     # Respond with JSON object of the room_settings
     respond_to do |format|
-      format.json { render body: @room.room_settings.to_json }
+      format.json { render body: @room.room_settings }
     end
   end
 
@@ -366,4 +367,13 @@ class RoomsController < ApplicationController
     current_user.rooms.length >= limit
   end
   helper_method :room_limit_exceeded
+
+  def record_meeting
+    # If the require consent setting is checked, then check the room setting, else, set to true
+    if recording_consent_required?
+      room_setting_with_config("recording")
+    else
+      true
+    end
+  end
 end

--- a/app/helpers/admins_helper.rb
+++ b/app/helpers/admins_helper.rb
@@ -80,6 +80,14 @@ module AdminsHelper
       end
   end
 
+  def require_consent_string
+    if @settings.get_value("Require Recording Consent") == "true"
+      I18n.t("administrator.site_settings.authentication.enabled")
+    else
+      I18n.t("administrator.site_settings.authentication.disabled")
+    end
+  end
+
   def log_level_string
     case Rails.logger.level
     when 0

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -98,7 +98,7 @@ class Room < ApplicationRecord
   end
 
   def recording_enabled?
-    room_settings["recording"]
+    JSON.parse(room_settings)["recording"]
   end
 
   private

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -97,12 +97,8 @@ class Room < ApplicationRecord
     active_rooms + inactive_rooms
   end
 
-  def settings_hash
-    JSON.parse(room_settings || "{}")
-  end
-
-  def recording?
-    settings_hash["recording"]
+  def recording_enabled?
+    room_settings["recording"]
   end
 
   private

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -58,6 +58,8 @@ class Setting < ApplicationRecord
       Rails.configuration.registration_method_default
     when "Room Authentication"
       false
+    when "Require Recording Consent"
+      Rails.configuration.require_consent_default
     when "Room Limit"
       Rails.configuration.number_of_rooms_default
     when "Shared Access"

--- a/app/views/admins/components/_room_settings.html.erb
+++ b/app/views/admins/components/_room_settings.html.erb
@@ -102,7 +102,7 @@
   <div class="mb-6 row">
     <div class="col-12">
      <div class="form-group">
-        <label class="form-label"><%= t("modal.room_settings.recordings") %></label>
+        <label class="form-label"><%= t("modal.room_settings.recording") %></label>
         <label class="form-label text-muted"><%= t("administrator.room_configuration.recordings.info") %></label>
         <div class="dropdown">
           <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/app/views/admins/components/_room_settings.html.erb
+++ b/app/views/admins/components/_room_settings.html.erb
@@ -98,31 +98,31 @@
       </div>
     </div>
   </div>
-
-  <div class="mb-6 row">
-    <div class="col-12">
-     <div class="form-group">
-        <label class="form-label"><%= t("modal.room_settings.recording") %></label>
-        <label class="form-label text-muted"><%= t("administrator.room_configuration.recordings.info") %></label>
-        <div class="dropdown">
-          <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <%= room_configuration_string("Room Configuration Recording") %>
-          </button>
-          <div class="dropdown-menu">
-            <%= button_to admin_update_room_configuration_path(setting: "Room Configuration Recording", value: "enabled"), class: "dropdown-item", "data-disable": "" do %>
-              <%= t("administrator.room_configuration.options.enabled") %>
-            <% end %>
-            <%= button_to admin_update_room_configuration_path(setting: "Room Configuration Recording", value: "optional"), class: "dropdown-item", "data-disable": "" do %>
-              <%= t("administrator.room_configuration.options.optional") %>
-            <% end %>
-            <%= button_to admin_update_room_configuration_path(setting: "Room Configuration Recording", value: "disabled"), class: "dropdown-item", "data-disable": "" do %>
-              <%= t("administrator.room_configuration.options.disabled") %>
-            <% end %>
+  <% if recording_consent_required? %>
+    <div class="mb-6 row">
+      <div class="col-12">
+      <div class="form-group">
+          <label class="form-label"><%= t("modal.room_settings.recording") %></label>
+          <label class="form-label text-muted"><%= t("administrator.room_configuration.recordings.info") %></label>
+          <div class="dropdown">
+            <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <%= room_configuration_string("Room Configuration Recording") %>
+            </button>
+            <div class="dropdown-menu">
+              <%= button_to admin_update_room_configuration_path(setting: "Room Configuration Recording", value: "enabled"), class: "dropdown-item", "data-disable": "" do %>
+                <%= t("administrator.room_configuration.options.enabled") %>
+              <% end %>
+              <%= button_to admin_update_room_configuration_path(setting: "Room Configuration Recording", value: "optional"), class: "dropdown-item", "data-disable": "" do %>
+                <%= t("administrator.room_configuration.options.optional") %>
+              <% end %>
+              <%= button_to admin_update_room_configuration_path(setting: "Room Configuration Recording", value: "disabled"), class: "dropdown-item", "data-disable": "" do %>
+                <%= t("administrator.room_configuration.options.disabled") %>
+              <% end %>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-
+  <% end %>
 
 </div>

--- a/app/views/admins/components/site_settings/_settings.html.erb
+++ b/app/views/admins/components/site_settings/_settings.html.erb
@@ -101,6 +101,27 @@
       </div>
     </div>
   </div>
+  <div class="row mb-2">
+    <div class="col-12">
+      <div class="form-group">
+        <label class="form-label"><%= t("administrator.site_settings.require_consent.title") %></label>
+        <label class="form-label text-muted"><%= t("administrator.site_settings.require_consent.info") %></label>
+        <div class="dropdown">
+          <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= require_consent_string %>
+          </button>
+          <div class="dropdown-menu" aria-labelledby="room-auth">
+            <%= button_to admin_update_settings_path(setting: "Require Recording Consent", value: "true"), class: "dropdown-item", "data-disable": "" do %>
+              <%= t("administrator.site_settings.authentication.enabled") %>
+            <% end %>
+            <%= button_to admin_update_settings_path(setting: "Require Recording Consent", value: "false"), class: "dropdown-item", "data-disable": "" do %>
+              <%= t("administrator.site_settings.authentication.disabled") %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
   <div class="row">
     <div class="col-12">
       <div class="form-group">

--- a/app/views/rooms/components/_room_event.html.erb
+++ b/app/views/rooms/components/_room_event.html.erb
@@ -18,7 +18,6 @@
     <div class="row pt-9">
       <div class="col-lg-12 col-sm-12">
         <h4 class="text-left"><%= t("room.invited") %></h4>
-        <h4 class="text-left text-danger"><%= t("room.recording_present") if @room.recording?%></h4>
         <h1 class="display-3 text-left mb-3 font-weight-400"><%= title(@room.name) %></h1>
         <hr class="mt-2 float-left w-25">
       </div>

--- a/app/views/rooms/components/_room_event.html.erb
+++ b/app/views/rooms/components/_room_event.html.erb
@@ -24,13 +24,13 @@
     </div>
 
     <div class="row">
-      <div class="col-lg-6 col-md-6 col-sm-12 form-inline mb-5 align-top">
+      <div class="col-lg-6 col-md-6 col-sm-12 mb-5">
         <% if @room.owner.image.blank? %>
           <span class="avatar"><%= @room.owner.name.first %></span>
         <% else %>
           <span class="avatar" style="background-image: url(<%= @room.owner.image %>)"></span>
         <% end %>
-        <h5 class="font-weight-normal ml-4 mt-3"><%= @room.owner.name %> (<%= t("room.owner") %>)</h5>
+        <h5 id="room-owner-name" class="font-weight-normal ml-4 mt-3 d-inline-block"><%= @room.owner.name %> (<%= t("room.owner") %>)</h5>
       </div>
 
       <div class="col-lg-6 col-md-6 col-sm-12">

--- a/app/views/rooms/join.html.erb
+++ b/app/views/rooms/join.html.erb
@@ -49,6 +49,12 @@
           </button>
         </span>
       </div>
+      <% if recording_consent_required? && @room.recording_enabled? %>
+        <label class="custom-control custom-checkbox">
+          <input id="delete-checkbox" type="checkbox" class="custom-control-input" required>
+          <h4 class="text-left text-danger mt-4 custom-control-label"><%= t("room.recording_present") %></h4>
+        </label>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/modals/_create_room_modal.html.erb
+++ b/app/views/shared/modals/_create_room_modal.html.erb
@@ -82,7 +82,6 @@
               <label class="custom-switch pl-0 mt-3 mb-3 w-100 text-left d-inline-block <%= "enabled-setting" if recording == "enabled" %>">
                 <span class="custom-switch-description"><%= t("modal.room_settings.recording")%></span>
                 <%= f.check_box :recording, class: "not-running-only custom-switch-input", data: { default: recording == "enabled" }, checked: false %>
-                <span class="float-right cursor-pointer running-only text-danger" style="display: none"><%= t("modal.room_settings.session_active")%></span>
                 <span class="custom-switch-indicator not-running-only float-right cursor-pointer"></span>
             </label>
             <% end %>

--- a/app/views/shared/modals/_create_room_modal.html.erb
+++ b/app/views/shared/modals/_create_room_modal.html.erb
@@ -78,7 +78,7 @@
               </label>
             <% end %>
             <% recording = room_configuration("Room Configuration Recording") %>
-            <% if recording != "disabled" %>
+            <% if recording_consent_required? && recording != "disabled" %>
               <label class="custom-switch pl-0 mt-3 mb-3 w-100 text-left d-inline-block <%= "enabled-setting" if recording == "enabled" %>">
                 <span class="custom-switch-description"><%= t("modal.room_settings.recording")%></span>
                 <%= f.check_box :recording, class: "not-running-only custom-switch-input", data: { default: recording == "enabled" }, checked: false %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,16 +52,16 @@ module Greenlight
 
     # Use standalone BigBlueButton server.
     config.bigbluebutton_endpoint = if ENV["BIGBLUEBUTTON_ENDPOINT"].present?
-                                      ENV["BIGBLUEBUTTON_ENDPOINT"]
-                                    else
-                                      config.bigbluebutton_endpoint_default
-                                    end
+      ENV["BIGBLUEBUTTON_ENDPOINT"]
+    else
+      config.bigbluebutton_endpoint_default
+    end
 
     config.bigbluebutton_secret = if ENV["BIGBLUEBUTTON_SECRET"].present?
-                                    ENV["BIGBLUEBUTTON_SECRET"]
-                                  else
-                                    config.bigbluebutton_secret_default
-                                  end
+      ENV["BIGBLUEBUTTON_SECRET"]
+    else
+      config.bigbluebutton_secret_default
+    end
 
     # Fix endpoint format if required.
     config.bigbluebutton_endpoint += "/" unless config.bigbluebutton_endpoint.ends_with?('/')
@@ -144,12 +144,12 @@ module Greenlight
 
     # Default registration method if the user does not specify one
     config.registration_method_default = if ENV["DEFAULT_REGISTRATION"] == "invite"
-                                           config.registration_methods[:invite]
-                                         elsif ENV["DEFAULT_REGISTRATION"] == "approval"
-                                           config.registration_methods[:approval]
-                                         else
-                                           config.registration_methods[:open]
-                                         end
+      config.registration_methods[:invite]
+    elsif ENV["DEFAULT_REGISTRATION"] == "approval"
+      config.registration_methods[:approval]
+    else
+      config.registration_methods[:open]
+    end
 
     # Default limit on number of rooms users can create
     config.number_of_rooms_default = 15

--- a/config/application.rb
+++ b/config/application.rb
@@ -157,6 +157,9 @@ module Greenlight
     # Allow users to share rooms by default
     config.shared_access_default = "true"
 
+    # Don't require recording consent by default
+    config.require_consent_default = "false"
+
     # Default admin password
     config.admin_password_default = ENV['ADMIN_PASSWORD'] || 'administrator'
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,7 +161,7 @@ en:
       all_moderator:
         info: Gives all users moderator privileges in BigBlueButton when they join the meeting.
       recordings:
-        info: Records a recording of the room and enables moderators to set recording markers
+        info: Allows room owners to specify whether they want the option to record a room or not. If enabled, the moderator must still click the "Record" button once the meeting has started.
       options:
         disabled: Disabled
         enabled: Always Enabled
@@ -415,13 +415,11 @@ en:
       update: Update Room
       client: Select client type
       join_moderator: All users join as moderators
-      recordings: Enable room recordings
       mute: Mute users when they join
       require_approval: Require moderator approval before joining
       start: Allow any user to start this meeting
       footer_text: Adjustment to your room can be done at anytime.
-      recording: Record sessions
-      session_active: Active session
+      recording: Allow room to be recorded
     rename_room:
       name_placeholder: Enter a new room name...
     share_access:
@@ -526,7 +524,7 @@ en:
     enter_the_access_code: Enter the room's access code
     invalid_provider: You have entered an invalid url. Please check the url and try again.
     invited: You have been invited to join
-    recording_present: The session is going to be recorded. This includes voice and video from your side.
+    recording_present: The session is going to be recorded. This may include voice and video from your side.
     invite_participants: Invite Participants
     join: Join
     last_session: Last session on %{session}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,9 @@ en:
         info: Set the default recording visbility for new recordings
         title: Recording Default Visibility
         warning: This setting will only be applied to rooms that aren't running
+      require_consent:
+        info: This setting enables a room setting that allows room owners to specify which rooms can be recorded. Users joining a recorded room must consent before joining.
+        title: Require Room Owner and Joiner Consent to Recording
       maintenance_banner:
         info: Displays a Banner to inform the user of a scheduled maintenance
         title: Maintenance Banner

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -202,12 +202,12 @@ describe RoomsController, type: :controller do
       @owner.main_room.update_attribute(:room_settings, { "muteOnStart": true, "requireModeratorApproval": true,
       "anyoneCanStart": true, "joinModerator": true }.to_json)
 
-      json_room_settings = "{\"running\":false,\"muteOnStart\":true,\"requireModeratorApproval\":true," \
+      json_room_settings = "{\"muteOnStart\":true,\"requireModeratorApproval\":true," \
         "\"anyoneCanStart\":true,\"joinModerator\":true}"
 
       get :room_settings, params: { room_uid: @owner.main_room }, format: :json
 
-      expect(JSON.parse(response.body).to_json).to eql(json_room_settings)
+      expect(JSON.parse(response.body)).to eql(json_room_settings)
     end
 
     it "should redirect to root if not logged in" do

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -202,8 +202,10 @@ describe RoomsController, type: :controller do
       @owner.main_room.update_attribute(:room_settings, { "muteOnStart": true, "requireModeratorApproval": true,
       "anyoneCanStart": true, "joinModerator": true }.to_json)
 
-      json_room_settings = "{\"muteOnStart\":true,\"requireModeratorApproval\":true," \
-        "\"anyoneCanStart\":true,\"joinModerator\":true}"
+      json_room_settings = { "anyoneCanStart" => true,
+                             "joinModerator" => true,
+                             "muteOnStart" => true,
+                             "requireModeratorApproval" => true }
 
       get :room_settings, params: { room_uid: @owner.main_room }, format: :json
 


### PR DESCRIPTION
Changes:
  - Improved wording of strings
  - Small code quality changes
  - Removed "Active Session" warning

The reason I removed the warning is that I believe it is partially misleading/inaccurate. The warning appears if the session is running and the room owner attempts to change a setting. My issue with it is that the room setting should still be changeable even if the meeting is running, even if the change won't apply until the meeting ends and a new one is created. This is how the rest of the room settings work, so making 1 of them work differently than the others could cause some confusion

What I would rather do is maybe provide a more general warning for all settings and not just the recording setting if the room is running, but I believe that can be branched off to a different PR