### PR TITLE
Change en.yml for little help

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,7 +36,7 @@ en:
         enabled: Enabled
         info: Only allow authenticated users to join a room
         title: Require Authentication for Rooms
-        user-info: You must sign in to Greenlight to join this room
+        user-info: You must sign in above to join this room.
       branding:
         change: Change Image
         info: Change the branding image that appears in the top left corner


### PR DESCRIPTION
Intention: 
Many people don't know what Greenlight is. And to give the users a little help I changed it to "login above".