### PR TITLE
Preupload translations add

### DIFF
--- a/app/assets/stylesheets/rooms.scss
+++ b/app/assets/stylesheets/rooms.scss
@@ -118,3 +118,8 @@
   word-break: break-all;
   white-space: normal;
 }
+
+.custom-file-label::after {
+font-family: 'Font Awesome 5 Free';
+content: "\f574";
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -551,6 +551,7 @@ en:
       recent_rooms: Go To a Recently Joined Room
       title: Join a Room
     no_sessions: This room has no sessions, yet!
+    add_presentation: Add presentation
     preupload_success: Successfully added presentation
     preupload_error: There was an error updating the room presentation
     recordings: Room Recordings


### PR DESCRIPTION
Add icon because "Browse" can not be translated
Add lost translation


Are the following bugs known?
file size over 750kb when I want to start the room:
<img width="859" alt="image" src="https://user-images.githubusercontent.com/8763656/86513841-b93f3100-be0d-11ea-9761-48f45f035ab4.png">

file size over 1mb at the upload will get:
Nginx error: 413 – Request Entity Too Large Error 
but the client_max_body_size in the /etc/nginx/site-av.. is set to the default 10mb