### PR TITLE
Record title, instead of room name, in the popup

### DIFF
--- a/app/views/shared/components/_public_recording_row.html.erb
+++ b/app/views/shared/components/_public_recording_row.html.erb
@@ -16,13 +16,14 @@
 <tr>
   <td>
     <div id="recording-title" class="edit_hover_class" data-recordid="<%= recording[:recordID] %>" data-room-uid="<%= room_uid_from_bbb(recording[:meetingID]) %>" data-path="<%= rename_recording_path(meetingID: recording[:meetingID], record_id: recording[:recordID]) %>">
-      <span id="recording-text" title="<%= recording[:name] %>">
-        <% if recording[:metadata][:name] %>
+      <% if recording[:metadata][:name] %>
+        <span id="recording-text" title="<%= recording[:metadata][:name] %>">
           <%= recording[:metadata][:name] %>
-        <% else %>
+      <% else %>
+        <span id="recording-text" title="<%= recording[:name] %>">
           <%= recording[:name] %>
-        <% end %>
-      </span>
+      <% end %>
+        </span>
     </div>
     <div class="small text-muted">
       <%= t("recording.recorded_on", date: recording_date(recording[:startTime])) %>

--- a/app/views/shared/components/_recording_row.html.erb
+++ b/app/views/shared/components/_recording_row.html.erb
@@ -16,13 +16,14 @@
 <tr>
   <td>
     <div id="recording-title" class="edit_hover_class" data-recordid="<%= recording[:recordID] %>" data-room-uid="<%= room_uid_from_bbb(recording[:meetingID]) %>" data-path="<%= rename_recording_path(meetingID: recording[:meetingID], record_id: recording[:recordID]) %>">
-      <span id='recording-text' title="<%= recording[:name] %>">
-        <% if recording[:metadata][:name] %>
+      <% if recording[:metadata][:name] %>
+        <span id='recording-text' title="<%= recording[:metadata][:name] %>">
           <%= recording[:metadata][:name] %>
-        <% else %>
+      <% else %>
+        <span id='recording-text' title="<%= recording[:name] %>">
           <%= recording[:name] %>
-        <% end %>
-      </span>
+      <% end %>
+        </span>
       <a><i id="edit-record" class="fa fa-edit align-top ml-2" data-edit-recordid="<%= recording[:recordID] %>"></i></a>
     </div>
     <div class="small text-muted">


### PR DESCRIPTION
A long record name can be truncated in the recording list. Might be better to show it in the popup. 