### PR TITLE
LDAP: Add support for domain-based login

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -137,6 +137,7 @@ class SessionsController < ApplicationController
     ldap_config[:base] = ENV['LDAP_BASE']
     ldap_config[:filter] = ENV['LDAP_FILTER']
     ldap_config[:uid] = ENV['LDAP_UID']
+    ldap_config[:domain] = ENV['LDAP_DOMAIN']
 
     if params[:session][:username].blank? || session_params[:password].blank?
       return redirect_to(ldap_signin_path, alert: I18n.t("invalid_credentials"))

--- a/sample.env
+++ b/sample.env
@@ -72,6 +72,7 @@ OAUTH2_REDIRECT=
 #   LDAP_BIND_DN=cn=admin,dc=example,dc=com
 #   LDAP_PASSWORD=password
 #   LDAP_ROLE_FIELD=ou
+#   LDAP_DOMAIN=domainname
 #   LDAP_FILTER=(&(attr1=value1)(attr2=value2))
 #   LDAP_ATTRIBUTE_MAPPING=name=displayName;uid=uid; (See link above for more details)
 LDAP_SERVER=
@@ -83,6 +84,7 @@ LDAP_BIND_DN=
 LDAP_AUTH=
 LDAP_PASSWORD=
 LDAP_ROLE_FIELD=
+LDAP_DOMAIN=
 LDAP_FILTER=
 LDAP_ATTRIBUTE_MAPPING=
 


### PR DESCRIPTION
With the new environment variable LDAP_DOMAIN. It is only used, if the
auth_method user is selected. Then the domain session controller sets
the domain field of the ldap_config which is then used in
blindsidenetworks/bn-ldap-authentication#8 to build the bindRequest
username like so: DOMAIN\USERNAME.