### PR TITLE
LDAP Sign-In form: user field attributes

### DIFF
--- a/app/views/sessions/ldap_signin.html.erb
+++ b/app/views/sessions/ldap_signin.html.erb
@@ -12,7 +12,7 @@
                                 <span class="input-icon-addon">
                                     <i class="fas fa-user"></i>
                                 </span>
-                                <%= f.text_field :username, class: "form-control", placeholder: t("administrator.users.table.username"), value: "" %>
+                                <%= f.text_field :username, class: "form-control", placeholder: t("administrator.users.table.username"), value: "", autocomplete: "username", autocapitalize: "none", spellcheck: "false", autofocus: "" %>
                             </div>
                         </div>
                         <div class="form-group">


### PR DESCRIPTION
- autocomplete="username": Tell the browser a user name should be filled, if any.
  Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
- autocapitalize="none": Tell browsers (especially on mobile devices like iOS) not to
  capitalize the first letter
  Reference: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocapitalize
- spellcheck="false": Do not spell-check the user name
  Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck
- autofocus: indicates that the input should automatically have focus, which makes sense
  because this form is shown after having clicked the "login" button so it's not an issue that
  the screen reader will skip the "Sign in to your account" text.
  Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefautofocus

This PR will improve usability especially on mobile devices. It does *not* not attempt to improve WCAG compliance.