### PR TITLE
Add basic anti-spam measures to the registration form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,5 +136,7 @@ gem 'random_password'
 
 # Adds helpers for the Google reCAPTCHA API
 gem "recaptcha"
+# Basic Spam protection with honeypot captcha
+gem 'invisible_captcha'
 
 gem 'i18n-language-mapping', '~> 0.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,8 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     i18n-language-mapping (0.1.2)
+    invisible_captcha (1.1.0)
+      rails (>= 4.2)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
@@ -430,6 +432,7 @@ DEPENDENCIES
   hiredis
   http_accept_language
   i18n-language-mapping (~> 0.1.1)
+  invisible_captcha
   jbuilder (~> 2.5)
   jquery-rails (~> 4.4)
   jquery-ui-rails

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,6 +28,7 @@ class UsersController < ApplicationController
   before_action :ensure_unauthenticated_except_twitter, only: [:create]
   before_action :check_user_signup_allowed, only: [:create]
   before_action :check_admin_of, only: [:edit, :change_password, :delete_account]
+  invisible_captcha only: [:create]
 
   # POST /u
   def create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
   belongs_to :role, required: false
 
   validates :name, length: { maximum: 256 }, presence: true,
-                   format: { without: /https?:\/\//i }
+                   format: { without: %r{https?://}i }
   validates :provider, presence: true
   validate :check_if_email_can_be_blank
   validates :email, length: { maximum: 256 }, allow_blank: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,8 @@ class User < ApplicationRecord
 
   belongs_to :role, required: false
 
-  validates :name, length: { maximum: 256 }, presence: true
+  validates :name, length: { maximum: 256 }, presence: true,
+                   format: { without: /https?:\/\//i }
   validates :provider, presence: true
   validate :check_if_email_can_be_blank
   validates :email, length: { maximum: 256 }, allow_blank: true,

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -59,6 +59,7 @@
               <%= f.password_field :password_confirmation, class: "form-control #{form_is_invalid?(@user, :password_confirmation)}", placeholder: t("signup.password_confirm") %>
               <div class="invalid-feedback d-block"><%= @user.errors.full_messages_for(:password_confirmation).first %></div>
             </div>
+            <%= invisible_captcha %>
             <% if Rails.configuration.terms %>
               <div class="form-inline">
                 <label class="custom-switch">

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,0 +1,3 @@
+InvisibleCaptcha.setup do |config|
+  config.timestamp_enabled = !Rails.env.test?
+end

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 InvisibleCaptcha.setup do |config|
   config.timestamp_enabled = !Rails.env.test?
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,6 +27,7 @@ describe User, type: :model do
   context 'validations' do
     it { should validate_presence_of(:name) }
     it { should validate_length_of(:name).is_at_most(256) }
+    it { should_not allow_value("https://www.bigbluebutton.org").for(:name) }
 
     it { should validate_presence_of(:provider) }
 


### PR DESCRIPTION
**Problem**
The registration form can be used to send spam. See #2093 

**Solution**
As using Google reCaptcha is not an option for everyone and it‘s not enabled by default I've added basic anti-spam measures with this PR:
- validate the name field to not include an http(s) url
- added honeypot captcha with invisible_captcha gem to the registration form

Solves #2093 