### PR TITLE
Enabling data URI as user's avatar

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -40,7 +40,7 @@
 
           <div class="dropdown">
             <a href="#" class="nav-link pr-0" data-toggle="dropdown">
-              <% if current_user.image.blank? || !valid_url?(current_user.image) %>
+              <% if current_user.image.blank? || ( !(/^data:image\/(jpeg|png|gif);base64/ =~ current_user.image) && !valid_url?(current_user.image)) %>
                 <span class="avatar"><%= current_user.name.first %></span>
               <% else %>
                 <span id="user-avatar" class="avatar d-none"><%= current_user.name.first %></span>

--- a/app/views/users/components/_account.html.erb
+++ b/app/views/users/components/_account.html.erb
@@ -56,7 +56,7 @@
     <%= f.label :image, t("settings.account.image"), class: "form-label mt-5" %>
     <div class="row">
       <div class="col-5 col-sm-2">
-        <% if @user.image.blank? || !valid_url?(@user.image) %>
+        <% if @user.image.blank? || ( !(/^data:image\/(jpeg|png|gif);base64/ =~ @user.image) && !valid_url?(@user.image)) %>
           <span class="avatar avatar-xxl mr-5 mt-2 bg-primary"><%= @user.name.first %></span>
         <% else %>
           <%= image_tag(@user.image, class: "avatar avatar-xxl mr-5 mt-2") %>


### PR DESCRIPTION
As BBB team starts to work on user's avatar images, it's time to start on the GR side.
https://github.com/bigbluebutton/bigbluebutton/pull/10458

As a starter, I would like to enable using data URI for user's avatar image. By this users can use whatever images they want even if the images are not on the internet (ie stored in local PC). 

This PR suggest just a small change. User has to convert the image on an internet service such as https://ezgif.com/image-to-datauri . In the ideal world we want to drag and drop an image on the setting form, convert image to base64 format (using Base64.encode64?), and use the data URI for avatar images. 

![avatarURI](https://user-images.githubusercontent.com/45039819/93693988-a51feb80-fb41-11ea-9950-e823c98b4fd6.gif)


