### PR TITLE
Allow customization of test email recipient

### DIFF
--- a/lib/tasks/configuration.rake
+++ b/lib/tasks/configuration.rake
@@ -49,7 +49,7 @@ def test_smtp
   authtype = ENV['SMTP_AUTH'].present? && ENV['SMTP_AUTH'] != "none" ? ENV['SMTP_AUTH'] : nil
 
   smtp.start(ENV['SMTP_DOMAIN'], user, password, authtype) do |s|
-    s.sendmail('test', ENV['SMTP_USERNAME'], ENV['SMTP_TEST_RECIPIENT'])
+    s.sendmail('test', ENV['SMTP_USERNAME'], ENV.fetch('SMTP_TEST_RECIPIENT', 'notifications@example.com'))
   end
 rescue => e
   failed("Error connecting to SMTP - #{e}")

--- a/lib/tasks/configuration.rake
+++ b/lib/tasks/configuration.rake
@@ -49,7 +49,7 @@ def test_smtp
   authtype = ENV['SMTP_AUTH'].present? && ENV['SMTP_AUTH'] != "none" ? ENV['SMTP_AUTH'] : nil
 
   smtp.start(ENV['SMTP_DOMAIN'], user, password, authtype) do |s|
-    s.sendmail('test', ENV['SMTP_USERNAME'], 'notifications@example.com')
+    s.sendmail('test', ENV['SMTP_USERNAME'], ENV['SMTP_TEST_RECIPIENT'])
   end
 rescue => e
   failed("Error connecting to SMTP - #{e}")

--- a/sample.env
+++ b/sample.env
@@ -138,6 +138,10 @@ SMTP_STARTTLS_AUTO=
 # Specify the email address that all mail is sent from
 SMTP_SENDER=
 
+# Specify the recipient for test emails (needed for providers like Microsoft, who are very 
+# strict about RFC 2606)
+SMTP_TEST_RECIPIENT=notifications@example.com
+
 # Prefix for the applications root URL.
 # Useful for deploying the application to a subdirectory, which is highly recommended
 # if deploying on a BigBlueButton server. Keep in mind that if you change this, you'll


### PR DESCRIPTION
Hi there,

When setting up SMTP through Microsoft email servers, we get the following error message:

```
Checking environment: Passed
Checking Connection: Passed
Checking Secret: Passed
Checking SMTP connection: Failed
Error connecting to SMTP - 501 5.1.5 Recipient address reserved by RFC 2606 [xxxxxxxx.eop-EUR02.prod.protection.outlook.com]
```

this MR allows the system integrator to specify an RFC 2606 - compliant test destination email recipient through the environment variable "SMTP_TEST_RECIPIENT"

regards