### PR TITLE
Basic anti-spam measures: Add anti-url validation to name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,8 @@ class User < ApplicationRecord
 
   belongs_to :role, required: false
 
-  validates :name, length: { maximum: 256 }, presence: true
+  validates :name, length: { maximum: 256 }, presence: true,
+                   format: { without: %r{https?://}i }
   validates :provider, presence: true
   validate :check_if_email_can_be_blank
   validates :email, length: { maximum: 256 }, allow_blank: true,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,6 +27,7 @@ describe User, type: :model do
   context 'validations' do
     it { should validate_presence_of(:name) }
     it { should validate_length_of(:name).is_at_most(256) }
+    it { should_not allow_value("https://www.bigbluebutton.org").for(:name) }
 
     it { should validate_presence_of(:provider) }
 


### PR DESCRIPTION
The registration form can be used to send spam, see issue #2093. The name field can be used for the spam message. This PR adds a simple validation to not allow a http(s) url as part of the name field of the registration form. 

We could also think about other additional validations, or restricting the length.