### PR TITLE
Basic anti-spam measures: Added honeypot captcha field to registration form with invisible_captcha

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,5 +136,7 @@ gem 'random_password'
 
 # Adds helpers for the Google reCAPTCHA API
 gem "recaptcha"
+# Basic Spam protection with honeypot captcha
+gem 'invisible_captcha'
 
 gem 'i18n-language-mapping', '~> 0.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,8 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     i18n-language-mapping (0.1.2)
+    invisible_captcha (1.1.0)
+      rails (>= 4.2)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
@@ -430,6 +432,7 @@ DEPENDENCIES
   hiredis
   http_accept_language
   i18n-language-mapping (~> 0.1.1)
+  invisible_captcha
   jbuilder (~> 2.5)
   jquery-rails (~> 4.4)
   jquery-ui-rails

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,6 +28,7 @@ class UsersController < ApplicationController
   before_action :ensure_unauthenticated_except_twitter, only: [:create]
   before_action :check_user_signup_allowed, only: [:create]
   before_action :check_admin_of, only: [:edit, :change_password, :delete_account]
+  invisible_captcha only: [:create]
 
   # POST /u
   def create

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -59,6 +59,7 @@
               <%= f.password_field :password_confirmation, class: "form-control #{form_is_invalid?(@user, :password_confirmation)}", placeholder: t("signup.password_confirm") %>
               <div class="invalid-feedback d-block"><%= @user.errors.full_messages_for(:password_confirmation).first %></div>
             </div>
+            <%= invisible_captcha %>
             <% if Rails.configuration.terms %>
               <div class="form-inline">
                 <label class="custom-switch">

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,0 +1,3 @@
+InvisibleCaptcha.setup do |config|
+  config.timestamp_enabled = !Rails.env.test?
+end

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 InvisibleCaptcha.setup do |config|
   config.timestamp_enabled = !Rails.env.test?
 end


### PR DESCRIPTION
The registration form can be used to send spam, see issue #2093. This adds a honeypot captcha field to the registration form. It's a simple anti-spam/-bot alternative to Google reCaptcha, which can not be used for privacy reasons for some Greenlight users. 