### PR TITLE
Enter a room by room ID

### DIFF
--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -39,7 +39,8 @@
         <script type="text/javascript">
           function Jump(){
             var b = location.href.match(/b\/$/) ? '' : 'b/';
-            location.href = b + document.myForm.mID.value;
+            var rid = document.myForm.mID.value.replace(/-/g,'').replace(/(...)(?!$)/g, '$1-');
+            location.href = b + rid;
             return;
         }
         </script>

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -23,12 +23,12 @@
             <h3 class="font-weight-normal ml-4 mt-3 text-right"><%= t("landing.enterid") %></h3>
           </div>
           <div class="col-lg-6 col-md-6 col-sm-12">
-            <form name="myForm" onsubmit="Jump()">
+            <form name="myForm">
               <div class="input-group">
                 <input required="required" value="" class="form-control join-form" placeholder="aaa-bbb-ccc" value="" autofocus="autofocus" type="text" name="mID">
                 <input type="text" name="dummy" style="display:none;">
                 <span class="input-group-append">
-                  <input type="button" value=<%= t("room.join") %> onclick="Jump()" class="btn btn-primary btn-sm px-7 form-control join-form">
+                  <input type="button" value=<%= t("room.join") %> onclick="Jump();" class="btn btn-primary btn-sm px-7 form-control join-form">
                 </span>
               </div>
             </form>

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -23,12 +23,12 @@
             <h3 class="font-weight-normal ml-4 mt-3 text-right"><%= t("landing.enterid") %></h3>
           </div>
           <div class="col-lg-6 col-md-6 col-sm-12">
-            <form name="myForm">
+            <form name="myForm" onsubmit="Jump()">
               <div class="input-group">
                 <input required="required" value="" class="form-control join-form" placeholder="aaa-bbb-ccc" value="" autofocus="autofocus" type="text" name="mID">
                 <input type="text" name="dummy" style="display:none;">
                 <span class="input-group-append">
-                  <input type="button" value=<%= t("room.join") %> onclick="Jump();" class="btn btn-primary btn-sm px-7 form-control join-form">
+                  <input type="button" value=<%= t("room.join") %> onclick="Jump()" class="btn btn-primary btn-sm px-7 form-control join-form">
                 </span>
               </div>
             </form>

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -23,12 +23,11 @@
             <h3 class="font-weight-normal ml-4 mt-3 text-right"><%= t("landing.enterid") %></h3>
           </div>
           <div class="col-lg-6 col-md-6 col-sm-12">
-            <form name="myForm">
+            <form name="myForm" onsubmit="Jump(); return false;">
               <div class="input-group">
                 <input required="required" value="" class="form-control join-form" placeholder="aaa-bbb-ccc" value="" autofocus="autofocus" type="text" name="mID">
-                <input type="text" name="dummy" style="display:none;">
                 <span class="input-group-append">
-                  <input type="button" value=<%= t("room.join") %> onclick="Jump();" class="btn btn-primary btn-sm px-7 form-control join-form">
+                  <input type="submit" value=<%= t("room.join") %> class="btn btn-primary btn-sm px-7 form-control join-form">
                 </span>
               </div>
             </form>

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -18,6 +18,32 @@
     <div class="row">
       <div class="col-md-12 col-sm-12 text-center">
         <h1 id="main-text" class="display-4 mb-4"> <%= t("landing.welcome").html_safe %></h1>
+        <div class="row">
+          <div class="col-lg-6 col-md-6 col-sm-12 mb-5 align-top">
+            <h3 class="font-weight-normal ml-4 mt-3 text-right"><%= t("landing.enterid") %></h3>
+          </div>
+          <div class="col-lg-6 col-md-6 col-sm-12">
+            <form name="myForm">
+              <div class="input-group">
+                <input required="required" value="" class="form-control join-form" placeholder="aaa-bbb-ccc" value="" autofocus="autofocus" type="text" name="mID">
+                <input type="text" name="dummy" style="display:none;">
+                <span class="input-group-append">
+                  <input type="button" value=<%= t("room.join") %> onclick="Jump();" class="btn btn-primary btn-sm px-7 form-control join-form">
+                </span>
+              </div>
+            </form>
+          </div>
+        </div>
+        <br>
+
+        <script type="text/javascript">
+          function Jump(){
+            var b = location.href.match(/b\/$/) ? '' : 'b/';
+            location.href = b + document.myForm.mID.value;
+            return;
+        }
+        </script>
+        
         <p class="lead offset-lg-2 col-lg-8 col-sm-12 "><%= t("landing.about", href: link_to(t("greenlight"), "https://bigbluebutton.org/2018/07/09/greenlight-2-0/", target: "_blank", rel: "noopener")).html_safe %></p>
         <%= link_to "https://youtu.be/Hso8yLzkqj8", target: "_blank" do %>
           <h4><%= t("landing.video") %> <i class="far fa-play-circle ml-1"></i></h4>

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -41,7 +41,7 @@
             var rid = document.myForm.mID.value.replace(/-/g,'').replace(/(...)(?!$)/g, '$1-');
             location.href = b + rid;
             return;
-        }
+          }
         </script>
         
         <p class="lead offset-lg-2 col-lg-8 col-sm-12 "><%= t("landing.about", href: link_to(t("greenlight"), "https://bigbluebutton.org/2018/07/09/greenlight-2-0/", target: "_blank", rel: "noopener")).html_safe %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -298,6 +298,7 @@ en:
     video: Watch our tutorial on using Greenlight
     upgrade: Show me how to upgrade to 2.0!
     version: We've released a new version of Greenlight, but your database isn't compatible.
+    enterid: Enter the room ID
   language_default: Default (browser language)
   ldap_error: Unable to connect to the LDAP server. Please check your LDAP configuration in the env file and ensure your server is running.
   login: Sign in

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -298,7 +298,7 @@ en:
     video: Watch our tutorial on using Greenlight
     upgrade: Show me how to upgrade to 2.0!
     version: We've released a new version of Greenlight, but your database isn't compatible.
-    enterid: Enter the room ID
+    enterid: Enter a room ID
   language_default: Default (browser language)
   ldap_error: Unable to connect to the LDAP server. Please check your LDAP configuration in the env file and ensure your server is running.
   login: Sign in


### PR DESCRIPTION
Currently the moderator can only send a direct link to users to invite them for a meeting. However the link can unintentionally contain a line break in the middle of URL when sent by Email. This has brought many troubles to my students, who have no idea how the correct link would look like.

Similar to Zoom, it would be convenient if users can join a meeting by entering a room ID. 

![enterid](https://user-images.githubusercontent.com/45039819/94695587-0ed59c00-0371-11eb-89bd-d57b9bbd7bd0.jpg)