### PR TITLE
GRN2-xx: Changed how pagination works on Server Recordings to improve performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -130,6 +130,9 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Enabled: false
 
+Metrics/ParameterLists:
+  Max: 7
+
 # A calculated magnitude based on number of assignments,
 # branches, and conditions.
 Metrics/AbcSize:

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -53,11 +53,13 @@ class AdminsController < ApplicationController
   # GET /admins/server_recordings
   def server_recordings
     server_rooms = rooms_list_for_recordings
+    @page = (params[:page].presence || 1).to_i
 
-    @search, @order_column, @order_direction, recs =
-      all_recordings(server_rooms, params.permit(:search, :column, :direction), true, true)
+    @search, @order_column, @order_direction, @recordings =
+      limited_recordings(server_rooms, @page, 25, params.permit(:search, :column, :direction), true, true)
 
-    @pagy, @recordings = pagy_array(recs)
+    # If the page has gone too far (no more recordings), then redirect back to the last page
+    return redirect_to admin_recordings_path(page: @page - 1) if @recordings == -1
   end
 
   # GET /admins/rooms

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -56,7 +56,8 @@ class AdminsController < ApplicationController
     @page = (params[:page].presence || 1).to_i
 
     @search, @order_column, @order_direction, @recordings =
-      limited_recordings(server_rooms, @page, 25, params.permit(:search, :column, :direction), true, true)
+      limited_recordings(server_rooms, @page, Rails.configuration.pagination_rows,
+        params.permit(:search, :column, :direction), true, true)
 
     # If the page has gone too far (no more recordings), then redirect back to the last page
     return redirect_to admin_recordings_path(page: @page - 1) if @recordings == -1

--- a/app/controllers/concerns/recorder.rb
+++ b/app/controllers/concerns/recorder.rb
@@ -47,6 +47,37 @@ module Recorder
     format_recordings(res, search_params, ret_search_params, search_name)
   end
 
+  # Makes paginated API calls to get recordings
+  def limited_recordings(room_bbb_ids, page, limit, search_params = {}, ret_search_params = false, search_name = false)
+    res = { recordings: [] }
+    temp_recs = []
+
+    # All recordings needed to display the current page
+    # If on page 3, and limit is 25, we need 75 recordings
+    total_recordings_needed = page * limit
+
+    until temp_recs.size >= total_recordings_needed
+      # No rooms left to check
+      break if room_bbb_ids.empty?
+      # bbb.get_recordings returns an object
+      # take only the array portion of the object that is returned
+      full_res = get_multiple_recordings(room_bbb_ids.pop(Rails.configuration.pagination_number))
+      temp_recs.push(*full_res[:recordings])
+    end
+
+    # Using example from above, start at index 50
+    starting_point = ((page - 1) * limit)
+
+    (0..limit - 1).each do |i|
+      res[:recordings] << temp_recs[i + starting_point] unless temp_recs[i + starting_point].nil?
+    end
+
+    # Really ugly way to indicate that there are no recordings left (page number gone too far)
+    return [-1, -1, -1, -1] if res[:recordings].empty?
+
+    format_recordings(res, search_params, ret_search_params, search_name)
+  end
+
   # Format, filter, and sort recordings to match their current use in the app
   def format_recordings(api_res, search_params, ret_search_params, search_name = false)
     search = search_params[:search] || ""

--- a/app/views/admins/components/_recordings.html.erb
+++ b/app/views/admins/components/_recordings.html.erb
@@ -95,7 +95,9 @@
       </table>
       <% if !@recordings.empty?%>
         <div class="float-md-right mt-4">
-          <%== pagy_bootstrap_nav(@pagy) %>
+          <%= link_to t("pagy.nav.prev").html_safe, admin_recordings_path(page: @page - 1), class: "btn btn-outline-primary #{"disabled" if @page == 1}" %>
+          <div class="btn btn-outline-primary"><%= @page %></div>
+          <%= link_to t("pagy.nav.next").html_safe, admin_recordings_path(page: @page + 1), class: "btn btn-outline-primary" %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
fixes #2132 

This PR greatly improves the load time for server recordings but has some pretty major side effects including:
- Column sort and search only sort/search the current page (not all recordings)
- Most recent recordings are not returned first - its kind of just scrambled