### PR TITLE
Feature to generate static pin for phone bridge in each room settings

### DIFF
--- a/app/assets/javascripts/room.js
+++ b/app/assets/javascripts/room.js
@@ -176,6 +176,9 @@ function showCreateRoom(target) {
   $("#room_all_join_moderator").prop("checked", $("#room_all_join_moderator").data("default"))
   $("#room_recording").prop("checked", $("#room_recording").data("default"))
 
+  $("#create-voice-bridge-pin").text(getLocalizedString("modal.create_room.voice_bridge_pin_placeholder"))
+  $("#room_voice_bridge_pin").val(null)
+
   //show all elements & their children with a create-only class
   $(".create-only").each(function() {
     $(this).show()
@@ -235,6 +238,14 @@ function updateCurrentSettings(settings_path){
     $("#room_anyone_can_start").prop("checked", $("#room_anyone_can_start").data("default") || settings.anyoneCanStart)
     $("#room_all_join_moderator").prop("checked", $("#room_all_join_moderator").data("default") || settings.joinModerator)
     $("#room_recording").prop("checked", $("#room_recording").data("default") || Boolean(settings.recording))
+    $("#room_voice_bridge_pin").val(settings.voiceBridgePin)
+    if (settings.voiceBridgePin) {
+      $("#create-voice-bridge-pin").html(getLocalizedString("modal.create_room.voice_bridge_pin") + ": <label tabindex=0>" + settings.voiceBridgePin + "</label>")
+      $("#room_voice_bridge_pin").val(voiceBridgePin)
+    } else {
+      $("#create-voice-bridge-pin").text(getLocalizedString("modal.create_room.voice_bridge_pin_placeholder"))
+      $("#room_voice_bridge_pin").val(null)
+    }
   })
 }
 
@@ -251,9 +262,20 @@ function generateAccessCode(){
   $("#room_access_code").val(accessCode)
 }
 
+function generateVoiceBridgePin() {
+  var pin = Math.floor(Math.random() * 90000) + 10000;
+  $("#create-voice-bridge-pin").html(getLocalizedString("modal.create_room.voice_bridge_pin") + ": <label tabindex=0>" + pin + "</label>")
+  $("#room_voice_bridge_pin").val(pin)
+}
+
 function ResetAccessCode(){
   $("#create-room-access-code").text(getLocalizedString("modal.create_room.access_code_placeholder"))
   $("#room_access_code").val(null)
+}
+
+function resetVoiceBridgePin() {
+  $("#create-voice-bridge-pin").text(getLocalizedString("modal.create_room.voice_bridge_pin_placeholder"))
+  $("#room_voice_bridge_pin").val(null)
 }
 
 function saveAccessChanges() {

--- a/app/controllers/concerns/bbb_server.rb
+++ b/app/controllers/concerns/bbb_server.rb
@@ -74,6 +74,7 @@ module BbbServer
     }
 
     create_options[:guestPolicy] = "ASK_MODERATOR" if options[:require_moderator_approval]
+    create_options[:voiceBridge] = options[:voice_bridge] if options[:voice_bridge]
 
     # Send the create request.
     begin

--- a/app/controllers/concerns/joiner.rb
+++ b/app/controllers/concerns/joiner.rb
@@ -57,6 +57,7 @@ module Joiner
       opts[:record] = record_meeting
       opts[:require_moderator_approval] = room_setting_with_config("requireModeratorApproval")
       opts[:mute_on_start] = room_setting_with_config("muteOnStart")
+      opts[:voice_bridge] = @room_settings["voiceBridgePin"]
 
       if current_user
         redirect_to join_path(@room, current_user.name, opts, current_user.uid)

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -176,6 +176,7 @@ class RoomsController < ApplicationController
     opts[:mute_on_start] = room_setting_with_config("muteOnStart")
     opts[:require_moderator_approval] = room_setting_with_config("requireModeratorApproval")
     opts[:record] = record_meeting
+    opts[:voice_bridge] = @room_settings["voiceBridgePin"]
 
     begin
       redirect_to join_path(@room, current_user.name, opts, current_user.uid)
@@ -336,6 +337,7 @@ class RoomsController < ApplicationController
       "anyoneCanStart": options[:anyone_can_start] == "1",
       "joinModerator": options[:all_join_moderator] == "1",
       "recording": options[:recording] == "1",
+      "voiceBridgePin": options[:voice_bridge_pin],
     }
 
     room_settings.to_json
@@ -344,7 +346,7 @@ class RoomsController < ApplicationController
   def room_params
     params.require(:room).permit(:name, :auto_join, :mute_on_join, :access_code,
       :require_moderator_approval, :anyone_can_start, :all_join_moderator,
-      :recording, :presentation)
+      :recording, :presentation, :voice_bridge_pin)
   end
 
   # Find the room from the uid.

--- a/app/views/shared/modals/_create_room_modal.html.erb
+++ b/app/views/shared/modals/_create_room_modal.html.erb
@@ -53,6 +53,9 @@
                 <i class="far fa-trash-alt"></i>
               </span>
             </div>
+            <% if Rails.configuration.voice_bridge_phone_number %>
+              <span id="voice_bridge_phone_number" class="form-control">Phone number: <%= Rails.configuration.voice_bridge_phone_number %></span>
+            <% end %>
 
             <% mute = room_configuration("Room Configuration Mute On Join") %>
             <% if mute != "disabled" %>

--- a/app/views/shared/modals/_create_room_modal.html.erb
+++ b/app/views/shared/modals/_create_room_modal.html.erb
@@ -43,6 +43,17 @@
               </span>
             </div>
 
+            <div class="input-icon mb-2">
+              <span id="generate-voice-bridge-pin" onclick="generateVoiceBridgePin()" class="input-icon-addon allow-icon-click cursor-pointer" tabindex="0" aria-label="<%= t("modal.create_room.voice_bridge_pin_btn_label") %>">
+                <i class="fas fa-dice"></i>
+              </span>
+              <%= f.label :voice_bridge_pin, t("modal.create_room.voice_bridge_pin_placeholder"), id: "create-voice-bridge-pin", class: "form-control" %>
+              <%= f.hidden_field :voice_bridge_pin, id: "room_voice_bridge_pin", value: "" %>
+              <span id="reset-voice-bridge-pin" onclick="resetVoiceBridgePin()" class="input-icon-addon allow-icon-click cursor-pointer" tabindex="0" aria-label="<%= t("modal.create_room.voice_bridge_pin_reset_label") %>">
+                <i class="far fa-trash-alt"></i>
+              </span>
+            </div>
+
             <% mute = room_configuration("Room Configuration Mute On Join") %>
             <% if mute != "disabled" %>
               <label class="custom-switch pl-0 mt-3 mb-3 w-100 text-left d-inline-block <%= "enabled-setting" if mute == "enabled" %>">

--- a/app/views/shared/modals/_create_room_modal.html.erb
+++ b/app/views/shared/modals/_create_room_modal.html.erb
@@ -43,6 +43,7 @@
               </span>
             </div>
 
+            <% if Rails.configuration.voice_bridge_phone_number %>
             <div class="input-icon mb-2">
               <span id="generate-voice-bridge-pin" onclick="generateVoiceBridgePin()" class="input-icon-addon allow-icon-click cursor-pointer" tabindex="0" aria-label="<%= t("modal.create_room.voice_bridge_pin_btn_label") %>">
                 <i class="fas fa-dice"></i>
@@ -53,8 +54,7 @@
                 <i class="far fa-trash-alt"></i>
               </span>
             </div>
-            <% if Rails.configuration.voice_bridge_phone_number %>
-              <span id="voice_bridge_phone_number" class="form-control">Phone number: <%= Rails.configuration.voice_bridge_phone_number %></span>
+            <span id="voice_bridge_phone_number" class="form-control">Phone number: <%= Rails.configuration.voice_bridge_phone_number %></span>
             <% end %>
 
             <% mute = room_configuration("Room Configuration Mute On Join") %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -171,5 +171,8 @@ module Greenlight
 
     # Default admin password
     config.admin_password_default = ENV['ADMIN_PASSWORD'] || 'administrator'
+
+    # Phone number
+    config.voice_bridge_phone_number = ENV['VOICE_BRIDGE_PHONE_NUMBER']
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -388,6 +388,10 @@ en:
       name_placeholder: Enter a room name...
       not_blank: Room name cannot be blank.
       title: Create New Room
+      voice_bridge_pin: Voice Conference PIN
+      voice_bridge_pin_placeholder: Generate an optional Voice Conference PIN
+      voice_bridge_pin_btn_label: Generate new Voice Conference PIN
+      voice_bridge_pin_reset_label: Reset Voice Conference PIN
     delete_account:
       confirm: Are you sure you want to delete this account?
       delete: I'm sure, delete this account.

--- a/sample.env
+++ b/sample.env
@@ -308,3 +308,8 @@ DEFAULT_REGISTRATION=open
 # For details, see: https://github.com/puma/puma#clustered-mode
 # Default: 1
 #WEB_CONCURRENCY=1
+
+#
+# Phone number of voice bridge
+#   If this is set, room owner can generate static pin in room settings
+#VOICE_BRIDGE_PHONE_NUMBER=

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -185,7 +185,7 @@ describe RoomsController, type: :controller do
       room_params = { name: name, "mute_on_join": "1",
         "require_moderator_approval": "1", "anyone_can_start": "1", "all_join_moderator": "1" }
       json_room_settings = "{\"muteOnStart\":true,\"requireModeratorApproval\":true," \
-        "\"anyoneCanStart\":true,\"joinModerator\":true,\"recording\":false}"
+        "\"anyoneCanStart\":true,\"joinModerator\":true,\"recording\":false,\"voiceBridgePin\":null}"
 
       post :create, params: { room: room_params }
 
@@ -585,9 +585,9 @@ describe RoomsController, type: :controller do
     it "properly updates room settings through the room settings modal and redirects to current page" do
       @request.session[:user_id] = @user.id
 
-      room_params = { "mute_on_join": "1", "name": @secondary_room.name, "recording": "1" }
+      room_params = { "mute_on_join": "1", "name": @secondary_room.name, "recording": "1", "voice_bridge_pin": "11111" }
       formatted_room_params = "{\"muteOnStart\":true,\"requireModeratorApproval\":false," \
-        "\"anyoneCanStart\":false,\"joinModerator\":false,\"recording\":true}" # JSON string format
+        "\"anyoneCanStart\":false,\"joinModerator\":false,\"recording\":true,\"voiceBridgePin\":\"11111\"}" # JSON string format
 
       expect { post :update_settings, params: { room_uid: @secondary_room.uid, room: room_params } }
         .to change { @secondary_room.reload.room_settings }
@@ -608,9 +608,9 @@ describe RoomsController, type: :controller do
       @admin.set_role :admin
       @request.session[:user_id] = @admin.id
 
-      room_params = { "mute_on_join": "1", "name": @secondary_room.name }
+      room_params = { "mute_on_join": "1", "name": @secondary_room.name, "voice_bridge_pin": "" }
       formatted_room_params = "{\"muteOnStart\":true,\"requireModeratorApproval\":false," \
-        "\"anyoneCanStart\":false,\"joinModerator\":false,\"recording\":false}" # JSON string format
+        "\"anyoneCanStart\":false,\"joinModerator\":false,\"recording\":false,\"voiceBridgePin\":\"\"}" # JSON string format
 
       expect { post :update_settings, params: { room_uid: @secondary_room.uid, room: room_params } }
         .to change { @secondary_room.reload.room_settings }


### PR DESCRIPTION
This PR is reference implementation to generate static pin for phone bridge in room settings.
UI is same as generating room access code.

Inspired by https://github.com/bigbluebutton/greenlight/issues/1645.

To activate this feature, you have to set `VOICE_BRIDGE_PHONE_NUMBER` in .env.