### PR TITLE
Fix broken UI on long filenames

### DIFF
--- a/app/assets/stylesheets/rooms.scss
+++ b/app/assets/stylesheets/rooms.scss
@@ -126,3 +126,10 @@
 .create-room-button {
   width: 49%;
 }
+
+#presentation-upload-label {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 75px;
+}


### PR DESCRIPTION
If you select a presentation with a very long filename in in Greenlight,
the filename text in the upload dialog wraps at the end and leaves the
label box, leading to a slightly broken looking user interface.

This patch adjusts the style to hide the end of a long filename, ending
with a horizontal ellipsis instead.

---

Before:
![Screenshot from 2020-10-20 20-59-32](https://user-images.githubusercontent.com/1008395/96633741-d2ff7800-1319-11eb-9bda-5a1b23f41631.png)

Fixed:
![Screenshot from 2020-10-20 21-05-41](https://user-images.githubusercontent.com/1008395/96633757-da268600-1319-11eb-9ab3-a6c63fa6583f.png)
