### PR TITLE
fix: health_check SMTP check when no auth required

### DIFF
--- a/app/controllers/health_check_controller.rb
+++ b/app/controllers/health_check_controller.rb
@@ -65,8 +65,12 @@ class HealthCheckController < ApplicationController
       smtp.enable_starttls_auto if smtp.respond_to?(:enable_starttls_auto)
     end
 
-    smtp.start(settings[:domain]) do |s|
-      s.authenticate(settings[:user_name], settings[:password], settings[:authentication])
+    if settings[:authentication].present? && settings[:authentication] != "none"
+      smtp.start(settings[:domain]) do |s|
+        s.authenticate(settings[:user_name], settings[:password], settings[:authentication])
+      end
+    else
+      smtp.start(settings[:domain])
     end
   rescue => e
     raise "Unable to connect to SMTP Server - #{e}"


### PR DESCRIPTION
The health_check controller implemented for the SMTP check try to authenticate in all case even when no auth is set and required.