### PR TITLE
Changed logo to env variable

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -137,7 +137,7 @@ module Greenlight
     # DEFAULTS
 
     # Default branding image if the user does not specify one
-    config.branding_image_default = "https://raw.githubusercontent.com/bigbluebutton/greenlight/master/app/assets/images/logo_with_text.png"
+    config.branding_image_default = ENV["DEFAULT_LOGO"].nil? ? "https://raw.githubusercontent.com/bigbluebutton/greenlight/master/app/assets/images/logo_with_text.png" : ENV["DEFAULT_LOGO"]
 
     # Default primary color if the user does not specify one
     config.primary_color_default = "#467fcf"

--- a/config/application.rb
+++ b/config/application.rb
@@ -137,11 +137,7 @@ module Greenlight
     # DEFAULTS
 
     # Default branding image if the user does not specify one
-    if ENV["DEFAULT_LOGO"].nil?
-      config.branding_image_default = "https://raw.githubusercontent.com/bigbluebutton/greenlight/master/app/assets/images/logo_with_text.png"
-    else
-      config.branding_image_default = ENV["DEFAULT_LOGO"]
-    end
+    config.branding_image_default = ENV["DEFAULT_LOGO"].presence || "https://raw.githubusercontent.com/bigbluebutton/greenlight/master/app/assets/images/logo_with_text.png"
 
     # Default primary color if the user does not specify one
     config.primary_color_default = "#467fcf"

--- a/config/application.rb
+++ b/config/application.rb
@@ -137,7 +137,8 @@ module Greenlight
     # DEFAULTS
 
     # Default branding image if the user does not specify one
-    config.branding_image_default = ENV["DEFAULT_LOGO"].nil? ? "https://raw.githubusercontent.com/bigbluebutton/greenlight/master/app/assets/images/logo_with_text.png" : ENV["DEFAULT_LOGO"]
+    config.branding_image_default = ENV["DEFAULT_LOGO"].nil? ? 
+     "https://raw.githubusercontent.com/bigbluebutton/greenlight/master/app/assets/images/logo_with_text.png" : ENV["DEFAULT_LOGO"]
 
     # Default primary color if the user does not specify one
     config.primary_color_default = "#467fcf"

--- a/config/application.rb
+++ b/config/application.rb
@@ -137,8 +137,11 @@ module Greenlight
     # DEFAULTS
 
     # Default branding image if the user does not specify one
-    config.branding_image_default = ENV["DEFAULT_LOGO"].nil? ? 
-     "https://raw.githubusercontent.com/bigbluebutton/greenlight/master/app/assets/images/logo_with_text.png" : ENV["DEFAULT_LOGO"]
+    if ENV["DEFAULT_LOGO"].nil?
+      config.branding_image_default = "https://raw.githubusercontent.com/bigbluebutton/greenlight/master/app/assets/images/logo_with_text.png"
+    else
+      config.branding_image_default = ENV["DEFAULT_LOGO"]
+    end
 
     # Default primary color if the user does not specify one
     config.primary_color_default = "#467fcf"

--- a/sample.env
+++ b/sample.env
@@ -308,3 +308,6 @@ DEFAULT_REGISTRATION=open
 # For details, see: https://github.com/puma/puma#clustered-mode
 # Default: 1
 #WEB_CONCURRENCY=1
+
+# The default logo, if no logo is defined within the application itself.
+DEFAULT_LOGO=https://raw.githubusercontent.com/bigbluebutton/greenlight/master/app/assets/images/logo_with_text.png


### PR DESCRIPTION
At the moment, the default logo is hardcoded in Greenlight. I want this to be more variable, and I want to be able to set this via the .env file.

This PR is a small modification, to allow the default value to be fed from the .env file.