### PR TITLE
Fix Invite Link Separator

### DIFF
--- a/app/controllers/concerns/joiner.rb
+++ b/app/controllers/concerns/joiner.rb
@@ -87,7 +87,7 @@ module Joiner
     {
       user_is_moderator: false,
       meeting_logout_url: request.base_url + logout_room_path(@room),
-      moderator_message: "#{invite_msg}\n\n#{request.base_url + room_path(@room)}",
+      moderator_message: "#{invite_msg}<br> #{request.base_url + room_path(@room)}",
       host: request.host,
       recording_default_visibility: @settings.get_value("Default Recording Visibility") == "public"
     }


### PR DESCRIPTION
This patch fixes the separator before the invite link in the text which
is sent to BigBlueButton. The `\n` characters were filtered out so that
at least a space character was missing here.

This fixes #2307

---

With patch applied:

![bbb-invite-link](https://user-images.githubusercontent.com/1008395/100141734-2756c400-2e93-11eb-9687-47e799116f8e.png)

