### PR TITLE
Allow Searching for Rooms

### DIFF
--- a/app/assets/javascripts/room.js
+++ b/app/assets/javascripts/room.js
@@ -347,3 +347,16 @@ function checkIfAutoJoin() {
     $("#room-join").click()
   }
 }
+
+function filterRooms() {
+  const search_term = document.getElementById('room-search').value.toLowerCase(),
+        create_room = document.getElementById('create-room-block').parentNode,
+        container = document.getElementById('room_block_container');
+
+  container.childNodes.forEach(r => {
+    let text = r.innerText;
+    if (r != create_room && text !== undefined) {
+      r.style.display = (text.toLowerCase().indexOf(search_term) < 0) ? 'none' : 'block';
+    }
+  })
+}

--- a/app/assets/javascripts/room.js
+++ b/app/assets/javascripts/room.js
@@ -142,6 +142,9 @@ $(document).on('turbolinks:load', function(){
     $("#remove-presentation").click(function(data) {
       removePreuploadPresentation($(this).data("remove"))
     })
+
+    // trigger initial room filter
+    filterRooms();
   }
 });
 
@@ -349,14 +352,18 @@ function checkIfAutoJoin() {
 }
 
 function filterRooms() {
-  const search_term = document.getElementById('room-search').value.toLowerCase(),
-        create_room = document.getElementById('create-room-block').parentNode,
-        container = document.getElementById('room_block_container');
+  const search_term = $('#room-search').val().toLowerCase(),
+        rooms = $('#room_block_container > div:not(:last-child)');
+        clear_room_search = $('#clear-room-search');
 
-  container.childNodes.forEach(r => {
-    let text = r.innerText;
-    if (r != create_room && text !== undefined) {
-      r.style.display = (text.toLowerCase().indexOf(search_term) < 0) ? 'none' : 'block';
-    }
+  if (search_term) {
+    clear_room_search.show();
+  } else {
+    clear_room_search.hide();
+  }
+
+  rooms.each(function(i, room) {
+    let text = $(this).find('h4').text();
+    room.style.display = (text.toLowerCase().indexOf(search_term) < 0) ? 'none' : 'block';
   })
 }

--- a/app/assets/stylesheets/admins.scss
+++ b/app/assets/stylesheets/admins.scss
@@ -24,7 +24,7 @@
   }
 }
 
-#clear-search {
+#clear-search, #clear-room-search {
   z-index: 9;
   position: absolute;
   right: 55px;
@@ -33,6 +33,10 @@
   &:hover {
     cursor: pointer;
   }
+}
+
+.room-search {
+  margin: 50px 0 25px 0;
 }
 
 .tag i {

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -82,6 +82,21 @@
       </div>
     </div>
 
+    <% if current_user.ordered_rooms.length > 6 %>
+      <div class="input-icon invite-link-input">
+        <span class="input-icon-addon">
+          <i class="fas fa-search"></i>
+        </span>
+        <input id="room-search"
+               type="text"
+               placeholder="<%= t("room.search") %>"
+               class="form-control w-100"
+               onChange="filterRooms()"
+               onKeyUp="filterRooms()"
+               style="margin: 50px 0 25px 0">
+      </div>
+    <% end %>
+
     <div id="room_block_container" class="row pt-7 pb-5">
       <% if current_user.role.get_permission("can_create_rooms") %>
         <% current_user.ordered_rooms.each do |room| %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -83,17 +83,16 @@
     </div>
 
     <% if current_user.ordered_rooms.length > 6 %>
-      <div class="input-icon invite-link-input">
-        <span class="input-icon-addon">
-          <i class="fas fa-search"></i>
+      <div class="input-group room-search">
+        <input id="room-search" type="text" class="form-control" placeholder="<%= t("room.search") %>" onChange="filterRooms()" onKeyUp="filterRooms()"></input>
+        <span id="clear-room-search" class="text-primary" onclick="$('#room-search').val(''); filterRooms()">
+          <i class="fas fa-times"></i>
         </span>
-        <input id="room-search"
-               type="text"
-               placeholder="<%= t("room.search") %>"
-               class="form-control w-100"
-               onChange="filterRooms()"
-               onKeyUp="filterRooms()"
-               style="margin: 50px 0 25px 0">
+        <span class="input-group-append">
+          <button class="btn btn-outline-primary" type="button" onclick="filterRooms()">
+            <i class="fas fa-search"></i>
+          </button>
+        </span>
       </div>
     <% end %>
 

--- a/config/locales/de_DE.yml
+++ b/config/locales/de_DE.yml
@@ -578,7 +578,6 @@ de_DE:
     shared_access_success: Raum erfolgreich geteilt
     shared_access_error: Beim Teilen des Raums ist ein Fehler aufgetreten
     start: Starten
-    search: Nach Raum suchen…
     unavailable: "Der Raum ist aktuell nicht verfügbar, weil die E-Mail des Rauminitiators noch nicht verifiziert wurde."
     update_settings_error: Bei der Aktualisierung der Raumeinstellungen ist ein Fehler aufgetreten.
     update_settings_success: Raumeinstellungen erfolgreich aktualisiert

--- a/config/locales/de_DE.yml
+++ b/config/locales/de_DE.yml
@@ -578,6 +578,7 @@ de_DE:
     shared_access_success: Raum erfolgreich geteilt
     shared_access_error: Beim Teilen des Raums ist ein Fehler aufgetreten
     start: Starten
+    search: Nach Raum suchen…
     unavailable: "Der Raum ist aktuell nicht verfügbar, weil die E-Mail des Rauminitiators noch nicht verifiziert wurde."
     update_settings_error: Bei der Aktualisierung der Raumeinstellungen ist ein Fehler aufgetreten.
     update_settings_success: Raumeinstellungen erfolgreich aktualisiert

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -579,6 +579,7 @@ en:
     shared_access_success: Room shared successfully
     shared_access_error: There was an error sharing the room
     start: Start
+    search: Search for room…
     unavailable: This room is currently unavailable due to the owner's email not being verified.
     update_settings_error: There was an error updating the room settings
     update_settings_success: Room settings successfully updated


### PR DESCRIPTION
If a user has a lot of rooms, finding the correct one can be somewhat
annoying and it would be great to be able to search for or filter the
rooms in the room list.

This patch adds a very simple search functionality for this. The search
bar is hidden as long as a user has not more than six (two rows in
desktop mode) rooms. If the number of rooms exceeds this limit, a search
field is shown to quickly filter the list.

#### Search bar in action

![greenlight-search](https://user-images.githubusercontent.com/1008395/100490720-af4ffe80-311d-11eb-9b5e-6ad3667c7741.gif)

#### Search bar appears when you have more than 6 rooms

![greenlight-search-7](https://user-images.githubusercontent.com/1008395/100490722-b971fd00-311d-11eb-8fae-96a9a44146e7.png)

#### No search with ≤ 6 rooms

![greenlight-no-search-2](https://user-images.githubusercontent.com/1008395/100490732-ca227300-311d-11eb-9eee-2f22324dc6ec.png)
