### PR TITLE
Improce Word Wrapping in Recording Table

### DIFF
--- a/app/assets/stylesheets/rooms.scss
+++ b/app/assets/stylesheets/rooms.scss
@@ -115,7 +115,7 @@
 }
 
 #recording-table .edit_hover_class {
-  word-break: break-all;
+  word-break: break-word;
   white-space: normal;
 }
 


### PR DESCRIPTION
Using `break-all` for word-wrapping in the recording table can cause
awkward word wrapping. Using `break-word` should mostly avoid that
while still ensuring that words too long to properly fit are wrapped.

---

Good example of awkward word wrapping by splitting the date in half:

![greenlight-rec-wrapping](https://user-images.githubusercontent.com/1008395/101065734-cb2c2800-3595-11eb-9761-b4a9095f0b77.png)
