### PR TITLE
update name on omniauth

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,7 +60,7 @@ class User < ApplicationRecord
       # Provider is the customer name if in loadbalanced config mode
       provider = auth['provider'] == "bn_launcher" ? auth['info']['customer'] : auth['provider']
       find_or_initialize_by(social_uid: auth['uid'], provider: provider).tap do |u|
-        u.name = auth_name(auth) unless u.name
+        u.name = auth_name(auth)
         u.username = auth_username(auth) unless u.username
         u.email = auth_email(auth)
         u.image = auth_image(auth) unless u.image


### PR DESCRIPTION
Currently the name is not updated when logging in, which is problematic if the name has changed in the LDAP.

The pull request solves the problem

fixes #2347