### PR TITLE
Being able to set colors from env file

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -140,13 +140,13 @@ module Greenlight
     config.branding_image_default = "https://raw.githubusercontent.com/bigbluebutton/greenlight/master/app/assets/images/logo_with_text.png"
 
     # Default primary color if the user does not specify one
-    config.primary_color_default = "#467fcf"
+    config.primary_color_default = ENV["PRIMARY_COLOR"].presence || "#467fcf"
 
     # Default primary color lighten if the user does not specify one
-    config.primary_color_lighten_default = "#e8eff9"
+    config.primary_color_lighten_default = ENV["PRIMARY_LIGHTEN_COLOR"].presence || "#e8eff9"
 
     # Default primary color darken if the user does not specify one
-    config.primary_color_darken_default = "#316cbe"
+    config.primary_color_darken_default = ENV["PRIMARY_DARKEN_COLOR"].presence || "#316cbe"
 
     # Default registration method if the user does not specify one
     config.registration_method_default = if ENV["DEFAULT_REGISTRATION"] == "invite"

--- a/sample.env
+++ b/sample.env
@@ -308,3 +308,15 @@ DEFAULT_REGISTRATION=open
 # For details, see: https://github.com/puma/puma#clustered-mode
 # Default: 1
 #WEB_CONCURRENCY=1
+
+# Default primary color if the user does not specify one
+# Default: #467fcf
+PRIMARY_COLOR="#467fcf"
+
+# Default primary color lighten if the user does not specify one
+# Default: #e8eff9
+PRIMARY_LIGHTEN_COLOR="#e8eff9"
+
+# Default primary color darken if the user does not specify one
+# Default: #316cbe
+PRIMARY_DARKEN_COLOR="#316cbe"


### PR DESCRIPTION
At the moment, we're doing experiments with automatic deployments of Greenlight.
We want to be able to give users the possibility to get into an immediately fully configured instance.

This will require us to be able to setup the coloring scheme as well from the env file.

The old/normal functions will not be impacted by this, as the value is only overwritten if it's present.