### PR TITLE
Use more recent ruby docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1-alpine AS base
+FROM ruby:2.5-alpine AS base
 
 # Set a variable for the install location.
 ARG RAILS_ROOT=/usr/src/app
@@ -36,7 +36,7 @@ RUN rm -rf tmp/cache spec
 
 ############### Build step done ###############
 
-FROM ruby:2.5.1-alpine
+FROM ruby:2.5-alpine
 
 # Set a variable for the install location.
 ARG RAILS_ROOT=/usr/src/app


### PR DESCRIPTION
The Dockerfile is currently pinned to Ruby 2.5.1, but the most recent patch release is 2.5.8. Docker deployments of greenlight might miss some important security fixes that way.

Gitlab CI/CD tests are actually run on `ruby:2.5` not `ruby:2.5.1-apline`. Tests and actual base image should be the same, if possible.