### PR TITLE
Increase Database pool size

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,5 @@
 default: &default
-  pool: 5
+  pool: 9
   timeout: 5000
 
 development:
@@ -21,3 +21,4 @@ production:
   database: <%= ENV['DB_NAME'] || 'db/production/production.sqlite3' %>
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
+  pool: <%= ENV['DB_POOL_SIZE'] || '9' %>

--- a/sample.env
+++ b/sample.env
@@ -267,6 +267,11 @@ ENABLE_SSL=true
 # DB_NAME=greenlight_production
 # DB_USERNAME=postgres
 # DB_PASSWORD=password
+# DB_POOL_SIZE=9
+#
+# DB_POOL_SIZE should be set to RAILS_MAX_THREADS + 4
+# The ActionCable-Workers require 4 connections.
+# Make sure your Database can handle the overall connection count calculated as follows: ( RAILS_MAX_THREADS + 4 ) * WEB_CONCURRENCY
 #
 # For deployments based on the docker-compose script also included, the HOST should be set with the Docker container id.
 #
@@ -276,6 +281,7 @@ DB_PORT=5432
 DB_NAME=greenlight_production
 DB_USERNAME=postgres
 DB_PASSWORD=password
+DB_POOL_SIZE=9
 
 # Use postgresql to handle ActionCable connections by default
 CABLE_ADAPTER=postgresql
@@ -314,6 +320,8 @@ DEFAULT_REGISTRATION=open
 # The size of the thread pool per worker used by Greenlight's web server.
 # For details, see: https://github.com/puma/puma#thread-pool
 # Default: 5
+#
+# If you change this value please correct the DB_POOL_SIZE to RAILS_MAX_THREADS + 4 (ActionCable-Workers)
 #RAILS_MAX_THREADS=5
 
 # The amount of workers (separate processes) used by the web server.


### PR DESCRIPTION
The required pool size is calculated by `RAILS_MAX_THREADS + #Action
Cable-Workers` (default: `5 + 4 = 9`)
The default pool size of 5 is to low for all required connections.
