### PR TITLE
Added undocumented parameter

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -335,3 +335,8 @@ DEFAULT_REGISTRATION=open
 # For details, see: https://github.com/puma/puma#clustered-mode
 # Default: 1
 #WEB_CONCURRENCY=1
+
+# Sets the footer of greenlight application with current build version.
+# Empty: hide version
+# Default: v2
+VERSION_CODE=v2


### PR DESCRIPTION
We found a undocumented parameter for the `.env` that we would like to share with the community. We are using the parameter for our external installation of greenlight. It's just a little bit hardning/security through obscurity.