### PR TITLE
Added parameter for log level

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -83,9 +83,6 @@ module Greenlight
       config.url_host = ENV['URL_HOST'] || ''
     end
 
-    # Specify the log level
-    config.log_level = ENV["RAILS_LOG_LEVEL"].present? ? ENV['RAILS_LOG_LEVEL'].to_sym : :debug
-
     # Specify the email address that all mail is sent from
     config.smtp_sender = ENV['SMTP_SENDER'] || "notifications@example.com"
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -84,7 +84,7 @@ module Greenlight
     end
 
     # Specify the log level
-    config.log_level = ENV["RAILS_LOG_LEVEL"].present? ? ENV['RAILS_LOG_LEVEL'].to_sym : :info
+    config.log_level = ENV["RAILS_LOG_LEVEL"].present? ? ENV['RAILS_LOG_LEVEL'].to_sym : :debug
 
     # Specify the email address that all mail is sent from
     config.smtp_sender = ENV['SMTP_SENDER'] || "notifications@example.com"

--- a/config/application.rb
+++ b/config/application.rb
@@ -84,7 +84,7 @@ module Greenlight
     end
 
     # Specify the log level
-    config.log_level = ENV['RAILS_LOG_LEVEL'].to_sym
+    config.log_level = ENV["RAILS_LOG_LEVEL"].present? ? ENV['RAILS_LOG_LEVEL'].to_sym : :info
 
     # Specify the email address that all mail is sent from
     config.smtp_sender = ENV['SMTP_SENDER'] || "notifications@example.com"

--- a/config/application.rb
+++ b/config/application.rb
@@ -83,6 +83,9 @@ module Greenlight
       config.url_host = ENV['URL_HOST'] || ''
     end
 
+    # Specify the log level
+    config.log_level = ENV['RAILS_LOG_LEVEL'].to_sym
+
     # Specify the email address that all mail is sent from
     config.smtp_sender = ENV['SMTP_SENDER'] || "notifications@example.com"
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -127,7 +127,7 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   # Specify the log level
-  config.log_level = ENV["RAILS_LOG_LEVEL"].present? ? ENV['RAILS_LOG_LEVEL'].to_sym : :debug
+  config.log_level = ENV["RAILS_LOG_LEVEL"].present? ? ENV['RAILS_LOG_LEVEL'].to_sym : :info
 
   # Use Lograge for logging
   config.lograge.enabled = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -126,6 +126,9 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
+  # Specify the log level
+  config.log_level = ENV["RAILS_LOG_LEVEL"].present? ? ENV['RAILS_LOG_LEVEL'].to_sym : :debug
+
   # Use Lograge for logging
   config.lograge.enabled = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -142,8 +142,6 @@ Rails.application.configure do
     "#{time} - #{severity}: #{msg} \n"
   end
 
-  config.log_level = :info
-
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 

--- a/sample.env
+++ b/sample.env
@@ -257,8 +257,9 @@ ENABLE_SSL=true
 # RAILS_LOG_REMOTE_TAG=greenlight
 
 # Specify the log level
+# Allowed values are: debug|info|warn|error|fatal|unknown
 # For details, see: https://docs.ruby-lang.org/en/master/Logger.html
-RAILS_LOG_LEVEL=info
+#RAILS_LOG_LEVEL=info
 
 # Database settings
 #

--- a/sample.env
+++ b/sample.env
@@ -256,6 +256,10 @@ ENABLE_SSL=true
 # RAILS_LOG_REMOTE_PORT=9999
 # RAILS_LOG_REMOTE_TAG=greenlight
 
+# Specify the log level
+# For details, see: https://docs.ruby-lang.org/en/master/Logger.html
+RAILS_LOG_LEVEL=info
+
 # Database settings
 #
 # Greenlight may work out of the box with sqlite3, but for production it is recommended to use postgresql.


### PR DESCRIPTION
Added the `RAILS_LOG_LEVEL` parameter to the `.env` file  to set a static log level. This "fixes" (or is a workaround) for the issue https://github.com/bigbluebutton/greenlight/issues/2421. 

I would maybe remove the possibility to "manipulate" the log level setting while the application is running. As it is already implemented with the other settings in relation to logging.