### PR TITLE
GRN2-362: Moved moderator access setting to Room Configuration

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -188,7 +188,7 @@ class ApplicationController < ActionController::Base
 
   # Indicates whether users are allowed to add moderator access codes to rooms
   def moderator_code_allowed?
-    @settings.get_value("Moderator Access Codes") == "true"
+    @settings.get_value("Room Configuration Moderator Access Codes") == "optional"
   end
   helper_method :moderator_code_allowed?
 

--- a/app/views/admins/components/_room_settings.html.erb
+++ b/app/views/admins/components/_room_settings.html.erb
@@ -124,5 +124,26 @@
       </div>
     </div>
   <% end %>
+  <div class="row">
+    <div class="col-12">
+      <div class="form-group">
+        <label class="form-label"><%= t("administrator.room_configuration.moderator_codes.title") %></label>
+        <label class="form-label text-muted"><%= t("administrator.room_configuration.moderator_codes.info") %></label>
+        <div class="dropdown">
+          <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= room_configuration_string("Room Configuration Moderator Access Codes") %>
+          </button>
+          <div class="dropdown-menu" aria-labelledby="room-auth">
+            <%= button_to admin_update_room_configuration_path(setting: "Room Configuration Moderator Access Codes", value: "optional"), class: "dropdown-item", "data-disable": "" do %>
+              <%= t("administrator.room_configuration.options.optional") %>            
+            <% end %>
+            <%= button_to admin_update_room_configuration_path(setting: "Room Configuration Moderator Access Codes", value: "disabled"), class: "dropdown-item", "data-disable": "" do %>
+              <%= t("administrator.room_configuration.options.disabled") %>   
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 
 </div>

--- a/app/views/admins/components/site_settings/_settings.html.erb
+++ b/app/views/admins/components/site_settings/_settings.html.erb
@@ -143,27 +143,6 @@
       </div>
     </div>
   </div>
-  <div class="row mb-2">
-    <div class="col-12">
-      <div class="form-group">
-        <label class="form-label"><%= t("administrator.site_settings.moderator_codes.title") %></label>
-        <label class="form-label text-muted"><%= t("administrator.site_settings.moderator_codes.info") %></label>
-        <div class="dropdown">
-          <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <%= moderator_codes_string %>
-          </button>
-          <div class="dropdown-menu" aria-labelledby="room-auth">
-            <%= button_to admin_update_settings_path(setting: "Moderator Access Codes", value: "true"), class: "dropdown-item", "data-disable": "" do %>
-              <%= t("administrator.site_settings.moderator_codes.enabled") %>
-            <% end %>
-            <%= button_to admin_update_settings_path(setting: "Moderator Access Codes", value: "false"), class: "dropdown-item", "data-disable": "" do %>
-              <%= t("administrator.site_settings.moderator_codes.disabled") %>
-            <% end %>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
   <div class="row">
     <div class="col-12">
       <div class="form-group">

--- a/config/application.rb
+++ b/config/application.rb
@@ -176,7 +176,7 @@ module Greenlight
     config.preupload_presentation_default = "false"
 
     # Don't show option to generate moderator access codes
-    config.moderator_codes_default = "false"
+    config.moderator_codes_default = "disabled"
 
     # Default admin password
     config.admin_password_default = ENV['ADMIN_PASSWORD'] || 'administrator'

--- a/config/locales/de_DE.yml
+++ b/config/locales/de_DE.yml
@@ -105,11 +105,6 @@ de_DE:
           approval: Zulassen/Ablehnen
           invite: Teilnahme durch Einladung
           open: Offene Registrierung
-      moderator_codes:
-        info: "Mit gültigen Moderatorencodes können Nutzerinnen einem Raum als Moderator beitreten, ohne sich vorher einen Account anzulegen und einzeln Zugriff zu erhalten. Die Einstellung kann für jeden Raum seperat getätigt werden."
-        title: Ermöglicht die Erstellung von Moderatorencodes
-        enabled: Aktiviert
-        disabled: Deaktiviert
       rooms:
         info: "Limitiert die Anzahl der Räume, die Nutzer einrichten können (inklusive des Startraums). Diese Einstellung wirkt sich nicht auf Administratoren aus."
         title: Anzahl der Räume pro Nutzer
@@ -395,9 +390,7 @@ de_DE:
       title: Neue Rolle erstellen
     create_room:
       access_code: Zugangscode
-      moderator_access_code: Moderatorencode
       access_code_placeholder: Generieren eines optionalen Raumzugangscodes
-      moderator_access_code_placeholder: Generieren eines optionalen Moderatorencodes
       auto_join: Automatisch dem Raum beitreten
       create: Raum erstellen
       free_delete: Sie können den Raum jederzeit wieder löschen.
@@ -550,7 +543,6 @@ de_DE:
     access_code_required: "Bitte geben Sie einen gültigen Zugangscode ein, um den Raum zu betreten"
     add_presentation: Präsentation hinzufügen
     copy_access: Zugangscode kopieren
-    copy_moderator_access: Moderatorcode kopieren
     create_room: Raum erstellen
     create_room_error: Bei der Erstellung des Raums ist ein Fehler aufgetreten
     create_room_success: Raum erfolgreich erstellt
@@ -559,8 +551,6 @@ de_DE:
       success: Raum erfolgreich gelöscht
       fail: "Raum konnte nicht gelöscht werden (%{error})"
     enter_the_access_code: Raumzugangscode bitte eingeben
-    enter_the_moderator_access_code: "Moderatorencode bitte eingeben!"
-    optional_moderator_access_code: "Optionaler Moderatorencode:"
     invalid_provider: "Sie haben eine ungültige URL eingegeben, bitte überprüfen Sie die URL und versuchen Sie es erneut."
     invitation_description: "Sie wurden zu %{name} über BigBlueButton zur Teilnahme eingeladen. Um beizutreten, klicken Sie auf den obigen Link und geben Sie Ihren Namen ein."
     invited: Sie wurden zur Teilnahme eingeladen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,11 +111,6 @@ en:
       shared_access:
         info: Setting to disabled will remove the button from the Room options dropdown, preventing users from sharing rooms
         title: Allow Users to Share Rooms
-      moderator_codes:
-        info: "With valid moderator codes, users can join a room as a moderator without having to create an account and receive access individually. The setting can be made separately for each room."
-        title: Enables the generation of moderator codes
-        enabled: Enabled
-        disabled: Disabled
       subtitle: Customize Greenlight
       tabs:
         appearance: Appearance
@@ -180,6 +175,9 @@ en:
         info: Gives all users moderator privileges in BigBlueButton when they join the meeting.
       recordings:
         info: Allows room owners to specify whether they want the option to record a room or not. If enabled, the moderator must still click the "Record" button once the meeting has started.
+      moderator_codes:
+        info: Allows room owners to optionally generate a moderator pin which allows other users to join directly as moderators.
+        title: Enables the generation of moderator codes
       options:
         disabled: Disabled
         enabled: Always Enabled

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -276,7 +276,8 @@ describe RoomsController, type: :controller do
     it "should use join name if user is not logged in and meeting running and moderator access code is enabled and set" do
       allow_any_instance_of(BigBlueButton::BigBlueButtonApi).to receive(:is_meeting_running?).and_return(true)
       allow_any_instance_of(Setting).to receive(:get_value).and_call_original
-      allow_any_instance_of(Setting).to receive(:get_value).with("Moderator Access Codes").and_return("true")
+      allow_any_instance_of(Setting).to receive(:get_value)
+        .with("Room Configuration Moderator Access Codes").and_return("optional")
 
       room = Room.new(name: "test", moderator_access_code: "abcdef")
       room.room_settings = "{ }"
@@ -416,7 +417,8 @@ describe RoomsController, type: :controller do
     it "should join the room as moderator if the user has the moderator_access code (and regular access code is not set)" do
       allow_any_instance_of(BigBlueButton::BigBlueButtonApi).to receive(:is_meeting_running?).and_return(true)
       allow_any_instance_of(Setting).to receive(:get_value).and_call_original
-      allow_any_instance_of(Setting).to receive(:get_value).with("Moderator Access Codes").and_return("true")
+      allow_any_instance_of(Setting).to receive(:get_value)
+        .with("Room Configuration Moderator Access Codes").and_return("optional")
 
       room = Room.new(name: "test", moderator_access_code: "abcdef")
       room.room_settings = "{ }"
@@ -431,7 +433,8 @@ describe RoomsController, type: :controller do
     it "should join the room as moderator if the user has the moderator_access code (and regular access code is set)" do
       allow_any_instance_of(BigBlueButton::BigBlueButtonApi).to receive(:is_meeting_running?).and_return(true)
       allow_any_instance_of(Setting).to receive(:get_value).and_call_original
-      allow_any_instance_of(Setting).to receive(:get_value).with("Moderator Access Codes").and_return("true")
+      allow_any_instance_of(Setting).to receive(:get_value)
+        .with("Room Configuration Moderator Access Codes").and_return("optional")
 
       room = Room.new(name: "test", access_code: "123456", moderator_access_code: "abcdef")
       room.room_settings = "{ }"
@@ -744,7 +747,8 @@ describe RoomsController, type: :controller do
 
     it "should redirect to show with valid moderator_access_code as regular access_code" do
       allow_any_instance_of(Setting).to receive(:get_value).and_call_original
-      allow_any_instance_of(Setting).to receive(:get_value).with("Moderator Access Codes").and_return("true")
+      allow_any_instance_of(Setting).to receive(:get_value)
+        .with("Room Configuration Moderator Access Codes").and_return("optional")
 
       @room.moderator_access_code = "abcdef"
       @room.save


### PR DESCRIPTION
@zechmeister I can't seem to be able to assign you as a reviewer, so I figured I would just tag you instead.

This MR does 2 things:
- Moves the setting for `Moderator Access Code` to `Room Configuration` instead of `Site Settings` since that's where all the room setting flippers are
- Removes the German translations that were added since Transfix will complain (and override them anyways)