### PR TITLE
Feat: Add user permission for recording

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -180,7 +180,7 @@ class ApplicationController < ActionController::Base
   end
   helper_method :shared_access_allowed
 
-  # Indicates whether users are allowed to share rooms
+  # Indicates whether users should consent recoding when joining rooms
   def recording_consent_required?
     @settings.get_value("Require Recording Consent") == "true"
   end

--- a/app/controllers/concerns/rolify.rb
+++ b/app/controllers/concerns/rolify.rb
@@ -120,7 +120,7 @@ module Rolify
     role_params = params.require(:role).permit(:name)
     permission_params = params.require(:role).permit(:can_create_rooms, :send_promoted_email,
       :send_demoted_email, :can_edit_site_settings, :can_edit_roles, :can_manage_users,
-      :can_manage_rooms_recordings, :can_appear_in_share_list, :colour)
+      :can_launch_recording, :can_manage_rooms_recordings, :can_appear_in_share_list, :colour)
 
     permission_params.transform_values! do |v|
       case v

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -431,11 +431,21 @@ class RoomsController < ApplicationController
   def record_meeting
     # If the require consent setting is checked, then check the room setting, else, set to true
     if recording_consent_required?
-      room_setting_with_config("recording")
+      room_setting_with_config("recording") && current_user&.role&.get_permission("can_launch_recording")
     else
-      true
+      current_user&.role&.get_permission("can_launch_recording")
     end
   end
+
+  def perm_to_record_meeting
+    # define perm without init config of room setting
+    if recording_consent_required?
+      @settings.get_value("Room Configuration Recording") != "disabled" && current_user&.role&.get_permission("can_launch_recording")
+    else
+      current_user&.role&.get_permission("can_launch_recording")
+    end
+  end
+  helper_method :perm_to_record_meeting
 
   # Checks if the file extension is allowed
   def valid_file_type

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -38,13 +38,13 @@ class Role < ApplicationRecord
     Role.create(name: "admin", provider: provider, priority: 0, colour: "#f1c40f")
         .update_all_role_permissions(can_create_rooms: true, send_promoted_email: true,
       send_demoted_email: true, can_edit_site_settings: true, can_manage_rooms_recordings: true,
-      can_edit_roles: true, can_manage_users: true)
+      can_launch_recording: true, can_edit_roles: true, can_manage_users: true)
     Role.create(name: "pending", provider: provider, priority: -1, colour: "#17a2b8").update_all_role_permissions
     Role.create(name: "denied", provider: provider, priority: -2, colour: "#343a40").update_all_role_permissions
     Role.create(name: "super_admin", provider: provider, priority: -3, colour: "#cd201f")
-        .update_all_role_permissions(can_create_rooms: true,
-      send_promoted_email: true, send_demoted_email: true, can_edit_site_settings: true,
-      can_edit_roles: true, can_manage_users: true, can_manage_rooms_recordings: true)
+        .update_all_role_permissions(can_create_rooms: true, send_promoted_email: true,
+      send_demoted_email: true, can_edit_site_settings: true, can_manage_rooms_recordings: true,
+      can_launch_recording: true, can_edit_roles: true, can_manage_users: true)
   end
 
   def self.create_new_role(role_name, provider)
@@ -72,6 +72,7 @@ class Role < ApplicationRecord
     update_permission("can_manage_users", permissions[:can_manage_users].to_s)
     update_permission("can_manage_rooms_recordings", permissions[:can_manage_rooms_recordings].to_s)
     update_permission("can_appear_in_share_list", permissions[:can_appear_in_share_list].to_s)
+    update_permission("can_launch_recording", permissions[:can_launch_recording].to_s)
   end
 
   # Updates the value of the permission and enables it

--- a/app/views/admins/components/_roles.html.erb
+++ b/app/views/admins/components/_roles.html.erb
@@ -20,8 +20,8 @@
         <div class="list-group list-group-transparent mb-0">
             <div id="rolesSelect" data-url="<%= admin_roles_order_path %>">
                 <% @roles.each do |role| %>
-                    <%= link_to admin_roles_path(selected_role: role.id), 
-                    class: "#{"sort-disabled" if role.name == "user" || role.name == "admin" || role.priority <= current_role.priority } dropdown-item list-group-item list-group-item-action #{"active" if @selected_role.id == role.id}", 
+                    <%= link_to admin_roles_path(selected_role: role.id),
+                    class: "#{"sort-disabled" if role.name == "user" || role.name == "admin" || role.priority <= current_role.priority } dropdown-item list-group-item list-group-item-action #{"active" if @selected_role.id == role.id}",
                     id: dom_id(role) do %>
                         <%= translated_role_name(role) %>
                     <% end %>
@@ -36,7 +36,7 @@
         <%= form_with model: @selected_role, url: admin_update_role_path(@selected_role.id), method: :post do |f| %>
             <%= f.label :name, t('administrator.roles.name'), class: "form-label" %>
             <%= f.text_field :name, class: 'form-control mb-3', value: translated_role_name(@selected_role), readonly: edit_disabled || @selected_role.name == "user" || @selected_role.name == "admin", required: true  %>
-            
+
             <%= f.hidden_field :colour, id: "role-colour", value: role_colour(@selected_role) %>
             <div class="form-group">
                 <label class="form-label"><%= t("administrator.roles.colour.title") %></label>
@@ -56,6 +56,11 @@
             <label class="custom-switch pl-0 mt-3 mb-3 w-100 text-left d-inline-block <%="form-disable" if !current_role.get_permission("can_manage_users") %>">
                 <span class="ml-0 custom-switch-description"><%= t("administrator.roles.manage_users")%></span>
                     <%= f.check_box :can_manage_users, checked: @selected_role.get_permission("can_manage_users"), class: "custom-switch-input", disabled: edit_disabled || !current_role.get_permission("can_manage_users") %>
+                <span class="custom-switch-indicator float-right"></span>
+            </label>
+            <label class="custom-switch pl-0 mt-3 mb-3 w-100 text-left d-inline-block <%="form-disable" if !current_role.get_permission("can_launch_recording") %>">
+                <span class="ml-0 custom-switch-description"><%= t("administrator.roles.can_launch_recording")%></span>
+                    <%= f.check_box :can_launch_recording, checked: @selected_role.get_permission("can_launch_recording"), class: "custom-switch-input", disabled: edit_disabled || !current_role.get_permission("can_launch_recording") %>
                 <span class="custom-switch-indicator float-right"></span>
             </label>
             <label class="custom-switch pl-0 mt-3 mb-3 w-100 text-left d-inline-block <%="form-disable" if !current_role.get_permission("can_manage_rooms_recordings") %>">

--- a/app/views/shared/modals/_create_room_modal.html.erb
+++ b/app/views/shared/modals/_create_room_modal.html.erb
@@ -73,7 +73,7 @@
                 <span class="custom-switch-indicator float-right cursor-pointer"></span>
               </label>
             <% end %>
-            
+
             <% any_start = room_configuration("Room Configuration Allow Any Start") %>
             <% if any_start != "disabled" %>
               <label class="custom-switch pl-0 mt-3 mb-3 w-100 text-left d-inline-block <%= "enabled-setting" if any_start == "enabled" %>">
@@ -91,7 +91,7 @@
               </label>
             <% end %>
             <% recording = room_configuration("Room Configuration Recording") %>
-            <% if recording_consent_required? && recording != "disabled" %>
+            <% if recording_consent_required? && recording != "disabled" && perm_to_record_meeting %>
               <label class="custom-switch pl-0 mt-3 mb-3 w-100 text-left d-inline-block <%= "enabled-setting" if recording == "enabled" %>">
                 <span class="custom-switch-description"><%= t("modal.room_settings.recording")%></span>
                 <%= f.check_box :recording, class: "not-running-only custom-switch-input", data: { default: recording == "enabled" }, checked: false %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,7 @@ en:
     roles:
       appear_in_share_list: Include users with this role in the dropdown for sharing rooms
       can_create_rooms: Can create rooms
+      can_launch_recording: Allow users with this role to launch recordings
       delete: Delete the role
       invalid_create: There was a problem creating a new role. Please check the role values and try again
       invalid_order: There was a problem updating the priority of the role. Please check the values and try again

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -145,6 +145,7 @@ fr:
     roles:
       appear_in_share_list: Inclure les utilisateurs ayant ce rôle dans la liste déroulante de partage des salons
       can_create_rooms: Peut créer des salles
+      can_launch_recording: Permet aux utilisateurs ayant ce rôle d'effectuer des enregistrements
       delete: Supprimer le rôle
       invalid_create: Il y a eu un problème lors de la création du nouveau rôle. Veuillez vérifier les valeurs entrées et réessayer.
       invalid_order: Il y a eu un problème lors de la mise à jour de la priorité du rôle. Veuillez vérifier les valeurs et réessayer.

--- a/db/migrate/20210319160827_add_can_launch_recording_to_permissions.rb
+++ b/db/migrate/20210319160827_add_can_launch_recording_to_permissions.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class MigrationProduct < ActiveRecord::Base
+  self.table_name = :roles
+end
+
+class SubMigrationProduct < ActiveRecord::Base
+  self.table_name = :role_permissions
+end
+
+class AddCanLaunchRecordingToPermissions < ActiveRecord::Migration[5.2]
+  def change
+    reversible do |dir|
+      dir.up do
+        MigrationProduct.all.each do |role|
+          SubMigrationProduct.create(role_id: role.id, name: "can_launch_recording", value: 'true', enabled: true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a role permission 'can_launch_record' to users to set the ability to run recording. By default everybody can record, but we can set to the user role without perm to record and create a new role for those who can.

solve issue #2568 

Please review my code before to watch if I forget something, it's the first time that I modify something around role_permissions and do a database change so I'm not totaly sure to do all needed things. But at least it's working for me.