### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ FROM ruby:2.7.2-alpine
 
 # Set a variable for the install location.
 ARG RAILS_ROOT=/usr/src/app
-ARG PACKAGES="tzdata curl postgresql-client sqlite-libs yarn nodejs bash"
+ARG PACKAGES="tzdata curl postgresql-client sqlite-libs yarn nodejs bash shared-mime-info"
 
 ENV RAILS_ENV=production
 ENV BUNDLE_APP_CONFIG="$RAILS_ROOT/.bundle"


### PR DESCRIPTION
--> https://github.com/bigbluebutton/greenlight/commit/1a625c70ade7a6bb4b7c73067fd3a1e6c6a281d9#r48758847

---

 mantridereso yesterday

I think it's necessary to add 'shared-mime-info' package at this position as well:

`
############### Build step done ###############

FROM ruby:2.7.2-alpine
Set a variable for the install location.

ARG RAILS_ROOT=/usr/src/app
ARG PACKAGES="tzdata curl postgresql-client sqlite-libs yarn nodejs bash shared-mime-info"

ENV RAILS_ENV=production
ENV BUNDLE_APP_CONFIG="$RAILS_ROOT/.bundle"
`
Otherwise presentation preupload fails, as /usr/share/mime/packages/freedesktop.org.xml isn't available in container.
@jfederico
jfederico yesterday Author Member

Yeah, that is right. The gem is passed but the dependency is still required