### PR TITLE
Fix newline/whitespace in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,4 +518,3 @@ DEPENDENCIES
   uglifier (~> 4.2.0)
   web-console (~> 3.7)
   webmock (~> 3.11)
-  


### PR DESCRIPTION
## Description
The new line with a whitespace at the end of Gemfile.lock leads to build error.
