### PR TITLE
Optimize space between icon and text in navigation

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -187,3 +187,7 @@ table {
 .btn i {
   transition: all .15s;
 }
+
+.nav-icon i {
+  width: 35px;
+}

--- a/app/views/admins/components/_menu_buttons.html.erb
+++ b/app/views/admins/components/_menu_buttons.html.erb
@@ -18,28 +18,28 @@
   <% highest_role.name %>
   <% if highest_role.get_permission("can_manage_users") || highest_role.name == "super_admin" %>
     <%= link_to admins_path, class: "list-group-item list-group-item-action dropdown-item #{"active" if active_page == "index"}" do %>
-      <span class="icon mr-3"><i class="fas fa-users"></i></span><%= t("administrator.users.title") %>
+      <span class="icon nav-icon"><i class="fas fa-users"></i></span><%= t("administrator.users.title") %>
     <% end %>
   <% end %>
   <% if highest_role.get_permission("can_manage_rooms_recordings") || highest_role.name == "super_admin" %>
     <%= link_to admin_rooms_path, class: "list-group-item list-group-item-action dropdown-item #{"active" if active_page == "server_rooms"}" do %>
-      <span class="icon mr-4"><i class="fas fa-binoculars"></i></span><%= t("administrator.rooms.title") %>
+      <span class="icon nav-icon"><i class="fas fa-binoculars"></i></span><%= t("administrator.rooms.title") %>
     <% end %>
     <%= link_to admin_recordings_path, class: "list-group-item list-group-item-action dropdown-item #{"active" if active_page == "server_recordings"}" do %>
-      <span class="icon mr-4"><i class="fas fa-video"></i></span><%= t("administrator.recordings.title") %>
+      <span class="icon nav-icon"><i class="fas fa-video"></i></span><%= t("administrator.recordings.title") %>
     <% end %>
   <% end %>
   <% if highest_role.get_permission("can_edit_site_settings") || highest_role.name == "super_admin" %>
     <%= link_to admin_site_settings_path, class: "list-group-item list-group-item-action dropdown-item #{"active" if active_page == "site_settings"}" do %>
-      <span class="icon mr-4"><i class="fas fa-cogs"></i></span><%= t("administrator.site_settings.title") %>
+      <span class="icon nav-icon"><i class="fas fa-cogs"></i></span><%= t("administrator.site_settings.title") %>
     <% end %>
     <%= link_to admin_room_configuration_path, class: "list-group-item list-group-item-action dropdown-item #{"active" if active_page == "room_configuration"}" do %>
-      <span class="icon mr-4"><i class="fas fa-sliders-h"></i></span><%= t("administrator.room_configuration.title") %>
+      <span class="icon nav-icon"><i class="fas fa-sliders-h"></i></span><%= t("administrator.room_configuration.title") %>
     <% end %>
   <% end %>
   <% if highest_role.get_permission("can_edit_roles")  || highest_role.name == "super_admin" %>
     <%= link_to admin_roles_path, class: "list-group-item list-group-item-action dropdown-item #{"active" if active_page == "roles"}" do %>
-      <span class="icon mr-4"><i class="fas fa-user-tag"></i></span><%= t("administrator.roles.title") %>
+      <span class="icon nav-icon"><i class="fas fa-user-tag"></i></span><%= t("administrator.roles.title") %>
     <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
## Description
The navigation in the admin interface shows not a straight line between icons and text. I have removed the mr-3 and mr-4 classes and added a new rule to set the same width to the awesome icons. Now the navigation looks cleaner

Maybe someone can test it, because I can't test it. I have no dev installation.

![image](https://user-images.githubusercontent.com/1473674/115118071-d6f71480-9fa1-11eb-91e9-b491db8bf63d.png)
