### PR TITLE
Room owner option: authentication is required to join a room 

### DIFF
--- a/app/assets/javascripts/room.js
+++ b/app/assets/javascripts/room.js
@@ -214,6 +214,7 @@ function showCreateRoom(target) {
   $("#room_anyone_can_start").prop("checked", $("#room_anyone_can_start").data("default"))
   $("#room_all_join_moderator").prop("checked", $("#room_all_join_moderator").data("default"))
   $("#room_recording").prop("checked", $("#room_recording").data("default"))
+  $("#room_require_authentication_to_join").prop("checked", $("#room_require_authentication_to_join").data("default"))
 
   //show all elements & their children with a create-only class
   $(".create-only").each(function() {
@@ -284,6 +285,7 @@ function updateCurrentSettings(settings_path){
     $("#room_anyone_can_start").prop("checked", $("#room_anyone_can_start").data("default") || settings.anyoneCanStart)
     $("#room_all_join_moderator").prop("checked", $("#room_all_join_moderator").data("default") || settings.joinModerator)
     $("#room_recording").prop("checked", $("#room_recording").data("default") || Boolean(settings.recording))
+    $("#room_require_authentication_to_join").prop("checked", $("#room_require_authentication_to_join").data("default") || settings.requireAuthenticationToJoin)
   })
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -192,6 +192,18 @@ class ApplicationController < ActionController::Base
   end
   helper_method :moderator_code_allowed?
 
+  # Shows global setting "authentication is required to access rooms"
+  def global_room_authentication_required?
+    @settings.get_value("Room Authentication") == "true"
+  end
+  helper_method :global_room_authentication_required?
+
+  # Indicates whether users are allowed to require authentication to join rooms
+  def room_require_authentication_allowed?
+    @settings.get_value("Room Configuration Require Authentication To Join") == "optional"
+  end
+  helper_method :room_require_authentication_allowed?
+  
   # Returns a list of allowed file types
   def allowed_file_types
     Rails.configuration.allowed_file_types

--- a/app/controllers/concerns/joiner.rb
+++ b/app/controllers/concerns/joiner.rb
@@ -58,6 +58,7 @@ module Joiner
       opts[:record] = record_meeting
       opts[:require_moderator_approval] = room_setting_with_config("requireModeratorApproval")
       opts[:mute_on_start] = room_setting_with_config("muteOnStart")
+      opts[:require_authentication_to_join] = room_setting_with_config("requireAuthenticationToJoin")
 
       if current_user
         redirect_to join_path(@room, current_user.name, opts, current_user.uid)

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -180,6 +180,7 @@ class RoomsController < ApplicationController
     opts[:mute_on_start] = room_setting_with_config("muteOnStart")
     opts[:require_moderator_approval] = room_setting_with_config("requireModeratorApproval")
     opts[:record] = record_meeting
+    opts[:require_authentication_to_join] = room_setting_with_config("requireAuthenticationToJoin")
 
     begin
       redirect_to join_path(@room, current_user.name, opts, current_user.uid)
@@ -451,6 +452,7 @@ class RoomsController < ApplicationController
 
   # Gets the room setting based on the option set in the room configuration
   def room_setting_with_config(name)
+    @room_settings = JSON.parse(@room[:room_settings])
     config = case name
     when "muteOnStart"
       "Room Configuration Mute On Join"

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -106,7 +106,7 @@ class RoomsController < ApplicationController
   # POST /:room_uid
   def join
     return redirect_to root_path,
-      flash: { alert: I18n.t("administrator.site_settings.authentication.user-info") } if auth_required
+      flash: { alert: I18n.t("administrator.site_settings.authentication.user-info") } if auth_required || room_setting_with_config("requireAuthenticationToJoin")
 
     @shared_room = room_shared_with_user
 
@@ -353,6 +353,7 @@ class RoomsController < ApplicationController
       anyoneCanStart: options[:anyone_can_start] == "1",
       joinModerator: options[:all_join_moderator] == "1",
       recording: options[:recording] == "1",
+      requireAuthenticationToJoin: options[:require_authentication_to_join] == "1"
     }
 
     room_settings.to_json
@@ -361,7 +362,7 @@ class RoomsController < ApplicationController
   def room_params
     params.require(:room).permit(:name, :auto_join, :mute_on_join, :access_code,
       :require_moderator_approval, :anyone_can_start, :all_join_moderator,
-      :recording, :presentation, :moderator_access_code)
+      :recording, :presentation, :moderator_access_code, :require_authentication_to_join)
   end
 
   # Find the room from the uid.
@@ -461,6 +462,8 @@ class RoomsController < ApplicationController
       "Room Configuration Allow Any Start"
     when "recording"
       "Room Configuration Recording"
+    when "requireAuthenticationToJoin"
+      "Room Configuration Require Authentication To Join"
     end
 
     case @settings.get_value(config)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -78,6 +78,8 @@ class Setting < ApplicationRecord
       room_config_setting("all-join-moderator")
     when "Room Configuration Recording"
       room_config_setting("recording")
+    when "Room Configuration Require Authentication To Join"
+      room_config_setting("require-authentication-to-join")
     end
   end
 

--- a/app/views/admins/components/_room_settings.html.erb
+++ b/app/views/admins/components/_room_settings.html.erb
@@ -124,7 +124,7 @@
       </div>
     </div>
   <% end %>
-  <div class="row">
+  <div class="mb-6 row">
     <div class="col-12">
       <div class="form-group">
         <label class="form-label"><%= t("administrator.room_configuration.moderator_codes.title") %></label>
@@ -145,5 +145,31 @@
       </div>
     </div>
   </div>
+  <% if !global_room_authentication_required? %>
+    <div class="row">
+      <div class="col-12">
+      <div class="form-group">
+          <label class="form-label"><%= t("modal.room_settings.require_authentication") %></label>
+          <label class="form-label text-muted"><%= t("administrator.room_configuration.require_authentication.info") %></label>
+          <div class="dropdown">
+            <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <%= room_configuration_string("Room Configuration Require Authentication To Join") %>
+            </button>
+            <div class="dropdown-menu">
+              <%= button_to admin_update_room_configuration_path(setting: "Room Configuration Require Authentication To Join", value: "enabled"), class: "dropdown-item", "data-disable": "" do %>
+                <%= t("administrator.room_configuration.options.enabled") %>
+              <% end %>
+              <%= button_to admin_update_room_configuration_path(setting: "Room Configuration Require Authentication To Join", value: "optional"), class: "dropdown-item", "data-disable": "" do %>
+                <%= t("administrator.room_configuration.options.optional") %>
+              <% end %>
+              <%= button_to admin_update_room_configuration_path(setting: "Room Configuration Require Authentication To Join", value: "disabled"), class: "dropdown-item", "data-disable": "" do %>
+                <%= t("administrator.room_configuration.options.disabled") %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
 
 </div>

--- a/app/views/shared/modals/_create_room_modal.html.erb
+++ b/app/views/shared/modals/_create_room_modal.html.erb
@@ -98,6 +98,14 @@
                 <span class="custom-switch-indicator not-running-only float-right cursor-pointer"></span>
             </label>
             <% end %>
+            <% global_room_auth = room_configuration("Room Configuration Require Authentication To Join") %>
+            <% if global_room_auth != "disabled" && room_require_authentication_allowed?%>
+              <label class="custom-switch pl-0 mt-3 mb-3 w-100 text-left d-inline-block">
+                <span class="custom-switch-description"><%= t("modal.room_settings.require_authentication")%></span>
+                <%= f.check_box :require_authentication_to_join, class: "not-running-only custom-switch-input", data: { default: false }, checked: false %>
+                <span class="custom-switch-indicator not-running-only float-right cursor-pointer"></span>
+              </label>
+            <% end %>
             <label id="auto-join-label" class="create-only custom-switch pl-0 mt-3 mb-3 w-100 text-left d-inline-block">
               <span class="custom-switch-description"><%= t("modal.create_room.auto_join") %></span>
               <%= f.check_box :auto_join, class: "custom-switch-input", checked: false %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -178,6 +178,9 @@ module Greenlight
     # Don't show option to generate moderator access codes
     config.moderator_codes_default = "disabled"
 
+    # Don't require authentication to join rooms by default
+    config.require_authentication_to_join = "false"
+
     # Default admin password
     config.admin_password_default = ENV['ADMIN_PASSWORD'] || 'administrator'
   end

--- a/config/locales/de_DE.yml
+++ b/config/locales/de_DE.yml
@@ -34,8 +34,8 @@ de_DE:
       authentication:
         disabled: Deaktiviert
         enabled: Aktiviert
-        info: Nur authentifizierte Nutzer dürfen diesen Raum betreten
-        title: Betreten des Raums erfordert Authentifizierung
+        info: Nur authentifizierte Nutzer dürfen einem Raum betreten
+        title: Betreten eines Raums erfordert Authentifizierung
         user-info: "Sie müssen sich oben anmelden, um diesem Raum beitreten zu können."
       branding:
         change: Bild ändern
@@ -178,6 +178,9 @@ de_DE:
       moderator_codes:
         info: "Ermöglicht es Rauminitiatoren, optional einen Moderatoren-PIN zu generieren, der es anderen Teilnehmern ermöglicht, direkt als Moderator beizutreten."
         title: Moderatoren-Zugangscode
+      require_authentication:
+        title: Benutzeranmeldung erforderlich
+        info: Ermöglicht Rauminitiatoren festzulegen, ob sich Benutzer authentifizieren müssen, bevor sie einen bestimmten Raum betreten können. Standardmäßig ist keine Authentifizierung erforderlich.
       options:
         disabled: Deaktiviert
         enabled: Immer aktiviert
@@ -452,6 +455,7 @@ de_DE:
       start: Jeder Teilnehmer kann die Konferenz starten
       footer_text: Anpassungen des Raums können jederzeit vorgenommen werden.
       recording: Aufnahme des Raumes erlauben
+      require_authentication: Benutzeranmeldung erforderlich bevor der Raum betreten werden kann
     rename_room:
       name_placeholder: Neuen Raumnamen eingeben...
     share_access:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,6 +178,9 @@ en:
       moderator_codes:
         info: Allows room owners to optionally generate a moderator pin which allows other users to join directly as moderators.
         title: Moderator Access Code
+      require_authentication:
+        title: Require Authentication before joining
+        info: Allow room owners to require authentication before a user can join a specific room. By default authentication is not required.
       options:
         disabled: Disabled
         enabled: Always Enabled
@@ -453,6 +456,7 @@ en:
       start: Allow any user to start this meeting
       footer_text: Adjustment to your room can be done at anytime.
       recording: Allow room to be recorded
+      require_authentication: Require authentication before joining
     rename_room:
       name_placeholder: Enter a new room name...
     share_access:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,10 @@ version: '3'
 services:
   app:
     entrypoint: [bin/start]
-    image: bigbluebutton/greenlight:v2
-    container_name: greenlight-v2
+    #    image: bigbluebutton/greenlight:v2
+    #container_name: greenlight-v2
+    image: greenlight:v3
+    container_name: greenlight-v3
     env_file: .env
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,8 @@ version: '3'
 services:
   app:
     entrypoint: [bin/start]
-    #    image: bigbluebutton/greenlight:v2
-    #container_name: greenlight-v2
-    image: greenlight:v3
-    container_name: greenlight-v3
+    image: bigbluebutton/greenlight:v2
+    container_name: greenlight-v2
     env_file: .env
     restart: unless-stopped
     ports:

--- a/sample.env
+++ b/sample.env
@@ -176,7 +176,8 @@ RELATIVE_URL_ROOT=/b
 #   anyone-can-start: Allows anyone with the join url to start the room in BigBlueButton
 #   all-join-moderator: All users join as moderators in BigBlueButton
 #   recording: Sessions are recorded
-ROOM_FEATURES=mute-on-join,require-moderator-approval,anyone-can-start,all-join-moderator,recording
+#   require-authentication-to-join: Require authentication to join a specific room
+ROOM_FEATURES=mute-on-join,require-moderator-approval,anyone-can-start,all-join-moderator,recording,require-authentication-to-join
 
 # Specify the maximum number of records to be sent to the BigBlueButton API in one call
 # Default is set to 25 records


### PR DESCRIPTION
## Description
Added a new room option which allows room owners to configure if authentication is required before a specific room can be joined. Clarified german translation to reflect distinction between settings for all rooms of a gl instance and single rooms.

Organization - Site Settings - Settings - Require Authentication for Rooms
enabled: options in room settings and global room configuration disappear
disabled: option in room settings is configurable (see below)

Organization - Room Configuration - Require authentication before joining
enabled: has the same effect as setting "Require Authentication for Rooms" to enabled
optional: room owners are able to configure this setting
disabled: room owners are not able to configure this setting, disabled for all rooms

## Testing Steps
add require-authentication-to-join to ROOM_FEATURES in .env
restart greenlight

## Screenshots
![room_auth_1](https://user-images.githubusercontent.com/82868455/117446675-b4bb3b80-af3c-11eb-89c0-f5e4122b7c4f.png)
![room_auth_2](https://user-images.githubusercontent.com/82868455/117446677-b553d200-af3c-11eb-8ce2-569b6b3080e0.png)
