### PR TITLE
Fix error with missing last session

### DIFF
--- a/app/controllers/concerns/bbb_server.rb
+++ b/app/controllers/concerns/bbb_server.rb
@@ -54,7 +54,7 @@ module BbbServer
     join_opts = {}
     join_opts[:userID] = uid if uid
     join_opts[:join_via_html5] = true
-    join_opts[:createTime] = room.last_session.to_datetime.strftime("%Q")
+    join_opts[:createTime] = room.last_session.to_datetime.strftime("%Q") if room.last_session
 
     bbb_server.join_meeting_url(room.bbb_id, name, password, join_opts)
   end


### PR DESCRIPTION
In some cases when you create a new room there is a missing last session. This throws an error. This check fixes that error.

## Description
Fixes some random issues when a new room is created and you attempt to start a meeting you get a 500 error.

## Testing Steps
Initialize Greenlight and login. Try to start a room, it gives a 500 error. It seems that Greenlight thinks that the room is already running because the backed reports a duplicate meeting and tries to initialize a create time from a previous session which does not exist. This simply add a check for a previous session actually existing so it avoids this issue of giving a 500 error when the backend is working fine.

