### PR TITLE
fix current user being nil on delete account page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -79,6 +79,7 @@ class UsersController < ApplicationController
 
   # GET /u/:user_uid/delete_account
   def delete_account
+    redirect_to signin_path unless current_user
   end
 
   # POST /u/:user_uid/edit


### PR DESCRIPTION
Trying opening the page like: https://demo.bigbluebutton.org/gl/u/gl-{id}/delete_account, without signing,
will show 500 error. This PR will redirect the user to the sign page instead of showing the 500 error page.
