### PR TITLE
Accessibility fix generate access code

### DIFF
--- a/app/assets/javascripts/room.js
+++ b/app/assets/javascripts/room.js
@@ -50,6 +50,9 @@ $(document).on('turbolinks:load', function(){
       showDeleteRoom(this)
     })
 
+    // For keyboard users to be able to generate access code
+    generateAccessCodeAccessibility()
+
     $('.selectpicker').selectpicker({
       liveSearchPlaceholder: getLocalizedString('javascript.search.start')
     });
@@ -429,4 +432,36 @@ function filterRooms() {
 function clearRoomSearch() {
   $('#room-search').val(''); 
   filterRooms()
+}
+
+function generateAccessCodeAccessibility() {
+  // For keyboard users to be able to generate access code
+  $("#generate-room-access-code").keyup(function(event) {
+    if (event.keyCode === 13 || event.keyCode === 32) {
+        generateAccessCode();
+    }
+  })
+
+  // For keyboard users to be able to reset access code
+  $("#reset-access-code").keyup(function(event) {
+    if (event.keyCode === 13 || event.keyCode === 32) {
+        ResetAccessCode();
+    }
+  })
+
+  // For keyboard users to be able to generate access code
+  // for moderator
+  $("#generate-moderator-room-access-code").keyup(function(event) {
+    if (event.keyCode === 13 || event.keyCode === 32) {
+        generateModeratorAccessCode();
+    }
+  })
+
+  // For keyboard users to be able to reset access code
+  // for moderator
+  $("#reset-moderator-access-code").keyup(function(event) {
+    if (event.keyCode === 13 || event.keyCode === 32) {
+        ResetModeratorAccessCode();
+    }
+  })
 }

--- a/app/views/shared/modals/_create_room_modal.html.erb
+++ b/app/views/shared/modals/_create_room_modal.html.erb
@@ -33,24 +33,24 @@
             </div>
 
             <div class="input-icon mb-2">
-              <span onclick="generateAccessCode()" class="input-icon-addon allow-icon-click cursor-pointer">
+              <span onclick="generateAccessCode()" class="input-icon-addon allow-icon-click cursor-pointer" id="generate-room-access-code" tabindex="0" aria-label='<%= t("modal.create_room.access_code_placeholder") %>'>
                 <i class="fas fa-dice"></i>
               </span>
-              <%= f.label :access_code, t("modal.create_room.access_code_placeholder"), id: "create-room-access-code", class: "form-control" %>
+              <%= f.label :access_code, t("modal.create_room.access_code_placeholder"), id: "create-room-access-code", class: "form-control", role: "log" %>
               <%= f.hidden_field :access_code %>
-              <span onclick="ResetAccessCode()" class="input-icon-addon allow-icon-click cursor-pointer">
+              <span onclick="ResetAccessCode()" class="input-icon-addon allow-icon-click cursor-pointer" id="reset-access-code" tabindex="0" aria-label='<%= t("modal.create_room.reset_access_code") %>' >
                 <i class="far fa-trash-alt"></i>
               </span>
             </div>
 
             <% if moderator_code_allowed? %>
               <div class="input-icon mb-2">
-                <span onclick="generateModeratorAccessCode()" class="input-icon-addon allow-icon-click cursor-pointer">
+                <span onclick="generateModeratorAccessCode()" class="input-icon-addon allow-icon-click cursor-pointer" id="generate-moderator-room-access-code" tabindex="0" aria-label='<%= t("modal.create_room.moderator_access_code_placeholder") %>'>
                   <i class="fas fa-dice"></i>
                 </span>
-                <%= f.label :moderator_access_code, t("modal.create_room.moderator_access_code_placeholder"), id: "create-room-moderator-access-code", class: "form-control" %>
+                <%= f.label :moderator_access_code, t("modal.create_room.moderator_access_code_placeholder"), id: "create-room-moderator-access-code", class: "form-control", role: "log" %>
                 <%= f.hidden_field :moderator_access_code %>
-                <span onclick="ResetModeratorAccessCode()" class="input-icon-addon allow-icon-click cursor-pointer">
+                <span onclick="ResetModeratorAccessCode()" class="input-icon-addon allow-icon-click cursor-pointer" id="reset-moderator-access-code" tabindex="0" aria-label='<%= t("modal.create_room.reset_moderator_access_code") %>'>
                   <i class="far fa-trash-alt"></i>
                 </span>
               </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -401,7 +401,9 @@ en:
       access_code: Access Code
       moderator_access_code: Moderator Code
       access_code_placeholder: Generate an optional room access code
+      reset_access_code: Reset the optional room access code
       moderator_access_code_placeholder: Generate an optional code for moderators
+      reset_moderator_access_code: Reset the optional code for moderators
       auto_join: Automatically join me into the room
       create: Create Room
       free_delete: You will be free to delete this room at any time.


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->
This PR should enable keyboard users to be able to generate or reset access codes. It also enable users with visual impairment to know what the generated code is.

## Description
<!--- Describe your changes in detail -->
The changes on this PR are as follows:
1. The dice icon on room settings to generate access code is accessible by keyboard, so the user is able to use tabs to go the icon and can use space or enter to generate the access code
2. The trash icon also accessible by the keyboard user, user can use tabs to access the icon and can use space or enter to reset / disable the access code
3. Also add some aria label on the icons so screen reader can see it
4. also make the generated code notified by screen reader.
5. Implement above also for the moderator code

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
To test this:
1. Go to home page, select any room and go to room settings
2. After the modal pop up, users should be able to go to generate access code icon / button by using only tabs / keyboard.
3. User also can go to the trash icon / button to remove the access code
4. Users can use enter / space to press the button / icon
5. Those steps also applied for the moderator code

## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
Not much changes on UI, but the buttons / icon should be able to be selected by only using keyboard
![Screenshot from 2021-06-15 11-57-53](https://user-images.githubusercontent.com/29434066/121973348-2787c400-cdd1-11eb-9b9b-44fa56dd76b6.png)
![Screenshot from 2021-06-15 11-57-42](https://user-images.githubusercontent.com/29434066/121973351-28b8f100-cdd1-11eb-9c2f-2788e3360189.png)
