### PR TITLE
Show access code in welcome message

### DIFF
--- a/app/controllers/concerns/joiner.rb
+++ b/app/controllers/concerns/joiner.rb
@@ -84,10 +84,8 @@ module Joiner
 
   # Default, unconfigured meeting options.
   def default_meeting_options
-    invite_msg = I18n.t("invite_message")
-    access_code_msg = I18n.t("modal.create_room.access_code")
-    moderator_message = "#{invite_msg}<br> #{request.base_url + room_path(@room)}"
-    moderator_message += "<br> #{access_code_msg}: #{@room.access_code}" unless @room.access_code.blank?
+    moderator_message = "#{I18n.t('invite_message')}<br> #{request.base_url + room_path(@room)}"
+    moderator_message += "<br> #{I18n.t('modal.create_room.access_code')}: #{@room.access_code}" if @room.access_code.present?
     {
       user_is_moderator: false,
       meeting_logout_url: request.base_url + logout_room_path(@room),

--- a/app/controllers/concerns/joiner.rb
+++ b/app/controllers/concerns/joiner.rb
@@ -85,10 +85,13 @@ module Joiner
   # Default, unconfigured meeting options.
   def default_meeting_options
     invite_msg = I18n.t("invite_message")
+    access_code_msg = I18n.t("modal.create_room.access_code")
+    moderator_message = "#{invite_msg}<br> #{request.base_url + room_path(@room)}"
+    moderator_message += "<br> #{access_code_msg}: #{@room.access_code}" unless @room.access_code.blank?
     {
       user_is_moderator: false,
       meeting_logout_url: request.base_url + logout_room_path(@room),
-      moderator_message: "#{invite_msg}<br> #{request.base_url + room_path(@room)}",
+      moderator_message: moderator_message,
       host: request.host,
       recording_default_visibility: @settings.get_value("Default Recording Visibility") == "public"
     }

--- a/spec/concerns/joiner_spec.rb
+++ b/spec/concerns/joiner_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+#
+# Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+#
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free Software
+# Foundation; either version 3.0 of the License, or (at your option) any later
+# version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+
+require "rails_helper"
+
+describe Joiner do
+  let(:controller) { FakesController.new }
+
+  before do
+    class FakesController < ApplicationController
+      include Joiner
+      def init(room)
+        @room = room
+        @settings = Setting.all
+      end
+    end
+    @user = create(:user)
+    @room = @user.main_room
+    @room.uid = 'xxxx'
+    controller.init @room
+    controller.request = ActionController::TestRequest.create(FakesController)
+  end
+
+  after do
+    Object.send :remove_const, :FakesController
+  end
+
+  it "should properly configure moderator message with nil access code" do
+    expect(controller.default_meeting_options[:moderator_message]).not_to include('Access Code:')
+  end
+
+  it "should properly configure moderator message with empty access code" do
+    @room.access_code = ""
+    expect(controller.default_meeting_options[:moderator_message]).not_to include('Access Code:')
+  end
+
+  it "should properly configure moderator message with access code" do
+    @room.access_code = "1234"
+    expect(controller.default_meeting_options).to include(moderator_message: include('Access Code: 1234'))
+  end
+end


### PR DESCRIPTION

Currently, in a call, the moderator is shown a link to the room that can be shared with others. however, if there is a Access Code set on the room, this is not shown and the only way to retrieve it is to leave the call.

This enhancement will display for the moderator the Access Code (if set) underneath the room link.

## Description

Modified default_meeting_options to add room access code in the moderator_message.

## Testing Steps

- Confirmed Access code was shown in moderator message in the chat of BBB when it was set
- Confirmed Access code label wasn't shown in moderator message in the chat when access code was not set
- Confirmed Access code label wasn't shown in moderator message in the chat when access code was nil

## Screenshots (if appropriate):

![accesscode](https://user-images.githubusercontent.com/4747270/123738821-a1ec3400-d8f9-11eb-8531-05e407525bcb.png)
