### PR TITLE
[fix] avoid printing %{inject} when no_recordings are available

### DIFF
--- a/app/views/shared/_sessions.html.erb
+++ b/app/views/shared/_sessions.html.erb
@@ -86,7 +86,7 @@
                       <% if user_recordings %>
                         <%= t("recording.no_user_recordings") %>
                       <% else %>
-                        <%= only_public ? t("recording.no_public_recordings") : t("recording.no_recordings") %>
+                        <%= only_public ? t("recording.no_public_recordings") : t("recording.no_recordings", inject: "") %>
                       <% end %>
                     </td>
                   </tr>


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Only added a 'inject: ' to the printing function used, as I had one client noting that we were printing '%{inject}' when a room had no recordings.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
Launch greenlight,
log in and go to the homepage, with browser configured to be in French.
when showing a room with norecording, you should not have '%{inject}' displayed anymore


## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
![Screenshot_20210629_154814](https://user-images.githubusercontent.com/17310666/123808974-811fe080-d8f1-11eb-99b0-797a13bc5b42.png)
