### PR TITLE
Update bundle commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ COPY Gemfile* ./
 COPY Gemfile Gemfile.lock $RAILS_ROOT/
 
 RUN bundle config --global frozen 1 \
-    && bundle install --deployment --without development:test:assets -j4 --path=vendor/bundle \
+    && bundle config set deployment 'true' \
+    && bundle config set without 'development:test:assets' \
+    && bundle install -j4 --path=vendor/bundle \
     && rm -rf vendor/bundle/ruby/2.7.0/cache/*.gem \
     && find vendor/bundle/ruby/2.7.0/gems/ -name "*.c" -delete \
     && find vendor/bundle/ruby/2.7.0/gems/ -name "*.o" -delete


### PR DESCRIPTION
Stop using deprecated commands

<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
When running the current docker file, one gets
```bash
Step 13/27 : RUN bundle config --global frozen 1     && bundle install --deployment --without development:test:assets -j4 --path=vendor/bundle     && rm -rf vendor/bundle/ruby/2.7.0/cache/*.gem     && find vendor/bundle/ruby/2.7.0/gems/ -name "*.c" -delete     && find vendor/bundle/ruby/2.7.0/gems/ -name "*.o" -delete
 ---> Running in e4421a2aeb91
[DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set deployment 'true'`, and stop using this flag                                                                      
[DEPRECATED] The `--without` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set without 'development:test:assets'`, and stop using this flag
```
so change
```bash
&& bundle install --deployment --without development:test:assets -j4 --path=vendor/bundle \
```
to
```bash
&& bundle config set deployment 'true' \
&& bundle config set without 'development:test:assets' \
&& bundle install -j4 --path=vendor/bundle \
```

## Testing Steps
Run 


