### PR TITLE
Avatar URL check - controlling response code

### DIFF
--- a/app/controllers/concerns/joiner.rb
+++ b/app/controllers/concerns/joiner.rb
@@ -53,6 +53,7 @@ module Joiner
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.scheme == 'https'
     response = http.request_head(uri)
+    return false if response.code != "200"
     return response['content-length'].to_i < Rails.configuration.max_avatar_size
   end
 


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change fixes a "broken image icon" shown in BBB as an avatar when the URL turns out to be unreachable. 

## Testing Steps
1. Put a truncated URL in the user profile pic, simulating the situation where the image in the Internet has been deleted.
2. Start BBB meeting, and you will see the "broken image icon" as the avatar. We may want the default alphabet icon in this case.
3. With this PR, BBB shows the default avatar with the starting two letters of your account name

