### PR TITLE
GRN2-397: fix(httpclient): updates certificate authorities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,5 +66,9 @@ ENV VERSION_CODE=$version_code
 # Set executable permission to start file
 RUN chmod +x bin/start
 
+# FIXME / to remove / https://github.com/nahi/httpclient/issues/445
+RUN cat /etc/ssl/certs/ca-certificates.crt \
+    >/usr/src/app/vendor/bundle/ruby/2.7.0/gems/httpclient-2.8.3/lib/httpclient/cacert.pem
+
 # Start the application.
 CMD ["bin/start"]


### PR DESCRIPTION

## Description

As reported here: nahi/httpclient#445
The httpclient gem comes with quite an old list of trusted certificate authorities.

As of today, we are seeing Greenlight failing to query some OIDC server, complaining about our LetsEncrypt certificate being invalid -- while a curl, from our Greenlight container, suggests there is no such issue with our certificate.

Thanks to @maxbes that figured it out.
Here's a patch that might help.

Obviously, it would be better to fix the httpclient library directly ( see nahi/httpclient#446 )
In doubt, I'm leaving this one too. Best case, httpclient would have been updated soon. Otherwise, we know of another way ...

## Testing Steps

Nothing specific / no change in Ruby code. Just make sure the image starts.

## Screenshots (if appropriate):

N/A