### PR TITLE
Keep PostgresSQL up to date (version 13.X)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     links:
       - db
   db:
-    image: postgres:13.2-alpine
+    image: postgres:13-alpine
     restart: unless-stopped
     ports:
       - 127.0.0.1:5432:5432


### PR DESCRIPTION
This PR fixes https://github.com/bigbluebutton/greenlight/issues/2962 to keep the docker container of the database server up to date (of 13.X). For the migration to the current version is no dump/restore required if already running a 13.X else a dump/restore/[upgrade](https://docs.bigbluebutton.org/greenlight/gl-config.html#upgrading-postgresql-versions) would be needed.

## Description
Changed the tag/version `13.2-alpine` to `13-alpine` in `docker-compose.yml` (line 27).

## Testing Steps
Running the new image with postgressql version 13.4 over a week with no problems - as also expected from migration notice of postgressql.