### PR TITLE
Update .gitlab-ci.yml: Use vendor/bundle as Bundler install location

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,10 +3,6 @@ stages:
   - build
   - deploy
 
-cache:
-  paths:
-    - /cache
-
 before_script:
 
 test:
@@ -14,9 +10,13 @@ test:
   image: ruby:2.5
   script:
   - apt-get update -qq && apt-get install -y -qq sqlite3 libsqlite3-dev nodejs
-  - bundle install --path /cache
+  - bundle config path vendor/bundle
+  - bundle install --jobs 4 --retry 3
   - bundle exec rake db:create RAILS_ENV=test
   - bundle exec rake test & bundle exec rspec & bundle exec rubocop --parallel
+  cache:
+    paths:
+      - vendor/bundle
   except:
     variables:
       - $CD_TEST_IGNORE


### PR DESCRIPTION
Use vendor/bundle as Bundler install location (just like in GitHub Actions)

## Description

GitLab CI otherwise won't actually cache anything at all, because caching only works
on paths in the local working copy (https://docs.gitlab.com/ee/ci/yaml/#cache).

Also, the cache only makes sense for the test task, the other ones use Docker anyways.

## Testing Steps

Mirror this repo to GitLab and activate CI/CD for it.

## Screenshots (if appropriate):

### After:
![Screenshot from 2021-11-18 11-50-08](https://user-images.githubusercontent.com/228095/142401781-7261d4ac-4f75-4cae-b1bb-cf020d28de8f.png)

### Before:
![Screenshot from 2021-11-18 11-50-51](https://user-images.githubusercontent.com/228095/142401880-3ffd66a5-9286-42e3-a996-fb07d419c3d4.png)

