### PR TITLE
GIT-2986: Fixed incorrect room recordings title (Closes #2986)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -152,4 +152,9 @@ module ApplicationHelper
   def protected_recording?(rec)
     !rec[:protected].nil?
   end
+
+  # Takes any expression and stringify it decoding any html charachter entity if found.
+  def html_entities_decode(expr)
+    CGI.unescapeHTML expr
+  end
 end

--- a/app/views/shared/components/_public_recording_row.html.erb
+++ b/app/views/shared/components/_public_recording_row.html.erb
@@ -18,10 +18,10 @@
     <div id="recording-title" class="edit_hover_class" data-recordid="<%= recording[:recordID] %>" data-room-uid="<%= room_uid_from_bbb(recording[:meetingID]) %>" data-path="<%= rename_recording_path(meetingID: recording[:meetingID], record_id: recording[:recordID]) %>">
       <% if recording[:metadata][:name] %>
         <span id="recording-text" title="<%= recording[:metadata][:name] %>">
-          <%= recording[:metadata][:name] %>
+          <%= html_entities_decode(recording[:metadata][:name]) %>
       <% else %>
         <span id="recording-text" title="<%= recording[:name] %>">
-          <%= recording[:name] %>
+          <%= html_entities_decode(recording[:name]) %>
       <% end %>
         </span>
     </div>

--- a/app/views/shared/components/_recording_row.html.erb
+++ b/app/views/shared/components/_recording_row.html.erb
@@ -18,10 +18,10 @@
     <div id="recording-title" class="edit_hover_class" data-recordid="<%= recording[:recordID] %>" data-room-uid="<%= room_uid_from_bbb(recording[:meetingID]) %>" data-path="<%= rename_recording_path(meetingID: recording[:meetingID], record_id: recording[:recordID]) %>">
       <% if recording[:metadata][:name] %>
         <span id='recording-text' title="<%= recording[:metadata][:name] %>">
-          <%= recording[:metadata][:name] %>
+          <%= html_entities_decode(recording[:metadata][:name]) %>
       <% else %>
         <span id='recording-text' title="<%= recording[:name] %>">
-          <%= recording[:name] %>
+          <%= html_entities_decode(recording[:name]) %>
       <% end %>
         </span>
       <a><i id="edit-record" class="fa fa-edit align-top ml-2" data-edit-recordid="<%= recording[:recordID] %>"></i></a>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -27,7 +27,21 @@ describe ApplicationHelper do
       expect(helper.omniauth_login_url(provider)).to eql("/b/auth/#{provider}")
     end
   end
-
+  describe "#html_decode" do
+    let(:expr_with_html_entities) { '&lt;&gt;&amp;&quot;' }
+    let(:expr_with_html_entities_decoded) { '<>&"' }
+    let(:expr_with_no_html_entities) { "this is some regular text!!" }
+    context "with html charachter entities" do
+     it "should return the decoded version of the expression" do
+       expect(html_entities_decode(expr_with_html_entities)).to eq(expr_with_html_entities_decoded)
+     end
+    end
+    context "with no html charachter entities" do
+      it "should return the expression stringified" do
+        expect(html_entities_decode(expr_with_no_html_entities)).to eq(expr_with_no_html_entities)
+      end
+    end
+  end
   describe "role_colur" do
     it "should use default if the user doesn't have a role" do
       expect(helper.role_colour(Role.create(name: "test"))).to eq(Rails.configuration.primary_color_default)


### PR DESCRIPTION
…86).

<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some BigBlueButton (BBB) configurations enforce encoding on recordings name, Greenlight (GL) logic on rendering the list of available recordings for a room is to fetch it from the BBB server, format and represent it on the view page.
there was no formatting to the recordings name to decode the encoded characters by the BBB server resulting in having the recordings of a room named 'foo<"bar">' to be presented with title 'foo& lt;& quot;bar& quot;& gt;' (whitespaces after each & were added to prevent GitHub from decoding entities automatically).

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
1) Created different rooms with different names containing some characters that maps to an [html entity](https://www.w3schools.com/html/html_entities.asp).
2) Started and recorded meetings on each room.
3) Checked and confirmed that the rooms with such names will have by default an incorrect recordings title.

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/29759616/145223224-45ba4716-d08d-461b-855b-3d9f4886f11b.png)