### PR TITLE
GIT-2927: Fixed lack of updates to trusted CA lists (Fixes #2927)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,10 +65,13 @@ ENV VERSION_CODE=$version_code
 
 # Set executable permission to start file
 RUN chmod +x bin/start
+# Update HTTPClient cacert.pem with the latest Mozilla cacert.pem
+RUN wget https://curl.se/ca/cacert.pem https://curl.se/ca/cacert.pem.sha256 -P /tmp
+RUN cd /tmp && sha256sum cacert.pem > cacert.pem.sha256sum && cd ${RAILS_ROOT}
+RUN diff /tmp/cacert.pem.sha256sum /tmp/cacert.pem.sha256
+RUN mv -v /tmp/cacert.pem $(bundle info httpclient --path)/lib/httpclient/ && rm -v /tmp/cacert*
 
-# FIXME / to remove / https://github.com/nahi/httpclient/issues/445
-RUN cat /etc/ssl/certs/ca-certificates.crt \
-    >/usr/src/app/vendor/bundle/ruby/2.7.0/gems/httpclient-2.8.3/lib/httpclient/cacert.pem
-
+# Update Openssl certs [This is for Faraday adapter for Net::HTTP]
+RUN [[ $(id -u) -eq 0 ]] && update-ca-certificates
 # Start the application.
 CMD ["bin/start"]


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Many users had experienced some connectivity error with external services.
The error log is "OpenSSL::SSL::SSLError (SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate))" which indicates that an HTTPS connection was closed because of a fail during x509 certificate verification.
The issues cause is the expiration of the DST Root CA X3 Let's encrypt root certificate.
As mentioned [here](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/) Let's encrypt has also a newer Root certificate  ISRG Root X1 which after the expiration of DST becomes the only valid certificate.

Greenlight (GL) requires the use of http client to use some external services (BigBlueButton,OmniAuth providers,...).
Some gems (dependencies) in the  GL application simplifies the communication with external APIs and comes with their own dependencies.
Some of which depends on [faraday ](https://rubygems.org/gems/faraday)and others on [httpclient](https://rubygems.org/gems/httpclient).
The faraday gem has [faraday-net_http](https://lostisland.github.io/faraday/adapters/net-http) which is the adapter to the Net::HTTP that is used for example by the [bigbluebutton-api-ruby.](https://github.com/mconf/bigbluebutton-api-ruby/blob/master/lib/bigbluebutton_api.rb#L753)
The [faraday](https://rubygems.org/gems/faraday-net_http/versions/1.0.1) adapter by default uses the OpenSSL::X509::Store as its default store to trusted CA list.
This raises an issue for some of the users who use an old docker image since their Openssl trusted root certificates is old which leads any https connection to any server (including but not limited to BigBlueButton servers) with a x509 certificate issued by Let's encrypt to break.
Second issue happens for another subset of users who may have an up to date openssl CA list but still experience some problems (including but not limited to OmniAuth),this subset may have a problem because of the httpclient gem that uses an [old ](https://github.com/nahi/httpclient/blob/master/lib/httpclient/cacert.pem)(from 2015) Mozilla CA list.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
1) Checked all the http client gems and the gems that depends on it.
2) Tested each http client gem in isolation.
3) Found hat HTTPClient by default loads the [cacert.pem](https://github.com/nahi/httpclient/blob/master/lib/httpclient/ssl_config.rb#L23) [on non JRuby runtimes] (the default in the repo is outdated) included in its lib/httpclient and falls back if [configured to ](https://github.com/nahi/httpclient/blob/4658227a46f7caa633ef8036f073bbd1f0a955a2/lib/httpclient/ssl_config.rb#L257)the OpenSSL store but any update in execution to its stores won't have an effect because it cashes it on runtime.
4) Found that Faraday adapter to Net::HTTP uses the OpenSSL as its store by default and cashes it on runtime.

## Solution
For HTTPClient: we fetch the latest  Mozilla cacert.pem securely on docker image build.
For Net::HTTP: we enforce the update of the openssl certs on image build.

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
