### PR TITLE
GIT-2207: Fixed internal error caused by overflowing pages (Fixes #2207)

### DIFF
--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -80,9 +80,9 @@ require 'pagy/extras/bootstrap'
 
 # Overflow extra: Allow for easy handling of overflowing pages
 # See https://ddnexus.github.io/pagy/extras/overflow
-# require 'pagy/extras/overflow'
+require 'pagy/extras/overflow'
 # Pagy::VARS[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
-
+Pagy::VARS[:overflow] = :last_page
 # Trim extra: Remove the page=1 param from links
 # See https://ddnexus.github.io/pagy/extras/trim
 # require 'pagy/extras/trim'


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Greenlight uses 'Pagy' gem for a simpler and efficient pagination.
[Pagy](https://ddnexus.github.io/pagy/how-to.html#gsc.tab=0) default behavior to handle overflowing pages is to raise the ['Pagy::OverflowError'](https://ddnexus.github.io/pagy/extras/overflow#gsc.tab=0) exception causing the application to render the 500 internal error page caused by the 'rescue_from' method in the ApplicationController.
Many actions in the AdminsController logic uses the 'redirect_back' to redirect the client back to were the initiated the request which leads upon banning,unbanning,undeleting,... last users in the last page to redirect the client back to an overflow page causing Pagy to raise the OverflowError exception and the controller to rescue_from it by rendering the internal error view which explains what occurred with [#2207](https://github.com/bigbluebutton/greenlight/issues/2207).
## Testing Steps
<!--- Please describe in detail how to test your changes. -->
1.  Created many users.
2. Updated their role to have the 'pending' state.
3. Start declining and approving users.
4. Observed the error with approving/declining the last user in the last page other than 1.
5. Confirmed the root cause by accessing overflown pages on several areas in the application (rooms,admin pannel,recordings...). 
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
