### PR TITLE
[LINT] exigenses in FR translation is printed exigenCes

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -538,7 +538,7 @@ fr:
     invite:
       fail: "Votre jeton d'authentification a expiré ou n'est pas valide. Si vous pensez qu'il s'agit d'une erreur, veuillez contacter votre administrateur."
       no_invite: Vous n'avez pas d'invitation. Veuillez contacter votre administrateur afin d'en recevoir une.
-    insecure_password: "Afin d'améliorer la sécurité des comptes, nous avons augmenté la complexité des mots de passe pour tous. Veuillez créer un nouveau mot de passe qui correspond aux exigenses indiquées ci-dessous."
+    insecure_password: "Afin d'améliorer la sécurité des comptes, nous avons augmenté la complexité des mots de passe pour tous. Veuillez créer un nouveau mot de passe qui correspond aux exigences indiquées ci-dessous."
   remove: Enlever
   rename: Renommer
   reset_password:


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->


## Description
I've renamed 'exigenses' to 'exigences' in FRENCH translation.
The privous word was badly written.
