### PR TITLE
GIT-1861: Fixed reset password and activation dead lock on users with terms unaccepted

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -52,11 +52,13 @@ class PasswordResetsController < ApplicationController
     elsif params[:user][:password] != params[:user][:password_confirmation]
       # Password does not match password confirmation
       flash.now[:alert] = I18n.t("password_different_notice")
-    elsif @user.update_attributes(user_params)
-      # Clear the user's social uid if they are switching from a social to a local account
-      @user.update_attribute(:social_uid, nil) if @user.social_uid.present?
-      # Deactivate the reset digest in use disabling the reset link.
-      @user.update(reset_digest: nil, reset_sent_at: nil)
+    elsif @user.without_terms_acceptance { @user.update_attributes(user_params) }
+      @user.without_terms_acceptance {
+        # Clear the user's social uid if they are switching from a social to a local account
+        @user.update_attribute(:social_uid, nil) if @user.social_uid.present?
+        # Deactivate the reset digest in use disabling the reset link.
+        @user.update(reset_digest: nil, reset_sent_at: nil)
+      }
       # Successfully reset password
       return redirect_to root_path, flash: { success: I18n.t("password_reset_success") }
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -97,13 +97,13 @@ class UsersController < ApplicationController
       params[:user][:name] = @user.name
       params[:user][:email] = @user.email
     end
-
-    if @user.update_attributes(user_params)
-      @user.update_attributes(email_verified: false) if user_params[:email] != @user.email
-
-      user_locale(@user)
-
-      if update_roles(params[:user][:role_id])
+    old_user_email = @user.email
+    if @user.without_terms_acceptance { @user.update_attributes(user_params) }
+      @user.without_terms_acceptance {
+        @user.update_attributes(email_verified: false) if user_params[:email] != old_user_email
+        user_locale(@user)
+      }
+      if @user.without_terms_acceptance { update_roles(params[:user][:role_id]) }
         return redirect_to redirect_path, flash: { success: I18n.t("info_update_success") }
       else
         flash[:alert] = I18n.t("administrator.roles.invalid_assignment")
@@ -116,23 +116,18 @@ class UsersController < ApplicationController
   # POST /u/:user_uid/change_password
   def update_password
     # Update the users password.
-    if @user.authenticate(user_params[:password])
-      # Verify that the new passwords match.
-      if user_params[:new_password] == user_params[:password_confirmation]
-        @user.password = user_params[:new_password]
-      else
-        # New passwords don't match.
-        @user.errors.add(:password_confirmation, "doesn't match")
-      end
+    if @user.authenticate(user_params[:old_password])
+      # Bad UX on client side [FIXED].
+      @user.assign_attributes user_params.slice(:password, :password_confirmation)
     else
       # Original password is incorrect, can't update.
-      @user.errors.add(:password, "is incorrect")
+      @user.errors.add(:old_password, I18n.t("old_password_incorrect"))
     end
 
     # Notify the user that their account has been updated.
-    return redirect_to change_password_path,
-      flash: { success: I18n.t("info_update_success") } if @user.errors.empty? && @user.save
-
+    if @user.errors.empty? && @user.without_terms_acceptance { @user.save }
+      return redirect_to change_password_path, flash: { success: I18n.t("info_update_success") }
+    end
     # redirect_to change_password_path
     render :change_password
   end
@@ -235,7 +230,7 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :image, :password, :password_confirmation,
-      :new_password, :provider, :accepted_terms, :language)
+      :old_password, :provider, :accepted_terms, :language)
   end
 
   def send_registration_email

--- a/app/views/users/components/_password.html.erb
+++ b/app/views/users/components/_password.html.erb
@@ -18,11 +18,11 @@
   <div class="form-group">
     <div class="row">
       <div class="col-8">
-        <%= f.label :password, t("settings.password.old"), class: "form-label" %>
-        <%= f.password_field :password, class: "form-control #{form_is_invalid?(@user, :password)}", autocomplete: :off, required: true %>
+        <%= f.label :old_password, t("settings.password.old"), class: "form-label" %>
+        <%= f.password_field :old_password, class: "form-control #{form_is_invalid?(@user, :old_password)}", autocomplete: :off, required: true %>
         <br>
-        <%= f.label :new_password, t("settings.password.new"), class: "form-label" %>
-        <%= f.password_field :new_password, class: "form-control", autocomplete: :off, required: true %>
+        <%= f.label :password, t("settings.password.new"), class: "form-label" %>
+        <%= f.password_field :password, class: "form-control #{form_is_invalid?(@user, :password)}", autocomplete: :off, required: true %>
         <% if form_is_invalid?(@user, :password) %>
           <div class="small text-danger"><%= t("reset_password.complexity") %></div>
         <% end %>

--- a/app/views/users/components/_password_security.html.erb
+++ b/app/views/users/components/_password_security.html.erb
@@ -16,15 +16,15 @@
 <div class="row">
   <div class="col">
     <ul>
-      <li class="small text-muted p-1">At least 8 characters</li>
-      <li class="small text-muted p-1">At least 1 lowercase character</li>
-      <li class="small text-muted p-1">At least 1 uppercase character</li>
+      <li class="small text-muted p-1"><%=t("password_complexity.minimum_len")%></li>
+      <li class="small text-muted p-1"><%=t("password_complexity.one_lower_case")%></li>
+      <li class="small text-muted p-1"><%=t("password_complexity.one_upper_case")%></li>
     </ul>
   </div>
   <div class="col">
     <ul>
-      <li class="small text-muted p-1">At least 1 number</li>
-      <li class="small text-muted p-1">At least 1 symbol</li>
+      <li class="small text-muted p-1"><%=t("password_complexity.one_digit")%></li>
+      <li class="small text-muted p-1"><%=t("password_complexity.one_sym")%></li>
     </ul>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
         name: Name
         password: Password
         password_confirmation: Password Confirmation
+        old_password: Old password
     errors:
       models:
         user:
@@ -496,6 +497,13 @@ en:
   password_empty_notice: Password cannot be empty.
   password_reset_success: Password has been reset.
   password_different_notice: Password Confirmation does not match.
+  old_password_incorrect: is incorrect
+  password_complexity:
+    minimum_len: At least 8 characters
+    one_lower_case: At least 1 lowercase character
+    one_upper_case: At least 1 uppercase character
+    one_digit: At least 1 number
+    one_sym: At least 1 non alphanumeric character
   provider:
     google: Google
     office365: Office 365

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -49,7 +49,6 @@ describe UsersController, type: :controller do
   describe "GET #edit" do
     it "renders the edit template" do
       user = create(:user)
-
       @request.session[:user_id] = user.id
 
       get :edit, params: { user_uid: user.uid }
@@ -328,65 +327,60 @@ describe UsersController, type: :controller do
   end
 
   describe "POST #update" do
+    before do
+      @user = create(:user, accepted_terms: false)
+      @request.session[:user_id] = @user.id
+      allow(Rails.configuration).to receive(:terms).and_return "This is a dummy text!"
+      allow(Rails.configuration).to receive(:enable_email_verification).and_return(true)
+    end
     it "properly updates usser attributes" do
-      user = create(:user)
-      @request.session[:user_id] = user.id
-
+      expect(@user.greenlight_account?).to be
       params = random_valid_user_params
-      post :update, params: params.merge!(user_uid: user)
-      user.reload
+      post :update, params: params.merge!(user_uid: @user)
 
-      expect(user.name).to eql(params[:user][:name])
-      expect(user.email).to eql(params[:user][:email])
+      # Changing email should deactivate the greenlight account.
+      expect(@user.activated?).not_to be unless @user.email == @user.reload.email
+      expect(@user.name).to eql(params[:user][:name])
       expect(flash[:success]).to be_present
-      expect(response).to redirect_to(edit_user_path(user))
+      expect(response).to redirect_to(edit_user_path(@user))
     end
 
     it "properly updates user attributes" do
       allow_any_instance_of(User).to receive(:greenlight_account?).and_return(false)
-      user = create(:user)
-      @request.session[:user_id] = user.id
-
       params = random_valid_user_params
-      post :update, params: params.merge!(user_uid: user)
-      user.reload
+      post :update, params: params.merge!(user_uid: @user)
+      @user.reload
 
-      expect(user.name).not_to eql(params[:user][:name])
-      expect(user.email).not_to eql(params[:user][:email])
+      expect(@user.name).not_to eql(params[:user][:name])
+      expect(@user.email).not_to eql(params[:user][:email])
       expect(flash[:success]).to be_present
-      expect(response).to redirect_to(edit_user_path(user))
+      expect(response).to redirect_to(edit_user_path(@user))
     end
 
     it "allows admins to update a non local accounts name/email" do
       allow_any_instance_of(User).to receive(:greenlight_account?).and_return(false)
-      user = create(:user)
-      admin = create(:user).set_role :admin
+      admin = create(:user)
+      admin.set_role :admin
       @request.session[:user_id] = admin.id
 
       params = random_valid_user_params
-      post :update, params: params.merge!(user_uid: user)
-      user.reload
+      post :update, params: params.merge!(user_uid: @user)
+      @user.reload
 
-      expect(user.name).to eql(params[:user][:name])
-      expect(user.email).to eql(params[:user][:email])
+      expect(@user.name).to eql(params[:user][:name])
+      expect(@user.email).to eql(params[:user][:email])
       expect(flash[:success]).to be_present
       expect(response).to redirect_to(admins_path)
     end
 
     it "renders #edit on unsuccessful save" do
-      @user = create(:user)
-      @request.session[:user_id] = @user.id
-
       post :update, params: invalid_params.merge!(user_uid: @user)
       expect(response).to render_template(:edit)
     end
 
     context 'Roles updates' do
       it "should fail to update roles if users tries to add a role with a higher priority than their own" do
-        user = create(:user)
-        @request.session[:user_id] = user.id
-
-        user_role = user.role
+        user_role = @user.role
 
         user_role.update_permission("can_manage_users", "true")
 
@@ -395,32 +389,27 @@ describe UsersController, type: :controller do
         tmp_role = Role.create(name: "test", priority: -4, provider: "greenlight")
 
         params = random_valid_user_params
-        post :update, params: params.merge!(user_uid: user, user: { role_id: tmp_role.id.to_s })
+        post :update, params: params.merge!(user_uid: @user, user: { role_id: tmp_role.id.to_s })
 
         expect(flash[:alert]).to eq(I18n.t("administrator.roles.invalid_assignment"))
         expect(response).to render_template(:edit)
       end
 
       it "should successfuly add roles to the user" do
-        allow(Rails.configuration).to receive(:enable_email_verification).and_return(true)
-
-        user = create(:user)
         admin = create(:user)
-
         admin.set_role :admin
-
         @request.session[:user_id] = admin.id
 
         tmp_role1 = Role.create(name: "test1", priority: 2, provider: "greenlight")
         tmp_role1.update_permission("send_promoted_email", "true")
 
         params = random_valid_user_params
-        params.merge!(user_uid: user, user: { role_id: tmp_role1.id.to_s })
+        params.merge!(user_uid: @user, user: { role_id: tmp_role1.id.to_s })
 
         expect { post :update, params: params }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
-        user.reload
-        expect(user.role.name).to eq("test1")
+        @user.reload
+        expect(@user.role.name).to eq("test1")
         expect(response).to redirect_to(admins_path)
       end
 
@@ -431,7 +420,7 @@ describe UsersController, type: :controller do
         new_role = Role.create(name: "test2", priority: 3, provider: "greenlight")
         new_role.update_permission("can_create_rooms", "true")
 
-        user = create(:user, role: old_role)
+        @user = create(:user, role: old_role)
         admin = create(:user)
 
         admin.set_role :admin
@@ -439,76 +428,59 @@ describe UsersController, type: :controller do
         @request.session[:user_id] = admin.id
 
         params = random_valid_user_params
-        params.merge!(user_uid: user, user: { role_id: new_role.id.to_s })
+        params.merge!(user_uid: @user, user: { role_id: new_role.id.to_s })
 
-        expect(user.role.name).to eq("test1")
-        expect(user.main_room).to be_nil
+        expect(@user.role.name).to eq("test1")
+        expect(@user.main_room).to be_nil
 
         post :update, params: params
 
-        user.reload
-        expect(user.role.name).to eq("test2")
-        expect(user.main_room).not_to be_nil
+        @user.reload
+        expect(@user.role.name).to eq("test2")
+        expect(@user.main_room).not_to be_nil
         expect(response).to redirect_to(admins_path)
       end
     end
   end
 
   describe "POST #update_password" do
-    before do
-      @user = create(:user)
-      @password = "#{Faker::Internet.password(min_length: 8, mix_case: true, special_characters: true)}1aB"
-    end
-
-    it "properly updates users password" do
-      @request.session[:user_id] = @user.id
-
-      params = {
+    def params(mode = 0)
+      {
         user: {
-          password: @user.password,
-          new_password: @password,
-          password_confirmation: @password,
+          old_password: mode == 0 ? @user.password : "incorrect_password",
+          password: @password,
+          password_confirmation: mode == 2 ? "#{@password}_random_string" : @password,
         }
       }
-      post :update_password, params: params.merge!(user_uid: @user)
-      @user.reload
-
-      expect(@user.authenticate(@password)).not_to be false
-      expect(@user.errors).to be_empty
-      expect(flash[:success]).to be_present
-      expect(response).to redirect_to(change_password_path(@user))
     end
+    context "with 'terms and conditions' exist and without acceptance." do
+      before do
+        @user = create(:user, accepted_terms: false)
+        @request.session[:user_id] = @user.id
+        allow(Rails.configuration).to receive(:terms).and_return "This is a dummy text!"
+        @password = "#{Faker::Internet.password(min_length: 8, mix_case: true, special_characters: true)}1aB"
+      end
+      it "properly updates users password" do
+        post :update_password, params: params.merge!(user_uid: @user)
+        @user.reload
 
-    it "doesn't update the users password if initial password is incorrect" do
-      @request.session[:user_id] = @user.id
-
-      params = {
-        user: {
-          password: "incorrect_password",
-          new_password: @password,
-          password_confirmation: @password,
-        }
-      }
-      post :update_password, params: params.merge!(user_uid: @user)
-      @user.reload
-      expect(@user.authenticate(@password)).to be false
-      expect(response).to render_template(:change_password)
-    end
-
-    it "doesn't update the users password if new passwords don't match" do
-      @request.session[:user_id] = @user.id
-
-      params = {
-        user: {
-          password: "incorrect_password",
-          new_password: @password,
-          password_confirmation: "#{@password}_random_string",
-        }
-      }
-      post :update_password, params: params.merge!(user_uid: @user)
-      @user.reload
-      expect(@user.authenticate(@password)).to be false
-      expect(response).to render_template(:change_password)
+        expect(@user.authenticate(@password)).not_to be false
+        expect(@user.errors).to be_empty
+        expect(flash[:success]).to be_present
+        expect(response).to redirect_to(change_password_path(@user))
+      end
+      it "doesn't update the users password if initial password is incorrect" do
+        post :update_password, params: params(1).merge!(user_uid: @user)
+        @user.reload
+        expect(@user.authenticate(@password)).to be false
+        expect(response).to render_template(:change_password)
+      end
+      it "doesn't update the users password if new passwords don't match" do
+        post :update_password, params: params(2).merge!(user_uid: @user)
+        @user.reload
+        expect(@user.authenticate(@password)).to be false
+        expect(response).to render_template(:change_password)
+      end
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,3 +78,7 @@ RSpec.configure do |config|
   #
   config.include ActiveSupport::Testing::TimeHelpers
 end
+
+# A dummy text to ensure testing without 'terms and conditions'.
+# Tests that depends on 'terms and conditions' will set them on example run.
+Rails.configuration.terms = false


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Organizations using Greenlight (GL) may have certain policies, terms and conditions that they would require their users to accept in order to consume their platform services.
Users who don't accept these terms won't be able to access all of the platform features until they align with its values.
But a user with unaccepted terms doesn't necessary mean that they refuse them as mentioned in #1861 [Terms can change and users may be explicitly have their acceptance reset by administrators in order to force them to read the new changes and accept them.].
Users with local accounts who still haven't accepted the terms should remain able to:
1. Reset their passwords.
2. Verify their email address.
3. Edit their profile information and password.
But users won't be able to join or manage their rooms or rooms that were shared with them until they accept terms.
There were issues that prevented users with unaccepted terms from having capabilities mentioned above.
This pull request ensures the users ability to reset their password, verify their email and change their information and administrators ability to send reset password emails and update profiles for users with unaccepted terms.
This pull request also solves some other minor bugs in the upstream not directly related to #3081.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
#### Password reset [FIXED][#1861]
1. User hadn't accept the terms.
2. User had forgotten their password and tries to reset it.
3. User receive the reset email.
4. User can't reset their password to login to accept the terms [dead lock].

### Account activation (email verification) [FIXED][#1861]
1. User have unaccepted terms (i.e. User signs up while no terms exist).
2. User receives the verification email.
3. Before verifying the email an administrator enables terms and conditions.
4. User can't activate their account [dead lock].

### User edit profile [FIXED][considered in same context with #1861]
1. User login with unaccepted terms.
2. User doesn't accept terms.
3. User access their edit profile space and attempt to update their information.
4. User can't update their information nor change their password.

Also:
### New email verification [FIXED][#3080]
1. A logged in active user or an administrator access the user edit profile panel.
2. An update request to the user email gets created.
3. User have their email updated without having to verify it.

### Secure password circumventing [FIXED][#3078]
1. User with old password logged in or an administrator access the user edit profile.
2. An administrative update upgrades the platform to add new password complexity policy.
3. User will have their `secure_password` set to `false` by default to force them to reset it upon the next login.
4. User or the administrator make an update on the user's information.
5. User gets their `secure_password` set to `true` and therefore they circumvent the password forced reset.

### Change password to a secure one [FIXED][#3079]
1. A logged in user with an insecure password access their edit profile space.
2. User attempts to change their password to a secure one without making a reset.
3. User changes their password without setting the `secure_password` flag to `true`.
4. User will be required to reset their secure password upon the next login.

This fixes #1861, #3080, #3079 , #3078  and enhances #3081.

**A references to issues was left with comments on parts of the pull request code to help ease the review and because of the extended description that made it difficult to refer here.**
  
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
