### PR TITLE
GIT-3085: Fixed the resetting password link constant usability

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -55,9 +55,8 @@ class PasswordResetsController < ApplicationController
     elsif @user.update_attributes(user_params)
       # Clear the user's social uid if they are switching from a social to a local account
       @user.update_attribute(:social_uid, nil) if @user.social_uid.present?
-
-      # Mark password as secure
-      @user.update(secure_password: true)
+      # Mark password as secure and deactivate the reset digest in use.
+      @user.update(reset_digest: nil, reset_sent_at: nil, secure_password: true)
       # Successfully reset password
       return redirect_to root_path, flash: { success: I18n.t("password_reset_success") }
     end

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -158,6 +158,7 @@ describe PasswordResetsController, type: :controller do
         user.reload
 
         expect(old_digest.eql?(user.password_digest)).to be false
+        expect(user.reset_digest.nil? && user.reset_sent_at.nil?).to be
         expect(response).to redirect_to(root_path)
       end
     end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As described in #3085 users after receiving the reset password email and after successfully changing their password will have their link active for the next 2hours (counting from the reset email sent time).
This raises some security concerns and this PR solves it by simply resetting the `reset_digest` upon successful password reset just like with the `activation_digest` on local account activation.
## Testing Steps
<!--- Please describe in detail how to test your changes. -->
1. Reset a user account password.
2. User receives the reset password email.
3. User hits the reset password button and access the reset password view to set the new one.
4. User successfully updates their password.
5. User with the same token can still reset their password until the 2hours time frame elapses.

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
