### PR TITLE
GIT-3073: Fixed the session failing for rooms with one character in length (Closes #3073).

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -25,7 +25,7 @@ class Room < ApplicationRecord
 
   before_destroy :destroy_presentation
 
-  validates :name, presence: true
+  validates :name, length: { in: 2..256 }
 
   belongs_to :owner, class_name: 'User', foreign_key: :user_id
   has_many :shared_access, dependent: :destroy

--- a/app/views/shared/modals/_create_room_modal.html.erb
+++ b/app/views/shared/modals/_create_room_modal.html.erb
@@ -28,7 +28,7 @@
               <span class="input-icon-addon">
                 <i class="fas fa-chalkboard-teacher"></i>
               </span>
-              <%= f.text_field :name, id: "create-room-name", class: "form-control text-center", value: "", placeholder: t("modal.create_room.name_placeholder"), autocomplete: :off, required: true %>
+              <%= f.text_field :name, id: "create-room-name", class: "form-control text-center", value: "", placeholder: t("modal.create_room.name_placeholder"), autocomplete: :off, required: true , minlength: 2, maxlength: 256 %>
               <div class="invalid-feedback text-left"><%= t("modal.create_room.not_blank") %></div>
             </div>
 

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -26,7 +26,7 @@ describe Room, type: :model do
   end
 
   context 'validations' do
-    it { should validate_presence_of(:name) }
+    it { should validate_length_of(:name).is_at_least(2).is_at_most(256) }
   end
 
   context 'associations' do


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
At the moment Greenlight (GL) rooms are validated only for presence meaning that any room can have any name in terms of length.
This raises some issues:
1. The BigBlueButton (BBB) API allow meetings to have names of length that is in `2..256` resulting in creating a room with one character length name on GL but failing each BBB API call for that room i.e. its meeting start.
2.  Rooms name have no limit in terms of length resulting in having names that may brake the UI, cause a delay on rendering and/or cause errors when exceeding the ruby or the database maximum allowed string length.

This solves #3073 by making the room `ActiveRecord` validates the `name` attribute length to be in `2..256` and updates the room create modal accordingly. 

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
1. Created a room with a one character name.
2. Confirming that the room gets created on GL.
3. Attempts to start a session on that room.
4. Confirms the fail of the operation with the same errors. 
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
