### PR TITLE
GIT-3100: Reconsidered the password complexity check design.

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -55,8 +55,8 @@ class PasswordResetsController < ApplicationController
     elsif @user.update_attributes(user_params)
       # Clear the user's social uid if they are switching from a social to a local account
       @user.update_attribute(:social_uid, nil) if @user.social_uid.present?
-      # Mark password as secure and deactivate the reset digest in use.
-      @user.update(reset_digest: nil, reset_sent_at: nil, secure_password: true)
+      # Deactivate the reset digest in use disabling the reset link.
+      @user.update(reset_digest: nil, reset_sent_at: nil)
       # Successfully reset password
       return redirect_to root_path, flash: { success: I18n.t("password_reset_success") }
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -98,7 +98,7 @@ class SessionsController < ApplicationController
     end
 
     return redirect_to edit_password_reset_path(user.create_reset_digest),
-flash: { alert: I18n.t("registration.insecure_password") } unless user.secure_password
+flash: { alert: I18n.t("registration.insecure_password") } unless User.secure_password?(session_params[:password])
 
     login(user)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,9 +45,6 @@ class UsersController < ApplicationController
 
     logger.info "Support: #{@user.email} user has been created."
 
-    # Mark password as secure
-    @user.update(secure_password: true)
-
     # Set user to pending and redirect if Approval Registration is set
     if approval_registration
       @user.set_role :pending
@@ -103,9 +100,6 @@ class UsersController < ApplicationController
 
     if @user.update_attributes(user_params)
       @user.update_attributes(email_verified: false) if user_params[:email] != @user.email
-
-      # Mark password as secure
-      @user.update(secure_password: true)
 
       user_locale(@user)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@ require 'bbb_api'
 class User < ApplicationRecord
   include Deleteable
 
+  PASSWORD_PATTERN = /\A(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*(\W|_)).{8,}\z/
   after_create :setup_user
 
   before_save { email.try(:downcase!) }
@@ -45,7 +46,7 @@ class User < ApplicationRecord
                     format: { with: /\A[\w+\-'.]+@[a-z\d\-.]+\.[a-z]+\z/i }
 
   validates :password, length: { minimum: 8 },
-            format: /\A(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,}\z/,
+            format: PASSWORD_PATTERN,
             confirmation: true,
             if: :validate_password?
 
@@ -113,6 +114,10 @@ class User < ApplicationRecord
 
       search_param = "%#{sanitize_sql_like(string)}%"
       where(search_query, search: search_param)
+    end
+
+    def secure_password?(pwd)
+      pwd.match? PASSWORD_PATTERN
     end
   end
 

--- a/db/migrate/20220209094148_remove_secure_password_from_users.rb
+++ b/db/migrate/20220209094148_remove_secure_password_from_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveSecurePasswordFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :secure_password, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_15_001240) do
+ActiveRecord::Schema.define(version: 2022_02_09_094148) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -144,7 +144,6 @@ ActiveRecord::Schema.define(version: 2021_12_15_001240) do
     t.boolean "deleted", default: false, null: false
     t.integer "role_id"
     t.datetime "last_login"
-    t.boolean "secure_password", default: false, null: false
     t.integer "failed_attempts"
     t.datetime "last_failed_attempt"
     t.index ["created_at"], name: "index_users_on_created_at"

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -288,15 +288,14 @@ describe SessionsController, type: :controller do
       expect(@user1.last_login).to_not be_nil
     end
 
-    it "redirects to reset password page if password is marked as insecure" do
+    it "redirects to reset password page if the password is insecure" do
       allow_any_instance_of(User).to receive(:create_reset_digest).and_return("reset_token")
-
-      @user1.update(secure_password: false)
-
+      @user1.update_attribute(:password, "example")
+      expect(@user1.authenticate("example")).to be
       post :create, params: {
         session: {
           email: @user1.email,
-          password: 'Example1!',
+          password: 'example',
         },
       }
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -28,7 +28,6 @@ FactoryBot.define do
     password_confirmation { password }
     accepted_terms { true }
     email_verified { true }
-    secure_password { true }
     activated_at { Time.zone.now }
     role { set_role(:user) }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,8 @@ require 'bigbluebutton_api'
 describe User, type: :model do
   before do
     @user = create(:user)
+    @secure_pwd = "#{Faker::Internet.password(min_length: 8, mix_case: true, special_characters: true)}1aB"
+    @insecure_pwd = Faker::Internet.password(min_length: 8, mix_case: true).to_s
   end
 
   context 'validations' do
@@ -47,10 +49,16 @@ describe User, type: :model do
       user = create(:user, email: "DOWNCASE@DOWNCASE.COM")
       expect(user.email).to eq("downcase@downcase.com")
     end
-
     context 'is greenlight account' do
       before { allow(subject).to receive(:greenlight_account?).and_return(true) }
       it { should validate_length_of(:password).is_at_least(8) }
+      it { should validate_confirmation_of(:password) }
+      it "should validate password complexity" do
+        @user.update(password: @secure_pwd, password_confirmation: @secure_pwd)
+        expect(@user).to be_valid
+        @user.update(password: @insecure_pwd, password_confirmation: @insecure_pwd)
+        expect(@user).to be_invalid
+      end
     end
 
     context 'is not greenlight account' do
@@ -266,6 +274,16 @@ describe User, type: :model do
 
       expect(@user.locked_out?).to be false
       expect(@user.reload.failed_attempts).to eq(0)
+    end
+  end
+  context 'class methods' do
+    context "#secure_password?" do
+      it "should return true for secure passwords" do
+        expect(User.secure_password?(@secure_pwd)).to be
+      end
+      it "should return false for insecure passwords" do
+        expect(User.secure_password?(@insecure_pwd)).not_to be
+      end
     end
   end
 end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As of the latest release of Greenlight (GL) `v2.11.x` the password complexity has increased.
The solution design used a flag (`secure_password`) to mark accounts with "secure/insecure" passwords so that the application can decide the proper action to take with each account.
Any user local account with insecure password (`secure_password == false`) won't login and gets redirected directly to `reset_password` page to update it matching the new requirements.
This raised some issues as described in #3078,#3079,#3081, #3091,#3100.
This addresses #3100 and #3091 while PR #3082 targets the others.

## Solution:
This proposition is straightforward, any local account will have its password validated against the complexity requirements upon login without the use of the `secure_password` flag which simplifies things a lot and avoid potential errors and overhead:
1. If the password is secure then the user login.
2. If the password is insecure (doesn't match the `PASSWORD_PATTERN`) the user won't login and they will get redirected to reset password page.
This will ensure that old accounts with already "secure" passwords doesn't get prompted to change theirs.

The password minimal complexity required remains the same:
1. A password has to have at least **One digit**.
2. A password has to have at least **One non-word characters (anything but `a-z, A-Z, 0-9`)**.
3. A password has to have at least **One Upper case letter**.
4. A password has to have at least **One lower case letter**.
5. A password has to be at least **8 characters in length**.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
1. Ran `bigbluebutton/greenlight:v2.10.0.3` on empty database.
2. Created three accounts two of which with insecure and one with a secure password.
3. Opened three browser sessions for each account.
4. Ran this PR docker image on the existing database.
5. Attempted to change the password on one account with an insecure one:
   5.1 Confirmed the complexity validation for the new password.
   5.2 Changed the password to a secure one.
   5.3 Signed out and resigned in on same account and confirming that the user doesn't has to reset their password.
6. Signed out all of the other sessions and resigned in to confirm that:
   6.1 The account with insecure password can't login and gets redirected to the reset password page:
       6.1.1 All validation for password complexity works.
       6.1.2 After resetting the password and signing in the user logs in without having to reset it again.
       6.1.3 Signing out and resigning in without having to reset the password.
   6.2 The user with secure password logs in without having to make a reset.

Also, Tested for `user` and `admin` create rake tasks.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
