### PR TITLE
GIT-3105: Enhancing Rake tasks UX (Closes #3105).

### DIFF
--- a/config/initializers/colorize.rb
+++ b/config/initializers/colorize.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+{
+  # https://www.ing.iac.es//~docs/external/bash/abs-guide/colorizing.html.
+  black: 30,
+  red: 31,
+  green: 32,
+  yellow: 33,
+  blue: 34,
+  magenta: 35,
+  cyan: 36,
+  white: 37
+}.each do |key, color_code|
+  define_method key do |text|
+    "\033[#{color_code}m#{text}\033[0m"
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,8 +28,14 @@ en:
     errors:
       models:
         user:
-          password: did not meet complexity requirements
-          confirmation: doesn't match Password
+          confirmation: doesn't match
+          attributes:
+            email:
+              invalid: invalid email format
+            password:
+              invalid: did not meet complexity requirements 
+              
+  
   administrator:
     site_settings:
       authentication:

--- a/lib/tasks/room.rake
+++ b/lib/tasks/room.rake
@@ -17,18 +17,18 @@ namespace :room do
 
     users = User.with_role(roles_arr)
     users.each do |user|
-      puts "Destroying #{user.uid} rooms - role: #{user.role.name}"
+      puts "  Destroying #{user.uid} rooms - role: #{user.role.name}"
       user.rooms.each do |room|
         if room.sessions.positive? && args[:include_used] != "true"
-          puts "Skipping room #{room.uid}"
+          puts yellow "   Skipping room #{room.uid}"
           next
         end
 
         begin
           room.destroy(true)
-          puts "Destroying room #{room.uid}"
+          puts green "    Destroying room #{room.uid}"
         rescue => e
-          puts "Failed to remove room #{room.uid} - #{e}"
+          puts red "    Failed to remove room #{room.uid} - #{e}"
         end
       end
     end
@@ -40,10 +40,10 @@ namespace :room do
 
       begin
         new_uid = "#{room.uid}-#{SecureRandom.alphanumeric(3).downcase}"
-        puts "Updating #{room.uid} to #{new_uid}"
+        puts green "  Updating #{room.uid} to #{new_uid}"
         room.update_attributes(uid: new_uid)
       rescue => e
-        puts "Failed to update #{room.uid} to #{new_uid} - #{e}"
+        puts red "    Failed to update #{room.uid} to #{new_uid} - #{e}"
       end
     end
   end

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -4,7 +4,7 @@ require 'bigbluebutton_api'
 
 namespace :user do
   desc "Creates a user account"
-  task :create, [:name, :email, :password, :role, :provider] => :environment do |_task, args|
+  task :create, [:name, :email, :password, :role, :validate, :provider] => :environment do |_task, args|
     u = {
       name: args[:name],
       password: args[:password],
@@ -20,41 +20,51 @@ namespace :user do
       u[:email] = "admin@example.com" if u[:email].blank?
     elsif u[:name].blank? || u[:password].blank? || u[:email].blank?
       # Check that all fields exist
-      puts "Missing Arguments"
-      exit
+      puts red "Missing Arguments"
+      exit 1 # 1 for missing arguments
     end
 
     # Create the default roles if not already created
     Role.create_default_roles(u[:provider]) if Role.where(provider: u[:provider]).count.zero?
 
     unless Role.exists?(name: u[:role], provider: u[:provider])
-      puts "Invalid Role - Role does not exist"
-      exit
+      puts red "Invalid Role - Role does not exist"
+      exit 2 # 2 for invalid Role.
     end
 
     u[:email].prepend "superadmin-" if args[:role] == "super_admin"
 
     # Create account if it doesn't exist
     if User.exists?(email: u[:email], provider: u[:provider])
-      puts "Account with that email already exists"
-      puts "Email: #{u[:email]}"
+      puts red "  Account with that email already exists"
+      puts yellow "   Email: #{u[:email]}"
+      exit 3 # 3 for email in use.
     else
-      user = User.create(name: u[:name], email: u[:email], password: u[:password],
-        provider: u[:provider], email_verified: true, accepted_terms: true)
+      validation = args[:validate] || "true"
+      user = User.new(name: u[:name], email: u[:email], password: u[:password],
+        secure_password: true, provider: u[:provider], email_verified: true, accepted_terms: true)
 
-      unless user.valid?
-        puts "Invalid Arguments"
-        puts user.errors.messages
-        exit
+      unless user.save(validate: validation == "true") && user.valid?
+        puts red "Invalid Arguments"
+        puts yellow user.errors.messages
+        if user.errors.include? :password
+          puts green " The password must:"
+          puts cyan "    1. Be 8 charachters in length."
+          puts cyan "    2. Have at least 1 lowercase letter."
+          puts cyan "    3. Have at least 1 upercase letter."
+          puts cyan "    4. Have at least 1 digit."
+          puts cyan "    5. Have at least 1 symbol #?!@$%^&*-"
+        end
+        exit 4 # 4 for invalid User.
       end
 
       user.set_role(u[:role])
 
-      puts "Account successfully created."
-      puts "Email: #{u[:email]}"
-      puts "Password: #{u[:password]}"
-      puts "Role: #{u[:role]}"
-      puts "PLEASE CHANGE YOUR PASSWORD IMMEDIATELY" if u[:password] == Rails.configuration.admin_password_default
+      puts green "  Account successfully created."
+      puts cyan "   Email: #{u[:email]}"
+      puts cyan "   Password: #{u[:password]}"
+      puts cyan "   Role: #{u[:role]}"
+      puts yellow " PLEASE CHANGE YOUR PASSWORD IMMEDIATELY" if u[:password] == Rails.configuration.admin_password_default
     end
   end
 
@@ -63,7 +73,7 @@ namespace :user do
 
     User.where(provider: args[:provider]).each do |user|
       if user.update(social_uid: "#{args[:provider]}:#{user.email}")
-        puts "Updated #{user.email} to #{args[:provider]}:#{user.email}"
+        puts green "Updated #{user.email} to #{args[:provider]}:#{user.email}"
       end
     end
   end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As requested in #3105 and #3091 the `user:create` has been reconsidered to improve the overall UX.
After the latest update to the password complexity it raised issues for administrators who are using the **Greenlight (GL)** rake tasks:
1. The password attribute invalid format message hadn't being specified so Rails had used its default message `is invalid` which didn't give any clear indication to the end user.
2. The successful creation of the account won't update its `secure_password` flag accordingly which will cause the user to get prompted for its reset on login.

This pull request answers what is listed above along with a BONUS:
1. The tasks output will be colorized and justified for a better UX:
   - Red for unexcepted results or errors, Yellow for information and warnings, Green for success of an operation and Cyan for highlighting something.
2. The `user:create` will  have specific exit codes:
   - Code 0: Success.
   - Code 1: for missing arguments (name,email or password is missing).
   - Code 2: for invalid Role (Role doesn't exist).
   - Code 3: for duplicated email (An account exist on db with the same email).
   - Code 4: for invalid User (Some arguments doesn't pass the user validation check).
 3. The `user:create` task now have a new optional argument `validate` making the expected arguments array `[:name, :email, :password, :role, :validate, :provider]`.
 The `validate` will enable/disable validations run on the user `ActiveRecord` instance:
    - By default validations will run.
    - Setting the `validate` argument to any thing other then "true" will cause the task to create a user without running any validations (no password complexity check etc...).
-> NOTE: Other checks such us those for email uniqueness and the existence of the role etc... will still run unaffected.  
4. With invalid passwords and with validation running the password complexity will be printed in the `stdout` for a better UX for administrators who may not be able to use the web app to check for requirements.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
1. Created a user with invalid password through the `user:create` rake task.
2. Confirmed the bad UX.

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![user_task](https://user-images.githubusercontent.com/29759616/152425230-d548589d-dae0-48bd-830b-8efaa77b4e5c.jpg)