### PR TITLE
GIT-3123: Removed the secure_password flag left in user:create rake task

### DIFF
--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -21,7 +21,7 @@ namespace :user do
     elsif u[:name].blank? || u[:password].blank? || u[:email].blank?
       # Check that all fields exist
       puts red "Missing Arguments"
-      exit 1 # 1 for missing arguments
+      exit 2 # 2 for missing arguments
     end
 
     # Create the default roles if not already created
@@ -29,7 +29,7 @@ namespace :user do
 
     unless Role.exists?(name: u[:role], provider: u[:provider])
       puts red "Invalid Role - Role does not exist"
-      exit 2 # 2 for invalid Role.
+      exit 3 # 3 for invalid Role.
     end
 
     u[:email].prepend "superadmin-" if args[:role] == "super_admin"
@@ -38,11 +38,11 @@ namespace :user do
     if User.exists?(email: u[:email], provider: u[:provider])
       puts red "  Account with that email already exists"
       puts yellow "   Email: #{u[:email]}"
-      exit 3 # 3 for email in use.
+      exit 4 # 4 for email in use.
     else
       validation = args[:validate] || "true"
       user = User.new(name: u[:name], email: u[:email], password: u[:password],
-        secure_password: true, provider: u[:provider], email_verified: true, accepted_terms: true)
+      provider: u[:provider], email_verified: true, accepted_terms: true)
 
       unless user.save(validate: validation == "true") && user.valid?
         puts red "Invalid Arguments"
@@ -53,9 +53,9 @@ namespace :user do
           puts cyan "    2. Have at least 1 lowercase letter."
           puts cyan "    3. Have at least 1 upercase letter."
           puts cyan "    4. Have at least 1 digit."
-          puts cyan "    5. Have at least 1 symbol #?!@$%^&*-"
+          puts cyan "    5. Have at least 1 non-alphanumeric character"
         end
-        exit 4 # 4 for invalid User.
+        exit 5 # 5 for invalid User.
       end
 
       user.set_role(u[:role])


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As described in #3123 this PR fixes the failing of the `user:create` rake task after the latest changes made to the upstream master branch by removing the update of the `secure_password` attribute in the task.

It also improves the password complexity message in the console by specifying the requirement of having `at least 1 non-alphanumeric character` to be more adequate with the regex `\W` metacharacter used in the `PASSWORD_PATTERN`.

Because rails uses `exit code 1` to indicate abortion because of an encountered error the task exit codes changes to:
 - Code 0: Success.
 - Code 2: for missing arguments (name,email or password is missing).
 - Code 3: for invalid Role (Role doesn't exist).
 - Code 4: for duplicated email (An account exist on db with the same email).
 - Code 5: for invalid User (Some arguments doesn't pass the user validation check).

-> NOTE: 
- The validation is controlled on the user creation scope only meaning that checks such us those for email uniqueness, the existence of the role and missing arguments will still run despite turning on/off the `validation`.
- Greenlight users must understand that turning off validation will ensure full control of a user account attribute values.
Users with insecure password will have their account created and validated successfully when validation is turned off but they will get caught on first login attempt and be required to change their password to match the complexity criteria. Administrators can leverage this to create accounts by automation tools without having to deal with password complexity overhead but still guarantee that the password they used are just temporary.
Also, the specific exit codes for `user:create` task can be used in scripts for commands chaining or to define specific case scenarios accordingly. 

This PR is a succession of #3108. 
 


## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
