### PR TITLE
Made the room meeting start use the room meeting options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,11 +5,11 @@ require:
 
 AllCops:
   Exclude:
-    - 'bin/**/*'
-    - 'db/schema.rb'
-    - 'db/data_schema.rb'
-    - 'vendor/**/*'
-    - 'vendor/bundle/**/*'
+    - "bin/**/*"
+    - "db/schema.rb"
+    - "db/data_schema.rb"
+    - "vendor/**/*"
+    - "vendor/bundle/**/*"
   DisabledByDefault: false
   TargetRubyVersion: 3.1
   NewCops: enable
@@ -39,6 +39,8 @@ RSpec/MessageSpies:
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
+RSpec/NestedGroups:
+  Max: 5
 # Enable having lines with up to 150 charachters in length.
 Layout/LineLength:
   Max: 150
@@ -49,7 +51,7 @@ Metrics/MethodLength:
 
 # Avoid long blocks with many lines.
 Metrics/BlockLength:
-  IgnoredMethods: [ 'describe', 'context' ]
+  IgnoredMethods: ["describe", "context"]
 
 # A calculated magnitude based on number of assignments,
 # branches, and conditions.

--- a/app/models/meeting_option.rb
+++ b/app/models/meeting_option.rb
@@ -25,6 +25,10 @@ class MeetingOption < ApplicationRecord
       public_options.pluck(:name, :id)
     end
 
+    def bbb_option_names_default_values
+      bbb_options.pluck(:name, :default_value)
+    end
+
     def password_option_ids
       password_options.pluck :id
     end

--- a/app/models/meeting_option.rb
+++ b/app/models/meeting_option.rb
@@ -4,4 +4,29 @@ class MeetingOption < ApplicationRecord
   has_many :room_meeting_options, dependent: :restrict_with_exception
 
   validates :name, presence: true, uniqueness: true
+  # Options that are relevent only to GL.
+  scope :gl_options, -> { where('name LIKE ?', 'gl%') }
+  # Options that will be sent to BBB as parameters.
+  scope :bbb_options, -> { where.not('name LIKE ?', 'gl%') }
+  # BBB meeting passwords.
+  scope :password_options, -> { where('name LIKE ?', '%PW%') }
+  # Options that can be configured by end users.
+  scope :public_options, -> { where.not('name LIKE ? OR name LIKE ?', '%PW%', 'meta%') }
+  # Options that should only be configured by the application.
+  scope :private_options, -> { where('name LIKE ? OR name LIKE ?', '%PW%', 'meta%') }
+
+  # Class methods
+  class << self
+    def public_option_names
+      public_options.pluck(:name)
+    end
+
+    def public_option_names_ids
+      public_options.pluck(:name, :id)
+    end
+
+    def password_option_ids
+      password_options.pluck :id
+    end
+  end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -10,6 +10,7 @@ class Room < ApplicationRecord
   validates :meeting_id, presence: true, uniqueness: true
 
   before_validation :set_friendly_id, :set_meeting_id, on: :create
+  after_create :set_meeting_passwords
 
   private
 
@@ -30,5 +31,14 @@ class Room < ApplicationRecord
     self.meeting_id = id
   rescue StandardError
     retry
+  end
+
+  def set_meeting_passwords
+    password_option_ids = MeetingOption.password_option_ids
+
+    password_option_ids&.each do |id|
+      # TODO: Revisit the password random value.
+      RoomMeetingOption.create! room_id: self.id, meeting_option_id: id, value: SecureRandom.alphanumeric(20)
+    end
   end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -12,6 +12,10 @@ class Room < ApplicationRecord
   before_validation :set_friendly_id, :set_meeting_id, on: :create
   after_create :set_meeting_passwords
 
+  def moderator?(user:)
+    self.user.id == user&.id
+  end
+
   private
 
   def set_friendly_id

--- a/app/models/room_meeting_option.rb
+++ b/app/models/room_meeting_option.rb
@@ -5,4 +5,6 @@ class RoomMeetingOption < ApplicationRecord
   belongs_to :meeting_option
 
   delegate :name, to: :meeting_option
+
+  scope :bbb_option_names_values, -> { includes(:meeting_option).where.not('name LIKE ?', 'gl%').pluck(:name, :value) }
 end

--- a/app/services/big_blue_button_api.rb
+++ b/app/services/big_blue_button_api.rb
@@ -15,11 +15,12 @@ class BigBlueButtonApi
   # Start a meeting for a specific room and returns the join URL.
   def start_meeting(room:, meeting_starter:, options: {})
     # TODO: amir - Revisit this.
-    create_options = default_create_opts.merge(options)
+    room_meeting_options = room.room_meeting_options.bbb_option_names_values.to_h
+    create_options = default_create_opts.merge(room_meeting_options).merge(options)
     join_options = { join_via_html5: true } # TODO: amir - Revisit this (createTime,...).
 
     user_name = meeting_starter&.name || 'Someone'
-    password = (meeting_starter && create_options[:moderatorPW]) || create_options[:attendeePW]
+    password = (room.moderator?(user: meeting_starter) && create_options['moderatorPW']) || create_options['attendeePW']
 
     bbb_server.create_meeting room.name, room.friendly_id, create_options
     bbb_server.join_meeting_url room.friendly_id, user_name, password, join_options
@@ -36,18 +37,6 @@ class BigBlueButtonApi
   end
 
   def default_create_opts
-    {
-      # TODO: amir - revisit this.
-      record: true,
-      logoutURL: 'http://localhost',
-      moderatorPW: 'mp',
-      attendeePW: 'ap',
-      moderatorOnlyMessage: 'Welcome Moderator',
-      muteOnStart: false,
-      guestPolicy: 'ALWAYS_ACCEPT',
-      'meta_gl-v3-listed': 'public',
-      'meta_bbb-origin-version': 3,
-      'meta_bbb-origin': 'Greenlight'
-    }
+    MeetingOption.bbb_option_names_default_values.to_h
   end
 end

--- a/app/services/meeting_config.rb
+++ b/app/services/meeting_config.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'bigbluebutton_api'
+
+class MeetingConfig
+  # UI only meeting options (These options has no use to be stored in the db).
+  UI_OPTION_NAMES = ['glJoinOnStart'].freeze
+
+  def initialize(room:, options:)
+    @room = room
+    @options = options
+  end
+
+  def create_meeting_options!
+    meeting_options_ids = MeetingOption.public_option_names_ids.to_h
+    public_options = MeetingOption.public_option_names
+
+    @options&.each do |option, value|
+      str_option = option.to_s
+      str_value = value.to_s
+
+      next unless public_options.include? str_option # Accept relevant options to the backend only.
+
+      RoomMeetingOption.create! room_id: @room.id, meeting_option_id: meeting_options_ids[str_option], value: str_value
+    end
+  end
+
+  # Class methods
+  class << self
+    # All of the expected meeting options that will be set by the room owner.
+    def option_names
+      MeetingOption.public_option_names + UI_OPTION_NAMES
+    end
+  end
+end

--- a/spec/factories/meeting_option_factory.rb
+++ b/spec/factories/meeting_option_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :meeting_option do
+    name { Faker::Types.unique.rb_string }
+    default_value { Faker::Types.rb_string }
+  end
+end

--- a/spec/models/meeting_option_spec.rb
+++ b/spec/models/meeting_option_spec.rb
@@ -8,4 +8,87 @@ RSpec.describe MeetingOption, type: :model do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }
   end
+
+  describe 'scopes' do
+    let(:public_option_names) { %w[bbbOption1 bbbOption2 glOption1 glOption2] }
+    let(:private_option_names) { %w[privatePW meta_option] }
+    let(:bbb_option_names) { %w[bbbOption1 bbbOption2 privatePW meta_option] }
+    let(:gl_option_names) { %w[glOption1 glOption2] }
+    let(:password_option_names) { %w[privatePW] }
+
+    before do
+      public_option_names.each { |name| create :meeting_option, name: }
+      private_option_names.each { |name| create :meeting_option, name: }
+    end
+
+    describe '#gl_options' do
+      it 'returns all meeting options with a "gl" prefix' do
+        gl_option_names_from_scope = described_class.gl_options.pluck :name
+        expect(gl_option_names - gl_option_names_from_scope).to be_empty
+      end
+    end
+
+    describe '#bbb_options' do
+      it 'returns all meeting options without a "gl" prefix' do
+        bbb_option_names_from_scope = described_class.bbb_options.pluck :name
+        expect(bbb_option_names - bbb_option_names_from_scope).to be_empty
+      end
+    end
+
+    describe '#password_options' do
+      it 'returns all meeting options having any "PW" substring' do
+        password_option_names_from_scope = described_class.password_options.pluck :name
+        expect(password_option_names - password_option_names_from_scope).to be_empty
+      end
+    end
+
+    describe '#public_options' do
+      it 'returns all meeting options without any "PW" substring or "meta" prefix' do
+        public_option_names_from_scope = described_class.public_options.pluck :name
+        expect(public_option_names - public_option_names_from_scope).to be_empty
+      end
+    end
+  end
+
+  describe 'class methods' do
+    describe 'public options' do
+      let(:public_option_names) { %w[option option1 option2] }
+      let(:public_option_names_ids) { public_option_names.each_with_index.to_a }
+      let(:public_options) { public_option_names_ids.map { |name, id| { id:, name: } } }
+
+      before { allow(described_class).to receive(:public_options).and_return public_options }
+
+      describe '#public_option_names' do
+        it 'calls public_options scope and returns an array of public meeting option names' do
+          expect(described_class).to receive(:public_options)
+          expect(described_class.public_option_names - public_option_names).to be_empty
+        end
+      end
+
+      describe '#public_option_names_ids' do
+        it 'calls public_options scope and returns a 2D array of vecotrs of public meeting option ids and names' do
+          expect(described_class).to receive(:public_options)
+          expect(described_class.public_option_names_ids - public_option_names_ids).to be_empty
+        end
+      end
+    end
+
+    describe 'password options' do
+      let(:password_options) do
+        password_option_names = %w[secretPW privatePW]
+        password_option_names_ids = password_option_names.each_with_index.to_a
+        password_option_names_ids.map { |name, id| { id:, name: } }
+      end
+      let(:password_option_ids) { password_options.pluck :id }
+
+      before { allow(described_class).to receive(:password_options).and_return password_options }
+
+      describe '#password_options_ids' do
+        it 'calls private_option scope and returns an array of the ids of all password options' do
+          expect(described_class).to receive(:password_options)
+          expect(described_class.password_option_ids - password_option_ids).to be_empty
+        end
+      end
+    end
+  end
 end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -29,6 +29,26 @@ RSpec.describe Room, type: :model do
     end
   end
 
+  describe 'after_create' do
+    let(:room) { create(:room) }
+
+    before do
+      create :meeting_option, name: 'attendeePW', default_value: ''
+      create :meeting_option, name: 'moderatorPW', default_value: ''
+    end
+
+    describe '#set_passwords' do
+      it 'creates and sets the moderatorPW and attendeePW meeting options for the created room' do
+        password_option_ids = MeetingOption.password_option_ids
+        room_meeting_options_ids_values = room.room_meeting_options.pluck(:meeting_option_id, :value).to_h
+
+        password_option_ids&.each do |id|
+          expect(room_meeting_options_ids_values[id]).to be_present
+        end
+      end
+    end
+  end
+
   describe 'validations' do
     subject { create(:room) }
 

--- a/spec/services/meeting_config_spec.rb
+++ b/spec/services/meeting_config_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe MeetingConfig, type: :service do
+  describe '#create_meeting_options!' do
+    let(:room) { create :room }
+    let(:existent_options) do
+      {
+        option: 'value',
+        option1: 'value1'
+      }
+    end
+
+    let(:inexistent_options) do
+      {
+        something: 'something',
+        something1: 'something1'
+      }
+    end
+
+    before do
+      create :meeting_option, name: 'option'
+      create :meeting_option, name: 'option1'
+      create :meeting_option, name: 'option2'
+    end
+
+    it 'creates room_meeting_options for existent meeting_options' do
+      expect(MeetingOption.count).not_to be_zero
+      meeting_config = described_class.new(room:, options: existent_options)
+      expect { meeting_config.create_meeting_options! }.to change { room.room_meeting_options.count }.from(0)
+    end
+
+    it 'filters out any inexistent room_meeting_options in the list of public_options' do
+      expect(MeetingOption.count).not_to be_zero
+      inexistent_options_string_keys = inexistent_options.keys.map(&:to_s)
+      expect(MeetingOption.public_option_names & inexistent_options_string_keys).to be_empty
+      meeting_config = described_class.new(room:, options: inexistent_options)
+      expect { meeting_config.create_meeting_options! }.not_to(change { room.room_meeting_options.count })
+    end
+  end
+
+  describe '#MeetingConfig.option_names' do
+    before { allow(MeetingOption).to receive(:public_option_names).and_return(%w[option option1 option2]) }
+
+    it 'returns a joined array of MeetingOption.public_option_names and MeetingConfig::UI_OPTION_NAMES' do
+      expect(MeetingOption).to receive(:public_option_names)
+      option_names = MeetingOption.public_option_names + described_class::UI_OPTION_NAMES
+      expect(described_class.option_names - option_names).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Now any created room on GL will use its created meeting options or the default ones for each start of a meeting.
**TODO:**
   - Refactor the code.
   - Add and update tests.
## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
