### PR TITLE
Backend: Added default meeting options creation on room create.

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -10,6 +10,7 @@ class Room < ApplicationRecord
   validates :meeting_id, presence: true, uniqueness: true
 
   before_validation :set_friendly_id, :set_meeting_id, on: :create
+  after_create :set_meeting_passwords!
 
   private
 
@@ -30,5 +31,15 @@ class Room < ApplicationRecord
     self.meeting_id = id
   rescue StandardError
     retry
+  end
+
+  # Generates and sets the 'attendeePW' and the 'moderatorPW' for the room meeting
+  def set_meeting_passwords!
+    password_option_ids = MeetingOption.where('name LIKE ?', '%PW').pluck(:id)
+
+    password_option_ids.each do |id|
+      # TODO: Revisit the password random value.
+      RoomMeetingOption.create! room_id: self.id, meeting_option_id: id, value: SecureRandom.alphanumeric(20)
+    end
   end
 end

--- a/spec/factories/meeting_option_factory.rb
+++ b/spec/factories/meeting_option_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :meeting_option do
+    name { Faker::Types.unique.rb_string }
+    default_value { Faker::Types.rb_string }
+  end
+end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -29,6 +29,31 @@ RSpec.describe Room, type: :model do
     end
   end
 
+  describe 'after_create' do
+    before do
+      create_list :meeting_option, 5
+    end
+
+    describe '#set_meeting_passwords' do
+      before do
+        create :meeting_option, name: 'somePW', default_value: ''
+        create :meeting_option, name: 'someOtherPW', default_value: ''
+      end
+
+      it 'creates and sets the password meeting options for the created room' do
+        room = create(:room)
+
+        password_option_ids_default_values_hash = MeetingOption.where('name LIKE ?', '%PW').pluck(:id, :default_value).to_h
+        room_meeting_options_ids_values = room.room_meeting_options.pluck(:meeting_option_id, :value).to_h
+        expect(room.room_meeting_options.count).to eq(password_option_ids_default_values_hash.size)
+
+        password_option_ids_default_values_hash&.each_key do |id|
+          expect(room_meeting_options_ids_values[id]).not_to eq(password_option_ids_default_values_hash[id])
+        end
+      end
+    end
+  end
+
   describe 'validations' do
     subject { create(:room) }
 

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -34,18 +34,27 @@ RSpec.describe Room, type: :model do
       create_list :meeting_option, 5
     end
 
+    describe '#create_default_meeting_options!' do
+      it 'fetches and creates all saved none password meeting options for the created room with default values' do
+        room = create(:room)
+        default_meeting_options_ids_values_hash = MeetingOption.pluck(:id, :default_value).to_h
+        room_meeting_option_ids_values_hash = room.room_meeting_options.pluck(:meeting_option_id, :value).to_h
+        expect(room_meeting_option_ids_values_hash).to eq(default_meeting_options_ids_values_hash)
+      end
+    end
+
     describe '#set_meeting_passwords' do
       before do
         create :meeting_option, name: 'somePW', default_value: ''
         create :meeting_option, name: 'someOtherPW', default_value: ''
       end
 
-      it 'creates and sets the password meeting options for the created room' do
+      it 'creates and sets the password meeting options and the rest of the default options for the created room' do
         room = create(:room)
+        expect(room.room_meeting_options.count).to eq(MeetingOption.count)
 
         password_option_ids_default_values_hash = MeetingOption.where('name LIKE ?', '%PW').pluck(:id, :default_value).to_h
         room_meeting_options_ids_values = room.room_meeting_options.pluck(:meeting_option_id, :value).to_h
-        expect(room.room_meeting_options.count).to eq(password_option_ids_default_values_hash.size)
 
         password_option_ids_default_values_hash&.each_key do |id|
           expect(room_meeting_options_ids_values[id]).not_to eq(password_option_ids_default_values_hash[id])


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Creating a room now will cause the creation of the room meeting options for all saved meeting options with their default values.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
