### PR TITLE
Frontend: Hot patch to dismiss the create room modal.

### DIFF
--- a/app/javascript/components/forms/CreateRoomForm.jsx
+++ b/app/javascript/components/forms/CreateRoomForm.jsx
@@ -12,7 +12,7 @@ import { createRoomFormConfig, createRoomFormFields } from '../../helpers/forms/
 
 export default function CreateRoomForm({ handleClose }) {
   const methods = useForm(createRoomFormConfig);
-  const { handleCreateRoom: onSubmit } = useCreateRoom();
+  const { handleCreateRoom: onSubmit } = useCreateRoom({ onSettled: handleClose });
   const { isSubmitting } = methods.formState;
   const fields = createRoomFormFields;
 

--- a/app/javascript/hooks/mutations/rooms/useCreateRoom.jsx
+++ b/app/javascript/hooks/mutations/rooms/useCreateRoom.jsx
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from 'react-query';
 import axios, { ENDPOINTS } from '../../../helpers/Axios';
 
-export default function useCreateRoom() {
+export default function useCreateRoom({ onSettled }) {
   const ROOMSLISTQUERYKEY = 'getRooms'; // TODO: amir - create a central store for query keys.
   const queryClient = useQueryClient();
 
@@ -39,6 +39,7 @@ export default function useCreateRoom() {
       // Always refetch after error or success:
       onSettled: () => {
         queryClient.invalidateQueries(ROOMSLISTQUERYKEY);
+        onSettled();
       },
     },
   );


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Now after the `createRoom` mutation completes (on success or on error) the create room modal will get dismissed.
## Testing Steps
<!--- Please describe in detail how to test your changes. -->
<!--- Please describe in detail how to test your changes. -->
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/29759616/165969243-faa5a8f5-7a53-4667-996c-294dcc59f299.png)
![image](https://user-images.githubusercontent.com/29759616/165969282-f4b09447-5747-4306-8c76-3bdc1677e1d4.png)
