### PR TITLE
Added waiting for room to start functionality

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
     - 'db/data_schema.rb'
     - 'vendor/**/*'
     - 'vendor/bundle/**/*'
+    - 'config/routes.rb'
   DisabledByDefault: false
   TargetRubyVersion: 3.1
   NewCops: enable

--- a/app/channels/rooms_channel.rb
+++ b/app/channels/rooms_channel.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RoomsChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "#{params[:friendly_id]}_rooms_channel"
+  end
+
+  def unsubscribed; end
+end

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -39,6 +39,8 @@ module Api
           join_url = bbb_api.start_meeting room: @room, meeting_starter: current_user, options: options
           logger.info "meeting successfully started for room(friendly_id):#{@room.friendly_id} by #{meeting_starter}."
 
+          ActionCable.server.broadcast "#{@room.friendly_id}_rooms_channel", join_url.to_s
+
           render_json data: { join_url: }, status: :created
         rescue BigBlueButton::BigBlueButtonException => e
           retries += 1

--- a/app/javascript/channels/consumer.jsx
+++ b/app/javascript/channels/consumer.jsx
@@ -1,0 +1,6 @@
+// Action Cable provides the framework to deal with WebSockets in Rails.
+// You can generate new channels where WebSocket features live using the `bin/rails generate channel` command.
+
+import { createConsumer } from '@rails/actioncable';
+
+export default createConsumer();

--- a/app/javascript/channels/index.jsx
+++ b/app/javascript/channels/index.jsx
@@ -1,0 +1,3 @@
+// Import all the channels to be used by Action Cable
+import '@rails/actioncable';
+import './rooms_channel';

--- a/app/javascript/channels/rooms_channel.jsx
+++ b/app/javascript/channels/rooms_channel.jsx
@@ -1,0 +1,24 @@
+import consumer from './consumer';
+
+export default function subscribeToRoom(friendlyId) {
+  consumer.subscriptions.create({
+    channel: 'RoomsChannel',
+    friendly_id: friendlyId,
+  }, {
+    connected() {
+      // Called when the subscription is ready for use on the server
+      console.log('connected');
+    },
+
+    disconnected() {
+      // Called when the subscription has been terminated by the server
+      console.log('disconnected');
+    },
+
+    received(joinUrl) {
+      // Called when there's incoming data on the websocket for this channel
+      console.log('received');
+      window.location.replace(joinUrl);
+    },
+  });
+}

--- a/app/javascript/components/rooms/RoomJoin.jsx
+++ b/app/javascript/components/rooms/RoomJoin.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Card from 'react-bootstrap/Card';
+import { useParams } from 'react-router-dom';
+import { Button, Col } from 'react-bootstrap';
+import FormLogo from '../forms/FormLogo';
+import useRoom from '../../hooks/queries/rooms/useRoom';
+import Spinner from '../shared/stylings/Spinner';
+import subscribeToRoom from '../../channels/rooms_channel';
+
+export default function RoomJoin() {
+  const { friendlyId } = useParams();
+  const { isLoading, data: room } = useRoom(friendlyId);
+  if (isLoading) return <Spinner />;
+
+  return (
+    <div className="wide-background">
+      <FormLogo />
+      <Card className="col-md-6 mx-auto p-4 border-0 shadow-sm">
+        <div className="mt-4">
+          <Col>
+            <Card.Subtitle className="text-muted mb-1">You have been invited to join</Card.Subtitle>
+            <Card.Title className="pb-2">
+              { room.name }
+            </Card.Title>
+          </Col>
+          <Col />
+        </div>
+
+        <Card.Footer className="mt-4 bg-white text-center">
+          <Button onClick={() => subscribeToRoom(friendlyId)}>Join</Button>
+        </Card.Footer>
+      </Card>
+    </div>
+  );
+}

--- a/app/javascript/main.jsx
+++ b/app/javascript/main.jsx
@@ -12,6 +12,7 @@ import Profile from './components/users/Profile';
 import Room from './components/rooms/Room';
 import Rooms from './components/rooms/Rooms';
 import HomePage from './components/home_page/HomePage';
+import RoomJoin from './components/rooms/RoomJoin';
 
 const queryClient = new QueryClient();
 
@@ -27,6 +28,7 @@ const root = (
             <Route path="/profile" element={<Profile />} />
             <Route path="/rooms" element={<Rooms />} />
             <Route path="/rooms/:friendlyId" element={<Room />} />
+            <Route path="/rooms/:friendlyId/join" element={<RoomJoin />} />
             <Route path="*" element={<h1 className="text-center">404</h1>} />
           </Route>
         </Routes>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@
 
 Rails.application.routes.draw do
   root 'components#index', via: :all
+  mount ActionCable.server => '/cable'
 
   # All the Api endpoints must be under /api/v1 and must have an extension .json.
   namespace :api do

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@hookform/resolvers": "^2.8.8",
         "@hotwired/turbo-rails": "^7.1.1",
         "@popperjs/core": "^2.11.2",
+        "@rails/actioncable": "^7.0.2",
         "axios": "^0.26.1",
         "babel-jest": "^27.5.1",
         "bootstrap": "^5.1.3",
@@ -2215,8 +2216,7 @@
     "node_modules/@rails/actioncable": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@rails/actioncable/-/actioncable-7.0.2.tgz",
-      "integrity": "sha512-G26maXW1Kx0LxQdmNNuNjQlRO/QlXNr3QfuwKiOKb5FZQGYe2OwtHTGXBAjSoiu4dW36XYMT/+L1Wo1Yov4ZXA==",
-      "license": "MIT"
+      "integrity": "sha512-G26maXW1Kx0LxQdmNNuNjQlRO/QlXNr3QfuwKiOKb5FZQGYe2OwtHTGXBAjSoiu4dW36XYMT/+L1Wo1Yov4ZXA=="
     },
     "node_modules/@react-aria/ssr": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@hookform/resolvers": "^2.8.8",
     "@hotwired/turbo-rails": "^7.1.1",
     "@popperjs/core": "^2.11.2",
+    "@rails/actioncable": "^7.0.2",
     "axios": "^0.26.1",
     "babel-jest": "^27.5.1",
     "bootstrap": "^5.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1282,7 +1282,7 @@
   "resolved" "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz"
   "version" "2.11.2"
 
-"@rails/actioncable@^7.0":
+"@rails/actioncable@^7.0", "@rails/actioncable@^7.0.2":
   "integrity" "sha512-G26maXW1Kx0LxQdmNNuNjQlRO/QlXNr3QfuwKiOKb5FZQGYe2OwtHTGXBAjSoiu4dW36XYMT/+L1Wo1Yov4ZXA=="
   "resolved" "https://registry.npmjs.org/@rails/actioncable/-/actioncable-7.0.2.tgz"
   "version" "7.0.2"


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

To try and keep this PR as simple as possible, this does not include:
- The check to see if a room has already started (it treats all rooms as if they haven't started)
- Visual waiting indicator

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
1. Go to any room and add `/join` to the end of the url
2. Open the room in another tab
3. Click `join` on the first window
4. Wait a couple seconds and click start on the second window
5. Ensure the first window is redirected at the same time

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
