### PR TITLE
Added the full joining functionality

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,3 +56,6 @@ Metrics/BlockLength:
 # branches, and conditions.
 Metrics/AbcSize:
   Max: 65
+
+RSpec/AnyInstance:
+  Enabled: false

--- a/app/javascript/channels/rooms_channel.jsx
+++ b/app/javascript/channels/rooms_channel.jsx
@@ -8,7 +8,6 @@ export default function subscribeToRoom(friendlyId, joinUrl) {
     connected() {
       // Called when the subscription is ready for use on the server
       console.log('connected');
-      console.log(joinUrl);
     },
 
     disconnected() {
@@ -19,7 +18,6 @@ export default function subscribeToRoom(friendlyId, joinUrl) {
     received() {
       // Called when there's incoming data on the websocket for this channel
       console.log('received');
-      console.log(joinUrl);
       window.location.replace(joinUrl);
     },
   });

--- a/app/javascript/channels/rooms_channel.jsx
+++ b/app/javascript/channels/rooms_channel.jsx
@@ -1,6 +1,6 @@
 import consumer from './consumer';
 
-export default function subscribeToRoom(friendlyId) {
+export default function subscribeToRoom(friendlyId, joinUrl) {
   consumer.subscriptions.create({
     channel: 'RoomsChannel',
     friendly_id: friendlyId,
@@ -8,6 +8,7 @@ export default function subscribeToRoom(friendlyId) {
     connected() {
       // Called when the subscription is ready for use on the server
       console.log('connected');
+      console.log(joinUrl);
     },
 
     disconnected() {
@@ -15,9 +16,10 @@ export default function subscribeToRoom(friendlyId) {
       console.log('disconnected');
     },
 
-    received(joinUrl) {
+    received() {
       // Called when there's incoming data on the websocket for this channel
       console.log('received');
+      console.log(joinUrl);
       window.location.replace(joinUrl);
     },
   });

--- a/app/javascript/components/rooms/RoomJoin.jsx
+++ b/app/javascript/components/rooms/RoomJoin.jsx
@@ -1,15 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Card from 'react-bootstrap/Card';
 import { useParams } from 'react-router-dom';
 import { Button, Col } from 'react-bootstrap';
 import FormLogo from '../forms/FormLogo';
 import useRoom from '../../hooks/queries/rooms/useRoom';
+import useRoomJoin from '../../hooks/queries/rooms/useRoomJoin';
 import Spinner from '../shared/stylings/Spinner';
-import subscribeToRoom from '../../channels/rooms_channel';
+import useRoomStatus from '../../hooks/queries/rooms/useRoomStatus';
+
+function waitOrJoin(refetchJoin, refetchStatus) {
+  refetchStatus();
+  refetchJoin();
+}
 
 export default function RoomJoin() {
   const { friendlyId } = useParams();
+  const [name, setName] = useState('');
   const { isLoading, data: room } = useRoom(friendlyId);
+  const { refetch: refetchJoin } = useRoomJoin(friendlyId, name);
+  const { refetch: refetchStatus } = useRoomStatus(friendlyId, name);
   if (isLoading) return <Spinner />;
 
   return (
@@ -27,7 +36,14 @@ export default function RoomJoin() {
         </div>
 
         <Card.Footer className="mt-4 bg-white text-center">
-          <Button onClick={() => subscribeToRoom(friendlyId)}>Join</Button>
+          <input
+            type="text"
+            id="join-name"
+            placeholder="Enter your name..."
+            className="form-control"
+            onChange={(event) => setName(event.target.value)}
+          />
+          <Button onClick={() => waitOrJoin(refetchJoin, refetchStatus)}>Join</Button>
         </Card.Footer>
       </Card>
     </div>

--- a/app/javascript/components/shared/stylings/Spinner.jsx
+++ b/app/javascript/components/shared/stylings/Spinner.jsx
@@ -6,8 +6,7 @@ export default function Spinner() {
     <BootstrapSpinner
       className="mx-1"
       as="span"
-      animation="grow"
-      size="sm"
+      animation="border"
       role="status"
       aria-hidden="true"
     />

--- a/app/javascript/hooks/queries/rooms/useRoomJoin.jsx
+++ b/app/javascript/hooks/queries/rooms/useRoomJoin.jsx
@@ -1,0 +1,21 @@
+import { useQuery } from 'react-query';
+import axios from 'axios';
+import subscribeToRoom from '../../../channels/rooms_channel';
+
+export default function useRoomJoin(friendlyId, name) {
+  return useQuery(
+    ['getRoomJoin', name],
+    () => axios.get(`/api/v1/rooms/${friendlyId}/join.json`, {
+      params: {
+        name,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    }).then((resp) => { subscribeToRoom(friendlyId, resp.data.data); }),
+    {
+      enabled: false,
+    },
+  );
+}

--- a/app/javascript/hooks/queries/rooms/useRoomStatus.jsx
+++ b/app/javascript/hooks/queries/rooms/useRoomStatus.jsx
@@ -1,0 +1,25 @@
+import { useQuery } from 'react-query';
+import axios from 'axios';
+
+export default function useRoomStatus(friendlyId, name) {
+  return useQuery(
+    ['getRoomStatus', name],
+    () => axios.get(`/api/v1/rooms/${friendlyId}/status.json`, {
+      params: {
+        name,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    }).then((resp) => {
+      const response = resp.data.data;
+      if (response.status) {
+        window.location.replace(response.joinUrl);
+      }
+    }),
+    {
+      enabled: false,
+    },
+  );
+}

--- a/app/services/big_blue_button_api.rb
+++ b/app/services/big_blue_button_api.rb
@@ -24,6 +24,14 @@ class BigBlueButtonApi
     bbb_server.join_meeting_url room.friendly_id, user_name, password, join_options
   end
 
+  def join_meeting(room:, name:)
+    bbb_server.join_meeting_url room.friendly_id, name, '', { role: 'Viewer' }
+  end
+
+  def meeting_running?(room:)
+    bbb_server.is_meeting_running?(room.friendly_id)
+  end
+
   private
 
   def bbb_endpoint

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
         member do
           post '/start', to: 'rooms#start', as: :start_meeting
           get '/recordings', to: 'rooms#recordings'
+          get '/join', to: 'rooms#join'
+          get '/status', to: 'rooms#status'
         end
       end
       resources :recordings, only: [:index]

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -111,4 +111,32 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
       expect(recording_ids).to be_empty
     end
   end
+
+  describe '#join' do
+    it 'calls the BigBlueButton service with the right values' do
+      room = create(:room, user:)
+
+      expect_any_instance_of(BigBlueButtonApi).to receive(:join_meeting).with(room:, name: user.name)
+      get :join, params: { friendly_id: room.friendly_id, name: user.name }
+    end
+  end
+
+  describe '#status' do
+    it 'calls the BigBlueButton service with the right values' do
+      room = create(:room, user:)
+
+      expect_any_instance_of(BigBlueButtonApi).to receive(:meeting_running?).with(room:)
+
+      get :status, params: { friendly_id: room.friendly_id, name: user.name }
+    end
+
+    it 'gets the joinUrl if the meeting is running' do
+      room = create(:room, user:)
+
+      allow_any_instance_of(BigBlueButtonApi).to receive(:meeting_running?).and_return(true)
+      expect_any_instance_of(BigBlueButtonApi).to receive(:join_meeting).with(room:, name: user.name)
+
+      get :status, params: { friendly_id: room.friendly_id, name: user.name }
+    end
+  end
 end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Both joining scenarios are now complete.
1. If the room has already started, the user will be joined into the room immediately with his name reflecting the value of the input field
2. If the room has not started, the user will go into a waiting state (UI still needs to be touched up). Once the room starts, the user will be automatically joined into the room

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
1. Copy the join url and then start the room
2. Paste the join url into an incognito tab and then enter a name and join
3. Ensure that you're automatically joined into the room
4. End the meeting and repeat, except this time, clicking Join first before the meeting has started
5. Ensure that the waiting user joins the room once the meeting has started

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
