### PR TITLE
Recording sync front end

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,7 @@ Metrics/BlockLength:
   IgnoredMethods: [ 'describe', 'context' ]
   Exclude:
     - 'config/routes.rb'
+  Max: 30
 
 # A calculated magnitude based on number of assignments,
 # branches, and conditions.

--- a/app/controllers/api/v1/recordings_controller.rb
+++ b/app/controllers/api/v1/recordings_controller.rb
@@ -3,6 +3,8 @@
 module Api
   module V1
     class RecordingsController < ApplicationController
+      skip_before_action :verify_authenticity_token # TODO: - Revisit this.
+
       # GET /api/v1/recordings.json
       # Returns: { data: Array[serializable objects(recordings)] , errors: Array[String] }
       # Does: Returns all the Recordings from all the current user's rooms
@@ -10,6 +12,13 @@ module Api
         recordings = current_user.recordings&.includes(:formats)
 
         render_json(data: recordings, status: :ok, include: :formats)
+      end
+
+      def recordings
+        recording_sync = RecordingSync.new
+        recording_sync.recording_resync(user: current_user)
+
+        render_json(status: :ok)
       end
     end
   end

--- a/app/controllers/api/v1/recordings_controller.rb
+++ b/app/controllers/api/v1/recordings_controller.rb
@@ -15,8 +15,7 @@ module Api
       end
 
       def recordings
-        recording_sync = RecordingSync.new
-        recording_sync.recording_resync(user: current_user)
+        RecordingsSync.new(user: current_user).call
 
         render_json(status: :ok)
       end

--- a/app/javascript/components/recordings/Recordings.jsx
+++ b/app/javascript/components/recordings/Recordings.jsx
@@ -1,17 +1,23 @@
 import React from 'react';
-import { Table, Card, Row } from 'react-bootstrap';
+import {
+  Table, Card, Row, Button,
+} from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faVideo } from '@fortawesome/free-solid-svg-icons';
 import Spinner from '../shared/stylings/Spinner';
 import useRecordings from '../../hooks/queries/recordings/useRecordings';
+import useRecordingsReSync from '../../hooks/queries/recordings/useRecordingsReSync';
 
 export default function Recordings() {
   const { isLoading, data: recordings } = useRecordings();
+  const { refetch: handleRecordingReSync } = useRecordingsReSync();
+
   if (isLoading) return <Spinner />;
 
   return (
     <div className="pt-3 wide-background full-height-rooms">
       <Row>
+        <Button className="my-2" onClick={handleRecordingReSync}>Re-sync Recordings</Button>
         <Card className="border-0 shadow-sm">
           <Table hover className="text-secondary mb-0">
             <thead>

--- a/app/javascript/helpers/Axios.jsx
+++ b/app/javascript/helpers/Axios.jsx
@@ -6,6 +6,7 @@ export const ENDPOINTS = {
   start_meeting: (friendlyId) => `rooms/${friendlyId}/start.json`,
   createRoom: '/rooms.json',
   recordings: '/recordings.json',
+  recordings_resync: '/recordings/recordingsReSync.json',
   room_recordings: (friendlyId) => `/rooms/${friendlyId}/recordings.json`,
 };
 

--- a/app/javascript/hooks/queries/recordings/useRecordingsReSync.jsx
+++ b/app/javascript/hooks/queries/recordings/useRecordingsReSync.jsx
@@ -1,0 +1,12 @@
+import { useQuery, useQueryClient } from 'react-query';
+
+import axios, { ENDPOINTS } from '../../../helpers/Axios';
+
+export default function useRecordingsReSync() {
+  const queryClient = useQueryClient();
+
+  return useQuery('getRecordingsResync', () => axios.get(ENDPOINTS.recordings_resync, {
+  }).then(() => queryClient.invalidateQueries('getRecordings')), {
+    enabled: false,
+  });
+}

--- a/app/services/big_blue_button_api.rb
+++ b/app/services/big_blue_button_api.rb
@@ -32,6 +32,11 @@ class BigBlueButtonApi
     bbb_server.is_meeting_running?(room.friendly_id)
   end
 
+  # Retrieve the recordings that belong to room with given meeting_id
+  def get_recordings(meeting_ids:)
+    bbb_server.get_recordings(meetingID: meeting_ids)
+  end
+
   private
 
   def bbb_endpoint

--- a/app/services/recording_sync.rb
+++ b/app/services/recording_sync.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class RecordingSync
+  def initialize; end
+
+  def recording_resync(user:)
+    bbb_api = BigBlueButtonApi.new
+    rooms = user.rooms
+
+    # Get the meeting_id of all the current user's rooms
+    meeting_ids = rooms.map(&:meeting_id)
+
+    # Clear current recordings
+    Recording.destroy_by(room_id: rooms.map(&:id))
+
+    # Get recordings
+    recordings = bbb_api.get_recordings(meeting_ids:)
+
+    # Create new recordings
+    recordings[:recordings].each do |recording|
+      room_id = Room.find_by(meeting_id: recording[:meetingID]).id
+
+      # Get length of presentation format(s)
+      length = get_recording_length(recording:)
+
+      # Create recording
+      new_recording = Recording.create(room_id:, name: recording[:name], record_id: recording[:recordID], visibility: 'Unlisted',
+                                       users: recording[:participants], length:)
+
+      # Create format(s)
+      create_formats(recording:, new_recording:)
+    end
+  end
+
+  private
+
+  # Returns the length of presentation recording for the recording given
+  def get_recording_length(recording:)
+    length = 0
+    if recording[:playback][:format].is_a?(Array)
+      recording[:playback][:format].each do |formats|
+        length = formats[:length] if formats[:type] == 'presentation'
+      end
+    else
+      length = recording[:playback][:format][:length]
+    end
+    length
+  end
+
+  # Creates format(s) for given new_recording
+  def create_formats(recording:, new_recording:)
+    if recording[:playback][:format].is_a?(Array)
+      recording[:playback][:format].each do |format|
+        Format.create(recording_id: new_recording.id, recording_type: format[:type], url: format[:url])
+      end
+    else
+      Format.create(recording_id: new_recording.id, recording_type: recording[:playback][:format][:type], url: recording[:playback][:format][:url])
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,11 @@ Rails.application.routes.draw do
         end
       end
       resources :room_settings, only: %i[show update], param: :friendly_id
-      resources :recordings, only: [:index]
+      resources :recordings, only: [:index] do
+        collection do
+          get '/recordingsReSync', to: 'recordings#recordings'
+        end
+      end
     end
   end
   match '*path', to: 'components#index', via: :all, constraints: lambda { |req|

--- a/spec/services/big_blue_button_api_spec.rb
+++ b/spec/services/big_blue_button_api_spec.rb
@@ -68,5 +68,12 @@ describe BigBlueButtonApi, type: :service do
         bbb_service.start_meeting room:, meeting_starter: nil, options: {}
       end
     end
+
+    describe 'calls bbb#get_recordings' do
+      it 'With list of meeting ids given as param' do
+        expect(bbb_server).to receive(:get_recordings).with(meetingID: [1, 2, 3])
+        bbb_service.get_recordings(meeting_ids: [1, 2, 3])
+      end
+    end
   end
 end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
New recording resync feature
- When button is pressed on the front end of the recordings page, recording_resync is triggered and then the back end is triggered
## Testing Steps
<!--- Please describe in detail how to test your changes. -->
- Create branch
- Pull code
- Create two rooms
- Put one room with meeting_id random-5678484
- Put the other room with meetinf_id random-1291479
- Change .env file for GL to point to this server:

- Run your server
- Go to recordings page and click resync button
- Recordings should appear right after clicking the button


You can test this yourself as well by creating recordings on any bbb server using api mate, but to fully test it, you would need to enable other recording formats to test the creation of the recording when there are multiple formats given. https://docs.bigbluebutton.org/2.4/install.html#installing-additional-recording-processing-formats

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/38328371/168148049-67734ae5-4e06-49d3-b9d0-851f8e5a186a.png)
