### PR TITLE
Front-end: Recording Re-Sync

### DIFF
--- a/app/javascript/components/recordings/Recordings.jsx
+++ b/app/javascript/components/recordings/Recordings.jsx
@@ -1,17 +1,23 @@
 import React from 'react';
-import { Table, Card, Row } from 'react-bootstrap';
+import {
+  Table, Card, Row, Button,
+} from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faVideo } from '@fortawesome/free-solid-svg-icons';
 import Spinner from '../shared/stylings/Spinner';
 import useRecordings from '../../hooks/queries/recordings/useRecordings';
+import useRecordingsReSync from '../../hooks/queries/recordings/useRecordingsReSync';
 
 export default function Recordings() {
   const { isLoading, data: recordings } = useRecordings();
+  const { refetch: handleRecordingReSync } = useRecordingsReSync();
+
   if (isLoading) return <Spinner />;
 
   return (
     <div className="pt-3 wide-background full-height-rooms">
       <Row>
+        <Button className="my-2" onClick={handleRecordingReSync}>Re-sync Recordings</Button>
         <Card className="border-0 shadow-sm">
           <Table hover className="text-secondary mb-0">
             <thead>

--- a/app/javascript/helpers/Axios.jsx
+++ b/app/javascript/helpers/Axios.jsx
@@ -6,6 +6,7 @@ export const ENDPOINTS = {
   start_meeting: (friendlyId) => `rooms/${friendlyId}/start.json`,
   createRoom: '/rooms.json',
   recordings: '/recordings.json',
+  recordings_resync: '/recordings/recordingsReSync.json',
   room_recordings: (friendlyId) => `/rooms/${friendlyId}/recordings.json`,
 };
 

--- a/app/javascript/hooks/queries/recordings/useRecordingsReSync.jsx
+++ b/app/javascript/hooks/queries/recordings/useRecordingsReSync.jsx
@@ -1,0 +1,12 @@
+import { useQuery, useQueryClient } from 'react-query';
+
+import axios, { ENDPOINTS } from '../../../helpers/Axios';
+
+export default function useRecordingsReSync() {
+  const queryClient = useQueryClient();
+
+  return useQuery('getRecordingsResync', () => axios.get(ENDPOINTS.recordings_resync, {
+  }).then(() => queryClient.invalidateQueries('getRecordings')), {
+    enabled: false,
+  });
+}


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
New recording resync feature
- When button is pressed on the front end of the recordings page, recording_resync is triggered and then the back end is triggered
## Testing Steps
<!--- Please describe in detail how to test your changes. -->
- Create branch
- Pull code
- Create two rooms
- Put one room with meeting_id random-5678484
- Put the other room with meetinf_id random-1291479
- Change .env file for GL to point to this server:

- Run your server
- Go to recordings page and click resync button
- Recordings should appear right after clicking the button


You can test this yourself as well by creating recordings on any bbb server using api mate, but to fully test it, you would need to enable other recording formats to test the creation of the recording when there are multiple formats given. https://docs.bigbluebutton.org/2.4/install.html#installing-additional-recording-processing-formats

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/38328371/168148049-67734ae5-4e06-49d3-b9d0-851f8e5a186a.png)
