### PR TITLE
Move user_avatar method from User model to Controller/Concerns

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -6,6 +6,8 @@ module Api
       # TODO: samuel - Bypass CSRF token for now
       skip_before_action :verify_authenticity_token
 
+      include Avatarable
+
       # GET /api/v1/sessions
       def index
         if current_user
@@ -15,7 +17,7 @@ module Api
               name: current_user.name,
               email: current_user.email,
               provider: current_user.provider,
-              avatar: current_user.user_avatar,
+              avatar: user_avatar(current_user),
               signed_in: true
             }
           }

--- a/app/controllers/concerns/avatarable.rb
+++ b/app/controllers/concerns/avatarable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Avatarable
+  extend ActiveSupport::Concern
+
+  def user_avatar(user)
+    return url_for(user.avatar) if user.avatar.attached?
+
+    ActionController::Base.helpers.image_url('default-avatar.png')
+  end
+end

--- a/app/controllers/concerns/avatarable.rb
+++ b/app/controllers/concerns/avatarable.rb
@@ -6,6 +6,6 @@ module Avatarable
   def user_avatar(user)
     return url_for(user.avatar) if user.avatar.attached?
 
-    ActionController::Base.helpers.image_url('default-avatar.png')
+    view_context.image_url('default-avatar.png')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,13 +18,6 @@ class User < ApplicationRecord
   # TODO: samuel - ActiveStorage validations needs to be discussed and implemented.
   validate :avatar_validation
 
-  def user_avatar
-    return rails_blob_path(avatar) if avatar.attached?
-
-    # TODO: samuel - Dirty implementation, the asset url is usually generated via a view helper (image_tag)
-    ActionController::Base.helpers.image_url('default-avatar.png')
-  end
-
   private
 
   def avatar_validation


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Move the user_avatar method from the User model to a Controller Concern.
Wherever the avatar url is needed, just add the following line `include Avatarable` in the controller and you will be able to use the `user_avatar(user)` method.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
