### PR TITLE
Allow room to be recorded

### DIFF
--- a/app/javascript/components/rooms/RoomSettings.jsx
+++ b/app/javascript/components/rooms/RoomSettings.jsx
@@ -40,6 +40,11 @@ export default function RoomSettings() {
                 value={checkedValue('muteOnStart')}
                 description="Automatically mute users when they join"
               />
+              <RoomSettingsRow
+                settingId="record"
+                value={checkedValue('record')}
+                description="Allow room to be recorded"
+              />
             </Col>
           </Row>
           <Row className="float-end">


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Room Setting
- Allows the user to set whether or not the room can be recorded or not
## Testing Steps
<!--- Please describe in detail how to test your changes. -->
- Pull code
- Create Room
- Go to room setting page
- Check the check box to true
- Go to rails console and find the room_meeting_option for that room (```Room.find(1).room_meeting_options```), and look at recording one (should be the first option) and see if the value changed from 'false' to 'true'
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/38328371/168896317-2d547fca-d9e3-4897-abd3-ad67f52b3faf.png)
