### PR TITLE
Fix single user issue with SharedAccess

### DIFF
--- a/app/controllers/api/v1/shared_accesses_controller.rb
+++ b/app/controllers/api/v1/shared_accesses_controller.rb
@@ -10,7 +10,7 @@ module Api
 
       # POST /api/v1/shared_accesses.json
       def create
-        user_ids = params[:users][:shared_users]
+        user_ids = params[:shared_users]
 
         shared_accesses = user_ids.map { |user_id| { user_id:, room_id: @room.id } }
 

--- a/app/javascript/components/forms/SharedAccessForm.jsx
+++ b/app/javascript/components/forms/SharedAccessForm.jsx
@@ -49,7 +49,7 @@ export default function SharedAccessForm({ handleClose }) {
                     value={user.id}
                     aria-label="tbd"
                     className="pe-3"
-                    {...register('users')}
+                    {...register('shared_users')}
                   />
                   <Avatar avatar={user.avatar} radius={40} />
                   <h6 className="text-primary mb-0 ps-3"> { user.name } </h6>

--- a/app/javascript/components/shared/SearchBar.jsx
+++ b/app/javascript/components/shared/SearchBar.jsx
@@ -22,6 +22,6 @@ export default function SearchBar({ id, setSearch }) {
 }
 
 SearchBar.propTypes = {
-  id: PropTypes.number.isRequired,
+  id: PropTypes.string.isRequired,
   setSearch: PropTypes.func.isRequired,
 };

--- a/app/javascript/hooks/mutations/shared_accesses/useShareAccess.jsx
+++ b/app/javascript/hooks/mutations/shared_accesses/useShareAccess.jsx
@@ -4,7 +4,10 @@ import axios from 'axios';
 export default function useShareAccess({ friendlyId, closeModal }) {
   const queryClient = useQueryClient();
 
-  const shareAccess = (users) => axios.post('/api/v1/shared_accesses.json', { friendly_id: friendlyId, users });
+  const shareAccess = (data) => {
+    const sharedUsers = [...data.shared_users];
+    return axios.post('/api/v1/shared_accesses.json', { friendly_id: friendlyId, shared_users: sharedUsers });
+  };
 
   const mutation = useMutation(shareAccess, {
     onSuccess: () => {

--- a/spec/controllers/shared_accesses_controller_spec.rb
+++ b/spec/controllers/shared_accesses_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::V1::SharedAccessesController, type: :controller do
     it 'shares a room with a user' do
       room = create(:room)
       user = create(:user)
-      post :create, params: { friendly_id: room.friendly_id, users: { shared_users: [user.id] } }
+      post :create, params: { friendly_id: room.friendly_id, shared_users: [user.id] }
       expect(user.shared_rooms).to include(room)
     end
   end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix an issue with SharedAccess where having only 1 shareable user would break the SharedAccess.

The form was sending an object instead of an array if there was only 1 shareable user.
But, we are using a .map on the form data.

The proposed solution is to put/merge the form data in an array with a spread operator.
`    const sharedUsers = [...data.shared_users];`
