### PR TITLE
hCaptcha sign-in and env var

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -30,7 +30,8 @@ module Api
       def create
         user = User.find_by(email: session_params[:email])
 
-        if user.present? && user.authenticate(session_params[:password])
+        # TODO: Add proper error logging for non-verified token hcaptcha
+        if user.present? && user.authenticate(session_params[:password]) && verify_hcaptcha(response: params[:token])
           sign_in user
           render json: { current_user:, signed_in: true }, status: :ok
         else

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -14,6 +14,7 @@ module Api
         # TODO: amir - ensure accessibility for unauthenticated requests only.
         user = User.new({ provider: 'greenlight' }.merge(user_params)) # TMP fix for presence validation of :provider
 
+        # TODO: Add proper error logging for non-verified token hcaptcha
         if verify_hcaptcha(response: params[:token]) && user.save
           session[:user_id] = user.id
           render_json status: :created

--- a/app/javascript/components/forms/SigninForm.jsx
+++ b/app/javascript/components/forms/SigninForm.jsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Button, Col, Row, Stack, Form as BootstrapForm,
+  Container,
 } from 'react-bootstrap';
 import { useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import FormControl from './FormControl';
 import Form from './Form';
 import { signinFormFields, signinFormConfig } from '../../helpers/forms/SigninFormHelpers';
@@ -12,9 +14,19 @@ import useCreateSession from '../../hooks/mutations/sessions/useCreateSession';
 
 export default function SigninForm() {
   const methods = useForm(signinFormConfig);
-  const { onSubmit } = useCreateSession();
+  const [token, setToken] = useState('');
+  const { onSubmit } = useCreateSession(token);
   const { isSubmitting } = methods.formState;
   const fields = signinFormFields;
+
+  const onError = (err) => {
+    console.log(`hCaptcha Error: ${err}`);
+  };
+
+  const onExpire = () => {
+    console.log('hCaptcha Token Expired');
+  };
+
   return (
     <Form methods={methods} onSubmit={onSubmit}>
       <FormControl field={fields.email} type="email" />
@@ -29,6 +41,15 @@ export default function SigninForm() {
           <Link to="/" className="text-link float-end small"> Forgot password? </Link>
         </Col>
       </Row>
+      <Container className="d-flex justify-content-center mt-3">
+        {/* TODO: - Make sitekey dynamic (Maybe ENV variable) */}
+        <HCaptcha
+          sitekey="10000000-ffff-ffff-ffff-000000000001"
+          onVerify={(response) => setToken(response)}
+          onError={onError}
+          onExpire={onExpire}
+        />
+      </Container>
       <Stack className="mt-1" gap={1}>
         <Button variant="primary" className="w-100 my-3 py-2" type="submit" disabled={isSubmitting}>
           Sign In

--- a/app/javascript/components/forms/SignupForm.jsx
+++ b/app/javascript/components/forms/SignupForm.jsx
@@ -32,7 +32,7 @@ export default function SignupForm() {
       <Container className="d-flex justify-content-center mt-3">
         {/* TODO: - Make sitekey dynamic (Maybe ENV variable) */}
         <HCaptcha
-          sitekey="deafadd9-444a-4025-bb80-86e83cd3aed2"
+          sitekey="10000000-ffff-ffff-ffff-000000000001"
           onVerify={(response) => setToken(response)}
           onError={onError}
           onExpire={onExpire}

--- a/app/javascript/hooks/mutations/sessions/useCreateSession.jsx
+++ b/app/javascript/hooks/mutations/sessions/useCreateSession.jsx
@@ -2,9 +2,8 @@ import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import axios, { ENDPOINTS } from '../../../helpers/Axios';
 
-const createSession = (userData) => axios.post(ENDPOINTS.signin, userData);
-
-export default function useCreateSession() {
+export default function useCreateSession(token) {
+  const createSession = (session) => axios.post(ENDPOINTS.signin, { session, token });
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
@@ -19,6 +18,6 @@ export default function useCreateSession() {
     },
   });
 
-  const onSubmit = (userData) => mutation.mutateAsync(userData).catch(/* Prevents the promise exception from bubbling */() => {});
+  const onSubmit = (session) => mutation.mutateAsync(session).catch(/* Prevents the promise exception from bubbling */() => {});
   return { onSubmit, ...mutation };
 }

--- a/config/initializers/hcaptcha.rb
+++ b/config/initializers/hcaptcha.rb
@@ -3,8 +3,8 @@
 # config/initializers/hcaptcha.rb
 
 Hcaptcha.configure do |config|
-  config.site_key = 'deafadd9-444a-4025-bb80-86e83cd3aed2'
-  config.secret_key = '0xf0422B999488FFa66dB89CDCda1923d939574Cd4'
+  config.site_key = ENV['RECAPTCHA_SITE_KEY']
+  config.secret_key = ENV['RECAPTCHA_SECRET_KEY']
   # # optional, default value = https://hcaptcha.com/siteverify
   # config.verify_url = 'VERIFY_URL'
   # # optional, default value = https://hcaptcha.com/1/api.js

--- a/sample.env
+++ b/sample.env
@@ -10,3 +10,8 @@ DATABASE_URL=
 #
 BIGBLUEBUTTON_ENDPOINT=
 BIGBLUEBUTTON_SECRET=
+
+# To enable hCaptcha on the user sign up and sign in, define these 2 keys
+#
+RECAPTCHA_SITE_KEY=
+RECAPTCHA_SECRET_KEY=


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- hCaptcha now enabled for sign in page as well
- Made the secret and site key editable in ENV vars
- Changed the site key and secret to the testing ones for now



**NOTE: Please add the following to your .env file once this is merged:**
```
RECAPTCHA_SITE_KEY=10000000-ffff-ffff-ffff-000000000001
RECAPTCHA_SECRET_KEY=0x0000000000000000000000000000000000000000
```
## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/38328371/171267706-ddca023e-f921-4e96-a71a-c9773e0efaef.png)
