### PR TITLE
Backend: Added 'lang' attribute to users records.

### DIFF
--- a/db/migrate/20220609103801_add_language_to_users.rb
+++ b/db/migrate/20220609103801_add_language_to_users.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddLanguageToUsers < ActiveRecord::Migration[7.0]
+  def change
+    change_table :users do |t|
+      t.string :language, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_31_182239) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_09_103801) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -123,6 +123,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_31_182239) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "role_id"
+    t.string "language", null: false
     t.index ["email", "provider"], name: "index_users_on_email_and_provider", unique: true
     t.index ["role_id"], name: "index_users_on_role_id"
   end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -9,5 +9,6 @@ FactoryBot.define do
     password { Faker::Internet.password }
     role
     last_login { nil }
+    language { %w[en fr es ar].sample }
   end
 end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users to set their preferred language and persist it on GL database and fetch it later on by the client app.

This PR completes **1.**
--
~1. Add an attribute on the Users model to define the selected user language.~
2. Create/Extend an action on the Users controller to enable the API to set the user language:
   2.2. GL should infer the language from the browser HTTP `ACCEPT_LANGUAGE` header and set it in its record upon creation.
  2.3 If the language cannot be inferred then GL will default to the configured  `default_locale`.
3. Enable `default_locale`  to be initialized via environmental variables.
4. Upon each authenticated request extracts the user chosen language from its record.
5. Populate the language select element on the profile section in the client side with static list of languages.
6. Enable profile update requests to use GL API to update the user details including its selected language.
7. Add a **I18n** lib  for GL frontend app, create dictionaries and localize the UI according to the user chosen language.
8. The language select menu should include the list of available languages in the client app.


### User story [Creating an account and Updating the language]:
---
1. User creates an account.
2. GL will infer the language code from the HTTP request with a fallback to the `default_locale` that will be initialized from an ENV variable `DEFAULT_LOCALE` defaulting to **'en'**.
3. User gets their account created if it passes validation with the language set to what GL has chosen.
4. User will have the UI localized to what GL inferred if the language is available on the client side I18n config with a fallback to **'en'**  _(NO I18n on API side, only client side I18n will be used in GLv3)._.
6. User goes to the profile section
7. User finds a select menu full of the available languages on the client app according to its config.
8. User will have their inferred language selected.
9. User can select another language and hit the update button.
10. The client app will send the update request to persist the user chosen language in GL db while updating the session context for the user changing the UI localization to the chosen language.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
