### PR TITLE
Enabled StandardError global rescue to production only.

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -10,9 +10,11 @@ module Api
 
       # For requests that raised an unkown exception.
       # Note: The order of each rescue is important (The highest has the lowest priority).
-      rescue_from StandardError do |exception|
-        log_exception exception
-        render_json errors: [Rails.configuration.custom_error_msgs[:server_error]], status: :internal_server_error
+      if Rails.env.production?
+        rescue_from StandardError do |exception|
+          log_exception exception
+          render_json errors: [Rails.configuration.custom_error_msgs[:server_error]], status: :internal_server_error
+        end
       end
 
       rescue_from ActionController::ParameterMissing do |exception|

--- a/spec/controllers/meetings_controller_spec.rb
+++ b/spec/controllers/meetings_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Api::V1::MeetingsController, type: :controller do
         presentation_url:,
         meeting_ended: meeting_ended_url,
         recording_ready: recording_ready_url
-      )
+      ).and_call_original
 
       post :start, params: { friendly_id: room.friendly_id }
     end
@@ -51,7 +51,7 @@ RSpec.describe Api::V1::MeetingsController, type: :controller do
         presentation_url:,
         meeting_ended: meeting_ended_url,
         recording_ready: recording_ready_url
-      )
+      ).and_call_original
 
       post :start, params: { friendly_id: room.friendly_id }
     end

--- a/spec/controllers/recordings_controller_spec.rb
+++ b/spec/controllers/recordings_controller_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Api::V1::RecordingsController, type: :controller do
     end
 
     it 'calls the RecordingsSync service with correct params' do
-      expect(RecordingsSync).to receive(:new).with(user:)
+      expect(RecordingsSync).to receive(:new).with(user:).and_call_original
       get :resync
     end
   end

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -99,8 +99,9 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
       room = create(:room, presentation: fixture_file_upload(file_fixture('default-avatar.png'), 'image/png'))
       patch :update,
             params: { friendly_id: room.friendly_id,
-                      presentation: { presentation: fixture_file_upload(file_fixture('default-avatar.png'), 'image/png') } }
+                      presentation: fixture_file_upload(file_fixture('default-avatar.png'), 'image/png') }
       expect(room.reload.presentation).to be_attached
+      expect(response).to have_http_status(:ok)
     end
   end
 


### PR DESCRIPTION
  + Fixed some failing tests.

<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->