### PR TITLE
Sorting recordings 0: Extended recordings index to enable sorting.

### DIFF
--- a/app/controllers/api/v1/recordings_controller.rb
+++ b/app/controllers/api/v1/recordings_controller.rb
@@ -5,14 +5,16 @@ module Api
     class RecordingsController < ApiController
       skip_before_action :verify_authenticity_token # TODO: - Revisit this.
       before_action :find_recording, only: :update
+      before_action :config_sorting, only: :index, if: -> { params.key?(:sort) }
 
       # GET /api/v1/recordings.json
       # Returns: { data: Array[serializable objects(recordings)] , errors: Array[String] }
       # Does: Returns all the Recordings from all the current user's rooms
 
       def index
-        recordings = current_user.recordings&.search(params[:search])
+        recordings = current_user.recordings&.order(@sort_config)&.search(params[:search])
 
+        # TODO: Optimise this.
         recordings.map! do |recording|
           {
             id: recording.id,
@@ -76,6 +78,18 @@ module Api
 
       def recording_params
         params.require(:recording).permit(:name)
+      end
+
+      def config_sorting
+        allowed_columns = %w[name length visibility]
+        allowed_directions = %w[ASC DESC]
+
+        sort_column = params[:sort][:column]
+        sort_direction = params[:sort][:direction]
+
+        return render_json status: :bad_request unless allowed_columns.include?(sort_column) && allowed_directions.include?(sort_direction)
+
+        @sort_config = { sort_column => sort_direction }
       end
 
       def find_recording

--- a/spec/controllers/recordings_controller_spec.rb
+++ b/spec/controllers/recordings_controller_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Api::V1::RecordingsController, type: :controller do
       recordings = create_list(:recording, 6)
       create_list(:room, 5, user:, recordings:)
       get :index
-
       expect(response).to have_http_status(:ok)
       response_recording_ids = JSON.parse(response.body)['data'].map { |recording| recording['id'] }
       expect(response_recording_ids).to eq(recordings.pluck(:id))
@@ -50,6 +49,33 @@ RSpec.describe Api::V1::RecordingsController, type: :controller do
       get :index, params: { search: '' }
       response_recording_ids = JSON.parse(response.body)['data'].map { |recording| recording['id'] }
       expect(response_recording_ids).to match_array(recordings.pluck(:id))
+    end
+
+    context 'ordering' do
+      before do
+        recordings = [create(:recording, name: 'B'), create(:recording, name: 'A'), create(:recording, name: 'C')]
+
+        create(:room, user:, recordings:)
+      end
+
+      it 'orders the recordings list by column and direction DESC' do
+        get :index, params: { sort: { column: 'name', direction: 'DESC' } }
+        expect(response).to have_http_status(:ok)
+        # Order is important match_array isn't adequate for this test.
+        expect(JSON.parse(response.body)['data'].pluck('name')).to eq(%w[C B A])
+      end
+
+      it 'orders the recordings list by column and direction ASC' do
+        get :index, params: { sort: { column: 'name', direction: 'ASC' } }
+        expect(response).to have_http_status(:ok)
+        # Order is important match_array isn't adequate for this test.
+        expect(JSON.parse(response.body)['data'].pluck('name')).to eq(%w[A B C])
+      end
+
+      it 'returns :bad_request for bad params if sort config was provided' do
+        get :index, params: { sort: { column: 'invalid', direction: 'invalid' } }
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users to sort recordings by name, length and visibility

This PR completes **0.** 
--
~~0. Extend the recordings API to sort the recordings list as indicated by the client app.~~
1. Update the Recordings table UI to show proper icons and handle click events.

At this point:
> Clicking any of the columns sort by icon should:
	- Show proper feedback i.e. activate the icon.
2. Connect the client app to the API and further extend the UI and mutations:

At this point:
> Clicking any of the columns sort by icon should:
	- Show proper feedback i.e. activate the icon.
	- Invalidate the recordings query cache.
	- Request a new list sorted by the selected column.

> Clicking attempts and outcomes:
   - First click order the list by the selected column ASC.
   - Second click order the list by the selected column DESC.
   - Third click resets the list (No sorting).

>Note: Users can sort by multiple columns at once.

### User story [Sorting recordings]:
---
0. User login.
1. User open All recordings or a room recordings page.
2. User will have a list of the recordings.
3. User can clicks on the columns (date, recording name, room name, length, number of users, visibility, formats.) to sort the list by.
4. User will observe adequate feedbacks and the expected result.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->