### PR TITLE
Sorting recordings 2: Integrated the UI to the recordings API.

### DIFF
--- a/app/javascript/components/recordings/Recordings.jsx
+++ b/app/javascript/components/recordings/Recordings.jsx
@@ -9,9 +9,8 @@ import RecordingsList from './RecordingsList';
 
 export default function Recordings() {
   const [input, setInput] = useState();
-  const [recordings, setRecordings] = useState();
   // TODO: Revisit this.
-  useRecordings(input, setRecordings);
+  const { data: recordings, isLoading } = useRecordings(input);
 
   const { refetch: handleRecordingReSync } = useRecordingsReSync();
 
@@ -24,7 +23,7 @@ export default function Recordings() {
         <Button variant="primary-light" className="ms-auto" onClick={handleRecordingReSync}>Re-Sync Recordings</Button>
       </Stack>
       <Card className="border-0 shadow-sm p-0 mt-4">
-        <RecordingsList recordings={recordings} />
+        <RecordingsList recordings={recordings} isLoading={isLoading} />
       </Card>
     </div>
   );

--- a/app/javascript/components/recordings/RecordingsList.jsx
+++ b/app/javascript/components/recordings/RecordingsList.jsx
@@ -4,8 +4,9 @@ import { Table } from 'react-bootstrap';
 import RecordingRow from './RecordingRow';
 import ProcessingRecordingRow from './ProcessingRecordingRow';
 import SortBy from '../shared/SortBy';
+import Spinner from '../shared/stylings/Spinner';
 
-export default function RecordingsList({ recordings, recordingsProcessing }) {
+export default function RecordingsList({ recordings, recordingsProcessing, isLoading }) {
   return (
     <Table hover className="text-secondary mb-0 recordings-list">
       <thead>
@@ -19,18 +20,18 @@ export default function RecordingsList({ recordings, recordingsProcessing }) {
         </tr>
       </thead>
       <tbody className="border-top-0">
-        { [...Array(recordingsProcessing)].map(() => <ProcessingRecordingRow />) }
-        {recordings?.length
+        {[...Array(recordingsProcessing)].map(() => <ProcessingRecordingRow />)}
+        {(isLoading && <tr><td colSpan="6"><Spinner /></td></tr>) || (recordings?.length
           ? (
             recordings?.map((recording) => <RecordingRow key={recording.id} recording={recording} />)
           )
           : (
             <tr>
-              <td className="fw-bold">
+              <td className="fw-bold" colSpan="6">
                 No recordings found!
               </td>
             </tr>
-          )}
+          ))}
       </tbody>
     </Table>
   );
@@ -39,6 +40,7 @@ export default function RecordingsList({ recordings, recordingsProcessing }) {
 RecordingsList.defaultProps = {
   recordings: [],
   recordingsProcessing: 0,
+  isLoading: false,
 };
 
 RecordingsList.propTypes = {
@@ -52,4 +54,5 @@ RecordingsList.propTypes = {
     map: PropTypes.func,
   })),
   recordingsProcessing: PropTypes.number,
+  isLoading: PropTypes.bool,
 };

--- a/app/javascript/helpers/Axios.jsx
+++ b/app/javascript/helpers/Axios.jsx
@@ -15,6 +15,7 @@ export const ENDPOINTS = {
   admin: {
     getRoles: 'admin/roles.json',
   },
+  recordings: '/recordings.json',
 };
 
 const axiosInstance = axios.create(

--- a/app/javascript/hooks/queries/recordings/useRecordings.jsx
+++ b/app/javascript/hooks/queries/recordings/useRecordings.jsx
@@ -1,16 +1,15 @@
 import { useQuery } from 'react-query';
-import axios from 'axios';
+import { useSearchParams } from 'react-router-dom';
+import axios, { ENDPOINTS } from '../../../helpers/Axios';
 
-export default function useRecordings(input, setRecordings) {
-  return useQuery(['getRecordings', input], () => axios.get('/api/v1/recordings.json', {
-    params: {
-      search: input,
-    },
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
-  }).then((resp) => {
-    setRecordings(resp.data.data);
-  }));
+export default function useRecordings(search) {
+  const [searchParams] = useSearchParams();
+
+  const params = {
+    'sort[column]': searchParams.get('sort[column]'),
+    'sort[direction]': searchParams.get('sort[direction]'),
+    search,
+  };
+
+  return useQuery(['getRecordings', { ...params }], () => axios.get(ENDPOINTS.recordings, { params }).then((resp) => resp.data.data));
 }


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users to sort recordings by name, length and visibility

This PR completes **2.** 
--
~~0. Extend the recordings API to sort the recordings list as indicated by the client app.~~
~~1. Update the Recordings table UI to show proper icons and handle click events.~~

At this point:
> Clicking any of the columns sort by icon should:
	~~- Show proper feedback i.e. activate the icon.~~
~~2. Connect the client app to the API and further extend the UI and mutations:~~

At this point:
> Clicking any of the columns sort by icon should:
	~~- Show proper feedback i.e. activate the icon.~~
	~~- Invalidate the recordings query cache.~~
	~~- Request a new list sorted by the selected column.~~

> Clicking attempts and outcomes:
   ~~- First click order the list by the selected column ASC.~~
   ~~- Second click order the list by the selected column DESC.~~
   ~~- Third click resets the list (No sorting).~~

~~>Note: Users can sort by multiple columns at once.~~

TODO:
   - Improve UI consistency [changing `serachParams` should change UI state, ...].
   - Revisit the `axios` config merging logic.
 
### User story [Sorting recordings]:
---
0. User login.
1. User open All recordings or a room recordings page.
2. User will have a list of the recordings.
3. User can clicks on the columns (date, recording name, room name, length, number of users, visibility, formats.) to sort the list by.
4. User will observe adequate feedbacks and the expected result.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/29759616/175099239-9867c2cb-4c61-4b59-9902-0fd593f059f9.png)
![x (1)](https://user-images.githubusercontent.com/29759616/175100159-87b554aa-fdec-4ade-97dc-9edb1964931a.gif)


