### PR TITLE
Roles delete 1: Added `Admin::RolesController#destroy`

### DIFF
--- a/app/controllers/api/v1/admin/roles_controller.rb
+++ b/app/controllers/api/v1/admin/roles_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     module Admin
       class RolesController < ApiController
-        before_action :find_role, only: %i[update show]
+        before_action :find_role, only: %i[update show destroy]
 
         # POST /api/v1/admin/roles.json
         # Expects: {}
@@ -49,6 +49,15 @@ module Api
           return render_error errors: @role.errors.to_a, status: :bad_request unless @role.update role_params
 
           render_json status: :ok
+        end
+
+        # DELETE /api/v1/admin/roles.json
+        # Expects: {}
+        # Returns: { data: Array[serializable objects] , errors: Array[String] }
+        # Does: Deletes a role.
+        def destroy
+          @role.destroy!
+          render_json
         end
 
         private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
         end
         resources :server_rooms, only: %i[index destroy], param: :friendly_id
         resources :server_recordings, only: %i[index]
-        resources :roles, only: %i[index create update show]
+        resources :roles
       end
     end
   end

--- a/spec/controllers/admin/roles_controller_spec.rb
+++ b/spec/controllers/admin/roles_controller_spec.rb
@@ -107,4 +107,24 @@ RSpec.describe Api::V1::Admin::RolesController, type: :controller do
       expect(response).to have_http_status(:not_found)
     end
   end
+
+  describe 'roles#destroy' do
+    it 'removes a given role if no user is dependant' do
+      role = create(:role)
+      expect { delete :destroy, params: { id: role.id } }.to change(Role, :count).from(1).to(0)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns :not_found for not found roles' do
+      delete :destroy, params: { id: 'VOID' }
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'fails to remove roles with dependant users with :internal_server_error' do
+      role = create(:role)
+      create(:user, role:)
+      expect { delete :destroy, params: { id: role.id } }.not_to change(Role, :count).from(1)
+      expect(response).to have_http_status(:internal_server_error)
+    end
+  end
 end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users with the right set of privileges to delete roles.

This PR completes **0.** 
--
~~0. Add `Admin::RolesController#destroy` to delete a role and its permissions.~~
> Deleting a Role should:
  - Remove its associated `RolePermissions` config.
1. Extend the UI on Roles page in the administration settings to delete the role.
2. Extend/Add required mutations and feedbacks to integrate with the 
`Admin::RoleController#destroy `API.
 
### User story [Manage Roles]:
---
1. A User with the right set of privileges authenticates.
2. User goes to the Organization settings.
3. User goes to the Roles page.
4. User can select a role and:
    - Delete it (Not all roles can be deleted).
[OR]
    - Edit color, name, permissions.
[OR]
    - Add new role while providing its name and maybe color.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->