### PR TITLE
(fix) Frontend: Room Card height

### DIFF
--- a/app/javascript/components/rooms/RoomCard.jsx
+++ b/app/javascript/components/rooms/RoomCard.jsx
@@ -18,7 +18,7 @@ export default function RoomCard({ room }) {
   const { handleStartMeeting, isLoading: startMeetingIsLoading } = useStartMeeting(room.friendly_id);
 
   return (
-    <Card id="room-card" className="shadow-sm border-0">
+    <Card id="room-card" className="h-100 shadow-sm border-0">
       <Card.Body className="pb-0" onClick={handleClick}>
         <div className="room-icon-square rounded-3">
           { room.shared_owner ? (

--- a/app/javascript/components/rooms/RoomsList.jsx
+++ b/app/javascript/components/rooms/RoomsList.jsx
@@ -37,7 +37,7 @@ export default function RoomsList() {
             }
             return false;
           }).map((room) => (
-            <Col key={room.friendly_id} className="mt-0">
+            <Col key={room.friendly_id} className="mt-0 mb-4">
               {(room.optimistic && <RoomPlaceHolder />) || <RoomCard room={room} />}
             </Col>
           ))


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
RoomCards would pile up if one of the card had a different height - mostly because of the length of the title. 
Add CSS class so RoomCards take 100% of the height of the parent element (and the height of the tallest RoomCard).


## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/43917914/176706203-d795dd05-266e-4b91-92ab-af81a14b8796.png)
