### PR TITLE
(fix) Frontend: Change Admin NavSideBar color

### DIFF
--- a/app/assets/stylesheets/admin_panel.scss
+++ b/app/assets/stylesheets/admin_panel.scss
@@ -6,9 +6,13 @@
   }
 
   .nav-pills .nav-link.active {
-    color: $primary;
+    color: $primary !important;
     background-color: $primary-light;
     font-weight: 600;
+
+    svg {
+      color: $primary !important;
+    }
   }
 
   .tab-content {

--- a/app/javascript/components/admin/shared/AdminNavSideBar.jsx
+++ b/app/javascript/components/admin/shared/AdminNavSideBar.jsx
@@ -9,38 +9,38 @@ export default function AdminNavSideBar() {
   return (
     <Nav variant="pills" className="flex-column">
       <Nav.Item>
-        <Nav.Link className="cursor-pointer" as={Link} to="/adminpanel/users" eventKey="users">
-          <UsersIcon className="hi-s text-primary me-3" />
+        <Nav.Link className="cursor-pointer text-muted" as={Link} to="/adminpanel/users" eventKey="users">
+          <UsersIcon className="hi-s me-3" />
           Manage Users
         </Nav.Link>
       </Nav.Item>
       <Nav.Item>
-        <Nav.Link className="cursor-pointer" as={Link} to="/adminpanel/server-rooms" eventKey="server-rooms">
-          <ServerIcon className="hi-s text-primary me-3" />
+        <Nav.Link className="cursor-pointer text-muted" as={Link} to="/adminpanel/server-rooms" eventKey="server-rooms">
+          <ServerIcon className="hi-s me-3" />
           Server Rooms
         </Nav.Link>
       </Nav.Item>
       <Nav.Item>
-        <Nav.Link className="cursor-pointer" as={Link} to="/adminpanel/server-recordings" eventKey="server-recordings">
-          <VideoCameraIcon className="hi-s text-primary me-3" />
+        <Nav.Link className="cursor-pointer text-muted" as={Link} to="/adminpanel/server-recordings" eventKey="server-recordings">
+          <VideoCameraIcon className="hi-s me-3" />
           Server Recordings
         </Nav.Link>
       </Nav.Item>
       <Nav.Item>
-        <Nav.Link className="cursor-pointer" as={Link} to="/adminpanel/site-settings" eventKey="site-settings">
-          <CogIcon className="hi-s text-primary me-3" />
+        <Nav.Link className="cursor-pointer text-muted" as={Link} to="/adminpanel/site-settings" eventKey="site-settings">
+          <CogIcon className="hi-s me-3" />
           Site Settings
         </Nav.Link>
       </Nav.Item>
       <Nav.Item>
-        <Nav.Link className="cursor-pointer" as={Link} to="/adminpanel/room-configuration" eventKey="room-configuration">
-          <AdjustmentsIcon className="hi-s text-primary me-3" />
+        <Nav.Link className="cursor-pointer text-muted" as={Link} to="/adminpanel/room-configuration" eventKey="room-configuration">
+          <AdjustmentsIcon className="hi-s me-3" />
           Room Configuration
         </Nav.Link>
       </Nav.Item>
       <Nav.Item>
-        <Nav.Link className="cursor-pointer" as={Link} to="/adminpanel/roles" eventKey="roles">
-          <IdentificationIcon className="hi-s text-primary me-3" />
+        <Nav.Link className="cursor-pointer text-muted" as={Link} to="/adminpanel/roles" eventKey="roles">
+          <IdentificationIcon className="hi-s me-3" />
           Roles
         </Nav.Link>
       </Nav.Item>


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change Admin NavSideBar default text/icon color from "text-primary" to "text-muted", as per mock ups.
The text/icon should become "primary" only when it is active.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/43917914/176716436-3705b646-0a1e-44e0-875e-541c006c76eb.png)

![image](https://user-images.githubusercontent.com/43917914/176716900-d4f8f50b-fa31-489e-bd93-70a2904ff51b.png)
