### PR TITLE
View Server Room: Added `View` option to Manage server rooms.

### DIFF
--- a/app/javascript/components/admin/server-rooms/ServerRoomRow.jsx
+++ b/app/javascript/components/admin/server-rooms/ServerRoomRow.jsx
@@ -1,23 +1,30 @@
 import React from 'react';
-import { DotsVerticalIcon } from '@heroicons/react/outline';
-import { Stack } from 'react-bootstrap';
+import { CursorClickIcon, DotsVerticalIcon, TrashIcon } from '@heroicons/react/outline';
+import { Dropdown, Stack } from 'react-bootstrap';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 export default function ServerRoomRow({ room }) {
   return (
     <tr className="align-middle text-muted border border-2">
       <td className="border-end-0">
         <Stack>
-          <span className="text-dark fw-bold"> { room.name } </span>
+          <span className="text-dark fw-bold"> {room.name} </span>
           <span> Ended: </span>
         </Stack>
       </td>
-      <td className="border-0"> { room.owner }</td>
-      <td className="border-0"> { room.friendly_id } </td>
+      <td className="border-0"> {room.owner}</td>
+      <td className="border-0"> {room.friendly_id} </td>
       <td className="border-0"> - </td>
       <td className="border-0"> - </td>
       <td className="border-start-0">
-        <DotsVerticalIcon className="hi-s text-muted" />
+        <Dropdown className="float-end cursor-pointer">
+          <Dropdown.Toggle className="hi-s" as={DotsVerticalIcon} />
+          <Dropdown.Menu>
+            <Dropdown.Item as={Link} to={`/rooms/${room.friendly_id}`}><CursorClickIcon className="hi-s" /> View</Dropdown.Item>
+            <Dropdown.Item><TrashIcon className="hi-s" /> Delete</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
       </td>
     </tr>
   );


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users with the right set of privileges to select and view a server room.

This PR completes **1**.  
--
~~1. Extend the UI to enable users to view selected room page.~~

### User story [View server room]:
---
0. A user with the right level of permissions authenticates to GL.
1. User opens the organization settings.
2. User selects the manage server rooms page.
3. User filters and selects a room.
4. User clicks on the room more options icon.
5. User clicks **view**.
6. User will be navigated to that room page.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/29759616/177610271-688adc0b-2c43-4fb1-83b9-75ae63417a81.png)