### PR TITLE
Room settings: Enable All users join as moderators setting.

### DIFF
--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -69,7 +69,7 @@ module Api
       end
 
       def authorized_as_moderator?
-        params[:access_code].present? && @room.moderator_access_code == params[:access_code]
+        (params[:access_code].present? && @room.moderator_access_code == params[:access_code]) || @room.anyone_joins_as_moderator?
       end
     end
   end

--- a/app/models/meeting_option.rb
+++ b/app/models/meeting_option.rb
@@ -12,4 +12,13 @@ class MeetingOption < ApplicationRecord
       .where(room_meeting_options: { room_id: })
       .pluck(:name, :value)
   end
+
+  def self.get_value(name:, room_id:)
+    joins(:room_meeting_options)
+      .select(:value)
+      .find_by(
+        name:,
+        room_meeting_options: { room_id: }
+      )
+  end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -26,6 +26,10 @@ class Room < ApplicationRecord
     all.to_a
   end
 
+  def anyone_joins_as_moderator?
+    MeetingOption.get_value(name: 'glAnyoneJoinAsModerator', room_id: id)&.value == 'true'
+  end
+
   private
 
   def set_friendly_id

--- a/spec/controllers/meetings_controller_spec.rb
+++ b/spec/controllers/meetings_controller_spec.rb
@@ -109,6 +109,24 @@ RSpec.describe Api::V1::MeetingsController, type: :controller do
       expect(response).to have_http_status(:ok)
     end
 
+    it 'joins as moderator if "glAnyoneJoinAsModerator" setting enabled and access code provided' do
+      allow_any_instance_of(Room).to receive(:anyone_joins_as_moderator?).and_return(true)
+      room = create(:room, user:, viewer_access_code: 'AAA', moderator_access_code: 'BBB')
+
+      expect_any_instance_of(BigBlueButtonApi).to receive(:join_meeting).with(room:, name: 'Someone', role: 'Moderator')
+      get :join, params: { friendly_id: room.friendly_id, name: 'Someone', access_code: 'AAA' }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'joins as moderator if "glAnyoneJoinAsModerator" setting enabled and access code NOT provided' do
+      allow_any_instance_of(Room).to receive(:anyone_joins_as_moderator?).and_return(true)
+      room = create(:room, user:, viewer_access_code: 'AAA', moderator_access_code: 'BBB')
+
+      expect_any_instance_of(BigBlueButtonApi).to receive(:join_meeting).with(room:, name: 'Someone', role: 'Moderator')
+      get :join, params: { friendly_id: room.friendly_id, name: 'Someone' }
+      expect(response).to have_http_status(:ok)
+    end
+
     it 'returns unauthorized if the access code is wrong' do
       room = create(:room, user:, viewer_access_code: 'AAA', moderator_access_code: 'BBB')
 

--- a/spec/models/meeting_option_spec.rb
+++ b/spec/models/meeting_option_spec.rb
@@ -30,4 +30,23 @@ RSpec.describe MeetingOption, type: :model do
               ])
     end
   end
+
+  describe '#get_value' do
+    it 'returns the room meeting option for a room by name' do
+      room = create(:room)
+
+      meeting_option1 = create(:meeting_option, name: 'setting')
+      create(:room_meeting_option, room:, meeting_option: meeting_option1, value: 'value1')
+
+      room_meeting_option = described_class.get_value(name: 'setting', room_id: room.id)
+
+      expect(room_meeting_option.value).to eq('value1')
+    end
+
+    it 'returns nil for unfound room meeting option' do
+      expect(
+        described_class.get_value(name: 'notASettingTrustMe', room_id: 'YouAlreadyTrustedMe')
+      ).to be_nil
+    end
+  end
 end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -29,6 +29,31 @@ RSpec.describe Room, type: :model do
     end
   end
 
+  describe '#anyone_joins_as_moderator?' do
+    let!(:room) { create(:room) }
+
+    it 'calls MeetingOption::get_value and returns true if "glAnyoneJoinAsModerator" is set to "true"' do
+      allow(MeetingOption).to receive(:get_value).and_return(instance_double(RoomMeetingOption, value: 'true'))
+      expect(MeetingOption).to receive(:get_value).with(name: 'glAnyoneJoinAsModerator', room_id: room.id)
+
+      expect(room).to be_anyone_joins_as_moderator
+    end
+
+    it 'calls MeetingOption::get_value and returns false if "glAnyoneJoinAsModerator" is NOT set to "true"' do
+      allow(MeetingOption).to receive(:get_value).and_return(instance_double(RoomMeetingOption, value: 'false'))
+      expect(MeetingOption).to receive(:get_value).with(name: 'glAnyoneJoinAsModerator', room_id: room.id)
+
+      expect(room).not_to be_anyone_joins_as_moderator
+    end
+
+    it 'calls MeetingOption::get_value and returns false if "glAnyoneJoinAsModerator" is NOT set' do
+      allow(MeetingOption).to receive(:get_value).and_return(nil)
+      expect(MeetingOption).to receive(:get_value).with(name: 'glAnyoneJoinAsModerator', room_id: room.id)
+
+      expect(room).not_to be_anyone_joins_as_moderator
+    end
+  end
+
   describe 'after_create' do
     describe 'create_meeting_options' do
       it 'creates a RoomMeetingOption for each MeetingOption' do


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users to join as moderators on rooms with the **All users join as moderators** setting enabled.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
