### PR TITLE
Delete Server Room 1: Extended `DeleteRoom` modal and form.

### DIFF
--- a/app/javascript/components/forms/DeleteRoomForm.jsx
+++ b/app/javascript/components/forms/DeleteRoomForm.jsx
@@ -6,24 +6,22 @@ import {
 import PropTypes from 'prop-types';
 import Form from './Form';
 import Spinner from '../shared/stylings/Spinner';
-import useDeleteRoom from '../../hooks/mutations/rooms/useDeleteRoom';
 
-export default function DeleteRoomForm({ friendlyId, handleClose }) {
+export default function DeleteRoomForm({ mutation: useDeleteRoomAPI, handleClose }) {
+  const deleteRoomAPI = useDeleteRoomAPI({ onSettled: handleClose });
   const methods = useForm();
-  const { isSubmitting } = methods.formState;
-  const deleteRoom = useDeleteRoom(friendlyId);
 
   return (
     <>
       <p className="text-center"> Are you sure you want to delete this room?</p>
-      <Form methods={methods} onSubmit={deleteRoom.mutate}>
+      <Form methods={methods} onSubmit={deleteRoomAPI.mutate}>
         <Stack direction="horizontal" gap={1} className="float-end">
           <Button variant="primary-reverse" onClick={handleClose}>
             Close
           </Button>
-          <Button variant="danger" type="submit" disabled={isSubmitting}>
+          <Button variant="danger" type="submit" disabled={deleteRoomAPI.isLoading}>
             Delete
-            { isSubmitting && <Spinner /> }
+            { deleteRoomAPI.isLoading && <Spinner /> }
           </Button>
         </Stack>
       </Form>
@@ -32,11 +30,10 @@ export default function DeleteRoomForm({ friendlyId, handleClose }) {
 }
 
 DeleteRoomForm.propTypes = {
-  friendlyId: PropTypes.string,
   handleClose: PropTypes.func,
+  mutation: PropTypes.func.isRequired,
 };
 
 DeleteRoomForm.defaultProps = {
-  friendlyId: '',
   handleClose: () => {},
 };

--- a/app/javascript/components/room_settings/RoomSettings.jsx
+++ b/app/javascript/components/room_settings/RoomSettings.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Row, Button, Col } from 'react-bootstrap';
+import { Row, Col, Button } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
 import Card from 'react-bootstrap/Card';
 import Spinner from '../shared/stylings/Spinner';
 import useRoomSettings from '../../hooks/queries/rooms/useRoomSettings';
+import useDeleteRoom from '../../hooks/mutations/rooms/useDeleteRoom';
 import RoomSettingsRow from './RoomSettingsRow';
 import AccessCodes from './AccessCodes';
 import Modal from '../shared/Modal';
@@ -11,12 +12,12 @@ import DeleteRoomForm from '../forms/DeleteRoomForm';
 
 export default function RoomSettings() {
   const { friendlyId } = useParams();
-  const { isLoading, data: settings } = useRoomSettings(friendlyId);
+  const roomSetting = useRoomSettings(friendlyId);
 
-  if (isLoading) return <Spinner />;
+  const mutationWrapper = (args) => useDeleteRoom({ friendlyId, ...args });
 
-  function checkedValue(settingId) {
-    const { value } = settings.find((setting) => setting.name === settingId);
+  const checkedValue = (settingId) => {
+    const { value } = roomSetting.data.find((setting) => setting.name === settingId);
 
     if (value === 'true' || value === 'ASK_MODERATOR') {
       return true;
@@ -24,7 +25,9 @@ export default function RoomSettings() {
       return false;
     }
     return value;
-  }
+  };
+
+  if (roomSetting.isLoading) return <Spinner />;
 
   return (
     <div className="wide-background full-height-room" id="room-settings">
@@ -68,11 +71,9 @@ export default function RoomSettings() {
           </Row>
           <Row className="float-end">
             <Modal
-              modalButton={
-                <Button className="mt-1 mx-2 float-end danger-light-button">Delete Room</Button>
-              }
-              title="Are you sure?"
-              body={<DeleteRoomForm friendlyId={friendlyId} />}
+              modalButton={<Button className="mt-1 mx-2 float-end danger-light-button">Delete Room</Button>}
+              title="Delete Room"
+              body={<DeleteRoomForm mutation={mutationWrapper} />}
             />
           </Row>
         </div>

--- a/app/javascript/hooks/mutations/rooms/useDeleteRoom.jsx
+++ b/app/javascript/hooks/mutations/rooms/useDeleteRoom.jsx
@@ -1,21 +1,24 @@
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
 import axios from '../../../helpers/Axios';
 
-export default function useDeleteRoom(friendlyId) {
+export default function useDeleteRoom({ friendlyId, onSettled }) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   return useMutation(
     () => axios.delete(`/rooms/${friendlyId}.json`),
     {
       onSuccess: () => {
+        queryClient.invalidateQueries('getRooms');
         navigate('/rooms');
         toast.success('Room deleted');
       },
       onError: () => {
         toast.error('There was a problem completing that action. \n Please try again.');
       },
+      onSettled,
     },
   );
 }


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users with the right set of privileges to delete server rooms.

This PR completes **1.** 
--
~~0. Create `Admin::ServerRoomsController#destroy`.~~
~~1. Extend and use `DeleteRoom` modal and `DeleteRoomForm`.~~
2. Add `useDeleteServerRoom` mutation.

 ---
### User story [Delete Server Room]:

1. User with the right set of permissions authenticates.
2. User navigates to the Admin panel -> Server rooms.
3. User filters and selects a server room.
4. User can click on more options and select delete room.
5. User should have the delete room modal popped up.
6. User can confirm or close the modal while having the expected feedback/side effects.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
