### PR TITLE
Delete server room 2: Integrated with `Admin::ServerRoomsController#destroy`.

### DIFF
--- a/app/javascript/components/admin/server_rooms/ServerRoomRow.jsx
+++ b/app/javascript/components/admin/server_rooms/ServerRoomRow.jsx
@@ -3,9 +3,14 @@ import { CursorClickIcon, DotsVerticalIcon, TrashIcon } from '@heroicons/react/o
 import { Dropdown, Stack } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import useDeleteServerRoom from '../../../hooks/mutations/admins/server-rooms/useDeleteServerRoom';
+import Modal from '../../shared/Modal';
+import DeleteRoomForm from '../../forms/DeleteRoomForm';
 
 export default function ServerRoomRow({ room }) {
-  console.log();
+  const { friendly_id: friendlyId } = room;
+  const mutationWrapper = (args) => useDeleteServerRoom({ friendlyId, ...args });
+
   return (
     <tr className="align-middle text-muted border border-2">
       <td className="border-end-0">
@@ -14,16 +19,20 @@ export default function ServerRoomRow({ room }) {
           <span> Ended: </span>
         </Stack>
       </td>
-      <td className="border-0"> { room.owner }</td>
-      <td className="border-0"> { room.friendly_id } </td>
-      <td className="border-0"> { room.participants ? room.participants : '-' } </td>
-      <td className="border-0"> { room.status } </td>
+      <td className="border-0"> {room.owner}</td>
+      <td className="border-0"> {room.friendly_id} </td>
+      <td className="border-0"> {room.participants ? room.participants : '-'} </td>
+      <td className="border-0"> {room.status} </td>
       <td className="border-start-0">
         <Dropdown className="float-end cursor-pointer">
           <Dropdown.Toggle className="hi-s" as={DotsVerticalIcon} />
           <Dropdown.Menu>
             <Dropdown.Item as={Link} to={`/rooms/${room.friendly_id}`}><CursorClickIcon className="hi-s" /> View</Dropdown.Item>
-            <Dropdown.Item><TrashIcon className="hi-s" /> Delete</Dropdown.Item>
+            <Modal
+              modalButton={<Dropdown.Item><TrashIcon className="hi-s" /> Delete</Dropdown.Item>}
+              title="Delete Server Room"
+              body={<DeleteRoomForm mutation={mutationWrapper} />}
+            />
           </Dropdown.Menu>
         </Dropdown>
       </td>

--- a/app/javascript/hooks/mutations/admins/server-rooms/useDeleteServerRoom.jsx
+++ b/app/javascript/hooks/mutations/admins/server-rooms/useDeleteServerRoom.jsx
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from 'react-query';
+import { toast } from 'react-hot-toast';
+import axios from '../../../../helpers/Axios';
+
+export default function useDeleteServerRoom({ friendlyId, onSettled }) {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    () => axios.delete(`admin/server_rooms/${friendlyId}.json`),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries('getServerRooms');
+        toast.success('Server room deleted.');
+      },
+      onError: () => {
+        toast.error('There was a problem completing that action. \n Please try again.');
+      },
+      onSettled,
+    },
+  );
+}


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users with the right set of privileges to delete server rooms.

This PR completes **2.** 
--
~~0. Create `Admin::ServerRoomsController#destroy`.~~
~~1. Extend and use `DeleteRoom` modal and `DeleteRoomForm`.~~
~~2. Add `useDeleteServerRoom` mutation.~~

 ---
### User story [Delete Server Room]:

1. User with the right set of permissions authenticates.
2. User navigates to the Admin panel -> Server rooms.
3. User filters and selects a server room.
4. User can click on more options and select delete room.
5. User should have the delete room modal popped up.
6. User can confirm or close the modal while having the expected feedback/side effects.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/29759616/178350067-3be3c70b-fc5e-4b65-b7d9-772328103edd.png)
