### PR TITLE
Server Recordings: Added `Admin::ServerRecordingsController#index` API.

### DIFF
--- a/app/controllers/api/v1/admin/server_recordings_controller.rb
+++ b/app/controllers/api/v1/admin/server_recordings_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class ServerRecordingsController < ApiController
+        # POST /api/v1/admin/server_recordings.json
+        # Expects: {}
+        # Returns: { data: Array[serializable objects] , errors: Array[String] }
+        # Does: Fetches and returns the list of server recordings.
+
+        def index
+          sort_config = config_sorting(allowed_columns: %w[name length visibility])
+
+          recordings = Recording.order(sort_config)&.search(params[:search])
+
+          render_data data: recordings
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,8 @@ Rails.application.routes.draw do
           end
         end
         resources :server_rooms, only: %i[index]
-        resources :roles, only: %i[index create]
+        resources :server_recordings, only: %i[index]
+        resources :roles, only: %i[index create]      
       end
     end
   end

--- a/spec/controllers/admin/server_recordings_controller_spec.rb
+++ b/spec/controllers/admin/server_recordings_controller_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::Admin::ServerRecordingsController, type: :controller do
+  before { request.headers['ACCEPT'] = 'application/json' }
+
+  describe '#index' do
+    it 'returns the list of recordings' do
+      recordings = [create(:recording, name: 'Tinky-Winky'), create(:recording, name: 'Dipsy'), create(:recording, name: 'Laa-Laa')]
+
+      get :index
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['data'].pluck('id')).to match_array(recordings.pluck(:id))
+    end
+
+    it 'returns the recordings according to the query' do
+      search_recordings = [create(:recording, name: 'Recording 1'), create(:recording, name: 'Recording 2'), create(:recording, name: 'Recording 3')]
+
+      get :index, params: { search: 'recording' }
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['data'].pluck('id')).to match_array(search_recordings.pluck(:id))
+    end
+
+    it 'returns all recordings if the search query is empty' do
+      recordings = create_list(:recording, 5)
+
+      get :index, params: { search: '' }
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['data'].pluck('id')).to match_array(recordings.pluck(:id))
+    end
+
+    context 'ordering' do
+      before do
+        create(:recording, name: 'O')
+        create(:recording, name: 'O')
+        create(:recording, name: 'P')
+      end
+
+      it 'orders the recordings list by column and direction DESC' do
+        get :index, params: { sort: { column: 'name', direction: 'DESC' } }
+        expect(response).to have_http_status(:ok)
+        # Order is important match_array isn't adequate for this test.
+        expect(JSON.parse(response.body)['data'].pluck('name')).to eq(%w[P O O])
+      end
+
+      it 'orders the recordings list by column and direction ASC' do
+        get :index, params: { sort: { column: 'name', direction: 'ASC' } }
+        expect(response).to have_http_status(:ok)
+        # Order is important match_array isn't adequate for this test.
+        expect(JSON.parse(response.body)['data'].pluck('name')).to eq(%w[O O P])
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users with the right set of privileges to view server recordings.

This PR completes **0.** 
--
~~0. Add `Admin::ServerRecordings#index`.~~
1. Add ServerRecordings UI.
2. Integrate the UI with the API.
 
User Story [View Server Recordings]:
---
0. User with the right set of permissions.
1. User navigates to Server Recordings.
2. User can view, filter and sort server recordings.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
