### PR TITLE
Add protectable to Recordings

### DIFF
--- a/app/javascript/components/recordings/RecordingRow.jsx
+++ b/app/javascript/components/recordings/RecordingRow.jsx
@@ -55,7 +55,8 @@ export default function RecordingRow({ recording }) {
         >
           <option value="Published">Published</option>
           <option value="Unpublished">Unpublished</option>
-          <option value="Protected">Protected</option>
+          {recording?.protectable === true
+            && <option value="Protected">Protected</option>}
         </Form.Select>
       </td>
       <td>
@@ -92,6 +93,7 @@ RecordingRow.propTypes = {
       recording_type: PropTypes.string.isRequired,
     })),
     visibility: PropTypes.string.isRequired,
+    protectable: PropTypes.bool.isRequired,
     created_at: PropTypes.string.isRequired,
     map: PropTypes.func,
   }).isRequired,

--- a/app/serializers/recording_serializer.rb
+++ b/app/serializers/recording_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RecordingSerializer < ApplicationSerializer
-  attributes :id, :record_id, :name, :length, :users, :visibility, :created_at
+  attributes :id, :record_id, :name, :length, :users, :visibility, :protectable, :created_at
 
   has_many :formats
 end

--- a/app/services/recording_creator.rb
+++ b/app/services/recording_creator.rb
@@ -15,7 +15,7 @@ class RecordingCreator
     new_name = @recording[:metadata][:name] || @recording[:name]
 
     new_recording = Recording.find_or_create_by(room_id:, name: new_name, record_id: @recording[:recordID], visibility:,
-                                                users: @recording[:participants], length:)
+                                                users: @recording[:participants], length:, protectable: @recording[:protected].present?)
 
     # Create format(s)
     create_formats(recording: @recording, new_recording:)

--- a/db/migrate/20220711200055_add_protectable_to_recordings.rb
+++ b/db/migrate/20220711200055_add_protectable_to_recordings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProtectableToRecordings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :recordings, :protectable, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_16_175700) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_11_200055) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,6 +71,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_16_175700) do
     t.string "visibility", null: false
     t.integer "length", null: false
     t.integer "users", null: false
+    t.boolean "protectable"
     t.index ["room_id"], name: "index_recordings_on_room_id"
   end
 

--- a/spec/services/recording_creator_spec.rb
+++ b/spec/services/recording_creator_spec.rb
@@ -36,6 +36,18 @@ describe RecordingCreator, type: :service do
 
       expect(room.recordings.count).to eq(1)
     end
+
+    it 'returns recording protectable attribute as true if the bbb server protected feature is enabled' do
+      room.update(meeting_id: 'random-1291479')
+      described_class.new(recording: protected_recording).call
+      expect(room.recordings.first.protectable).to be(true)
+    end
+
+    it 'returns recording protectable attribute as false if the bbb server protected feature is not enabled' do
+      room.update(meeting_id: 'random-1291479')
+      described_class.new(recording: single_format_recording).call
+      expect(room.recordings.first.protectable).to be(false)
+    end
   end
 
   private
@@ -98,6 +110,35 @@ describe RecordingCreator, type: :service do
                    length: 0,
                    size: '61117'
                  }]
+      },
+      data: {}
+    }
+  end
+
+  def protected_recording
+    {
+      recordID: 'f0e2be4518868febb0f381ebe7d46ae61364ef1e-1652287428125',
+      meetingID: 'random-1291479',
+      internalMeetingID: 'f0e2be4518868febb0f381ebe7d46ae61364ef1e-1652287428125',
+      name: 'random-1291479',
+      isBreakout: 'false',
+      published: true,
+      protected: true,
+      state: 'published',
+      startTime: 'Wed, 11 May 2022 12:43:48 -0400'.to_datetime,
+      endTime: 'Wed, 11 May 2022 12:44:20 -0400'.to_datetime,
+      participants: '1',
+      rawSize: '977816',
+      metadata: { isBreakout: 'false', meetingId: 'random-1291479', meetingName: 'random-1291479' },
+      size: '305475',
+      playback: {
+        format: {
+          type: 'presentation',
+          url: 'https://test24.bigbluebutton.org/playback/presentation/2.3/f0e2be4518868febb0f381ebe7d46ae61364ef1e-1652287428125',
+          processingTime: '6386',
+          length: 0,
+          size: '305475'
+        }
       },
       data: {}
     }


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the `protectable` column to Recordings so that the "Protected" option in the recording visibility drop-down list is only shown to users on a bbb server that has the protected recording feature enabled. 

Note: The "Recording" object from the bbb server response will have the `<protected>` children only if the feature is enabled.


## Testing Steps
<!--- Please describe in detail how to test your changes. -->
1. Test on a bbb server that has protected recording feature NOT enabled

- Re-Sync the Recordings
- Make sure that only the Published/Unpublished options are available in the recording visibility drop-down list.

2. Test on a bbb server that has protected recording feature enabled. 

- Re-Sync the Recordings
- Make sure that the Published/Unpublished/Protected options are available in the recording visibility drop-down list.

