### PR TITLE
Server recordings 1: Extended Recordings UIs.

### DIFF
--- a/app/javascript/components/forms/DeleteRecordingForm.jsx
+++ b/app/javascript/components/forms/DeleteRecordingForm.jsx
@@ -6,22 +6,22 @@ import {
 import PropTypes from 'prop-types';
 import Form from './Form';
 import Spinner from '../shared/stylings/Spinner';
-import useDeleteRecording from '../../hooks/mutations/recordings/useDeleteRecording';
 
-export default function DeleteRecordingForm({ recordId, handleClose }) {
+export default function DeleteRecordingForm({ mutation: useDeleteAPI, recordId, handleClose }) {
   const methods = useForm();
-  const deleteRecording = useDeleteRecording(recordId);
+  const deleteAPI = useDeleteAPI({ recordId, onSettled: handleClose });
+
   return (
     <>
       <p className="text-center"> Are you sure you want to delete this recording?</p>
-      <Form methods={methods} onSubmit={deleteRecording.mutate}>
+      <Form methods={methods} onSubmit={deleteAPI.mutate}>
         <Stack direction="horizontal" gap={1} className="float-end">
           <Button variant="primary-reverse" onClick={handleClose}>
             Close
           </Button>
-          <Button variant="danger" type="submit" disabled={deleteRecording.isLoading}>
+          <Button variant="danger" type="submit" disabled={deleteAPI.isLoading}>
             Delete
-            { deleteRecording.isLoading && <Spinner /> }
+            {deleteAPI.isLoading && <Spinner />}
           </Button>
         </Stack>
       </Form>
@@ -32,9 +32,10 @@ export default function DeleteRecordingForm({ recordId, handleClose }) {
 DeleteRecordingForm.propTypes = {
   handleClose: PropTypes.func,
   recordId: PropTypes.string,
+  mutation: PropTypes.func.isRequired,
 };
 
 DeleteRecordingForm.defaultProps = {
-  handleClose: () => {},
+  handleClose: () => { },
   recordId: -1,
 };

--- a/app/javascript/components/forms/UpdateRecordingForm.jsx
+++ b/app/javascript/components/forms/UpdateRecordingForm.jsx
@@ -4,24 +4,27 @@ import { useForm } from 'react-hook-form';
 import FormControl from './FormControl';
 import Form from './Form';
 import { UpdateRecordingsFormConfig, UpdateRecordingsFormFields } from '../../helpers/forms/UpdateRecordingsFormHelpers';
-import useUpdateRecording from '../../hooks/mutations/recordings/useUpdateRecording';
 
 export default function UpdateRecordingForm({
-  name, noLabel, recordId, hidden, setIsUpdating,
+  name, noLabel, recordId, hidden, setIsUpdating, mutation: useUpdateAPI,
 }) {
-  const updateRecording = useUpdateRecording(recordId);
+  const updateAPI = useUpdateAPI(recordId);
+
   UpdateRecordingsFormConfig.defaultValues.name = name;
+
   const methods = useForm(UpdateRecordingsFormConfig);
   const fields = UpdateRecordingsFormFields;
-  useEffect(() => { setIsUpdating(updateRecording.isLoading); }, [updateRecording.isLoading]);
+
+  useEffect(() => { setIsUpdating(updateAPI.isLoading); }, [updateAPI.isLoading]);
 
   return (
-    <Form
-      methods={methods}
-      onBlur={methods.handleSubmit(updateRecording.mutate)}
-      hidden={hidden}
-    >
-      <FormControl field={fields.name} noLabel={noLabel} type="text" disabled={updateRecording.isLoading} />
+    <Form methods={methods} onBlur={methods.handleSubmit(updateAPI.mutate)} hidden={hidden}>
+      <FormControl
+        field={fields.name}
+        noLabel={noLabel}
+        type="text"
+        disabled={updateAPI.isLoading}
+      />
     </Form>
   );
 }
@@ -39,4 +42,5 @@ UpdateRecordingForm.propTypes = {
   recordId: PropTypes.string.isRequired,
   hidden: PropTypes.bool,
   setIsUpdating: PropTypes.func,
+  mutation: PropTypes.func.isRequired,
 };

--- a/app/javascript/components/recordings/Recordings.jsx
+++ b/app/javascript/components/recordings/Recordings.jsx
@@ -6,13 +6,14 @@ import useRecordings from '../../hooks/queries/recordings/useRecordings';
 import useRecordingsReSync from '../../hooks/queries/recordings/useRecordingsReSync';
 import SearchBarQuery from '../shared/SearchBarQuery';
 import RecordingsList from './RecordingsList';
+import RoomsRecordingRow from './RoomsRecordingRow';
 
 export default function Recordings() {
   const [input, setInput] = useState();
   // TODO: Revisit this.
-  const { data: recordings, isLoading } = useRecordings(input);
+  const recordings = useRecordings(input);
 
-  const { refetch: handleRecordingReSync } = useRecordingsReSync();
+  const recordingsReSync = useRecordingsReSync();
 
   return (
     <div className="wide-background full-height-rooms">
@@ -20,10 +21,14 @@ export default function Recordings() {
         <div>
           <SearchBarQuery setInput={setInput} />
         </div>
-        <Button variant="primary-light" className="ms-auto" onClick={handleRecordingReSync}>Re-Sync Recordings</Button>
+        <Button variant="primary-light" className="ms-auto" onClick={recordingsReSync.refetch}>Re-Sync Recordings</Button>
       </Stack>
       <Card className="border-0 shadow-sm p-0 mt-4">
-        <RecordingsList recordings={recordings} isLoading={isLoading} />
+        <RecordingsList
+          recordings={recordings.data}
+          isLoading={recordings.isLoading}
+          RecordingRow={RoomsRecordingRow}
+        />
       </Card>
     </div>
   );

--- a/app/javascript/components/recordings/RecordingsList.jsx
+++ b/app/javascript/components/recordings/RecordingsList.jsx
@@ -1,22 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Table } from 'react-bootstrap';
-import RecordingRow from './RecordingRow';
 import ProcessingRecordingRow from './ProcessingRecordingRow';
 import SortBy from '../shared/SortBy';
 import Spinner from '../shared/stylings/Spinner';
 
-export default function RecordingsList({ recordings, recordingsProcessing, isLoading }) {
+export default function RecordingsList({
+  recordings, RecordingRow, recordingsProcessing, isLoading,
+}) {
   return (
-    <Table hover className="text-secondary mb-0 recordings-list">
+    <Table hover className="table-bordered border-1 text-secondary mb-0 recordings-list">
       <thead>
         <tr className="text-muted small">
-          <th className="fw-normal">Name <SortBy fieldName="name" /></th>
-          <th className="fw-normal">Length <SortBy fieldName="length" /></th>
-          <th className="fw-normal">Users</th>
-          <th className="fw-normal">Visibility <SortBy fieldName="visibility" /></th>
-          <th className="fw-normal">Formats</th>
-          <th aria-label="options" />
+          <th className="fw-normal border-end-0">Name <SortBy fieldName="name" /></th>
+          <th className="fw-normal border-0">Length <SortBy fieldName="length" /></th>
+          <th className="fw-normal border-0">Users</th>
+          <th className="fw-normal border-0">Visibility <SortBy fieldName="visibility" /></th>
+          <th className="fw-normal border-0">Formats</th>
+          <th className="border-start-0" aria-label="options" />
         </tr>
       </thead>
       <tbody className="border-top-0">
@@ -55,4 +56,5 @@ RecordingsList.propTypes = {
   })),
   recordingsProcessing: PropTypes.number,
   isLoading: PropTypes.bool,
+  RecordingRow: PropTypes.func.isRequired,
 };

--- a/app/javascript/components/recordings/RoomRecordings.jsx
+++ b/app/javascript/components/recordings/RoomRecordings.jsx
@@ -7,12 +7,13 @@ import useRoomRecordings from '../../hooks/queries/recordings/useRoomRecordings'
 import SearchBarQuery from '../shared/SearchBarQuery';
 import RecordingsList from './RecordingsList';
 import useRoomRecordingsProcessing from '../../hooks/queries/recordings/useRoomRecordingsProcessing';
+import RoomsRecordingRow from './RoomsRecordingRow';
 
 export default function RoomRecordings() {
   const [input, setInput] = useState('');
   const { friendlyId } = useParams();
-  const { data: recordings } = useRoomRecordings(friendlyId, input);
-  const { data: recordingsProcessing } = useRoomRecordingsProcessing(friendlyId);
+  const roomRecordings = useRoomRecordings(friendlyId, input);
+  const roomRecordingsProcessing = useRoomRecordingsProcessing(friendlyId);
 
   return (
     <div className="wide-background full-height-room">
@@ -22,7 +23,11 @@ export default function RoomRecordings() {
         </div>
       </Stack>
       <Card className="border-0 shadow-sm mt-4">
-        <RecordingsList recordings={recordings} recordingsProcessing={recordingsProcessing} />
+        <RecordingsList
+          recordings={roomRecordings.data}
+          RecordingRow={RoomsRecordingRow}
+          recordingsProcessing={roomRecordingsProcessing.data}
+        />
       </Card>
     </div>
   );

--- a/app/javascript/components/recordings/RoomsRecordingRow.jsx
+++ b/app/javascript/components/recordings/RoomsRecordingRow.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import useUpdateRecordingVisibility from '../../hooks/mutations/recordings/useUpdateRecordingVisibility';
+import useUpdateRecording from '../../hooks/mutations/recordings/useUpdateRecording';
+import useDeleteRecording from '../../hooks/mutations/recordings/useDeleteRecording';
+import RecordingRow from '../shared/RecordingRow';
+
+export default function RoomsRecordingRow({ recording }) {
+  return (
+    <RecordingRow
+      recording={recording}
+      visibilityMutation={useUpdateRecordingVisibility}
+      updateMutation={useUpdateRecording}
+      deleteMutation={useDeleteRecording}
+    />
+  );
+}
+
+RoomsRecordingRow.propTypes = {
+  recording: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    record_id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    length: PropTypes.number.isRequired,
+    users: PropTypes.number.isRequired,
+    formats: PropTypes.arrayOf(PropTypes.shape({
+      url: PropTypes.string.isRequired,
+      recording_type: PropTypes.string.isRequired,
+    })),
+    visibility: PropTypes.string.isRequired,
+    created_at: PropTypes.string.isRequired,
+    map: PropTypes.func,
+  }).isRequired,
+};

--- a/app/javascript/hooks/mutations/recordings/useDeleteRecording.jsx
+++ b/app/javascript/hooks/mutations/recordings/useDeleteRecording.jsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from 'react-query';
 import { toast } from 'react-hot-toast';
 import axios from '../../../helpers/Axios';
 
-export default function useDeleteRecording(recordId) {
+export default function useDeleteRecording({ recordId, onSettled }) {
   const queryClient = useQueryClient();
 
   return useMutation(
@@ -16,6 +16,7 @@ export default function useDeleteRecording(recordId) {
       onError: () => {
         toast.error('There was a problem completing that action. \n Please try again.');
       },
+      onSettled,
     },
   );
 }


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users with the right set of privileges to view server recordings.

This PR completes **1.** 
--
~~0. Add `Admin::ServerRecordings#index`.~~
~~1. Extend Recordings UIs.~~
2. Add ServerRecordings UI. & Integrate the UI with the API.
 
User Story [View Server Recordings]:
---
0. User with the right set of permissions.
1. User navigates to Server Recordings.
2. User can view, filter and sort server recordings.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->