### PR TITLE
Admin to join or start a server room

### DIFF
--- a/app/javascript/components/admin/server_rooms/ServerRoomRow.jsx
+++ b/app/javascript/components/admin/server_rooms/ServerRoomRow.jsx
@@ -9,11 +9,16 @@ import useDeleteServerRoom from '../../../hooks/mutations/admins/server-rooms/us
 import Modal from '../../shared/Modal';
 import DeleteRoomForm from '../../forms/DeleteRoomForm';
 import useStartMeeting from '../../../hooks/mutations/rooms/useStartMeeting';
+import useRoomStatus from '../../../hooks/queries/rooms/useRoomStatus';
+import { useAuth } from '../../../contexts/auth/AuthProvider';
 
 export default function ServerRoomRow({ room }) {
   const { friendly_id: friendlyId } = room;
   const mutationWrapper = (args) => useDeleteServerRoom({ friendlyId, ...args });
   const { handleStartMeeting } = useStartMeeting(friendlyId);
+  const currentUser = useAuth();
+  // TODO - samuel: useRoomStatus will not work if room has an access code. Will need to add bypass in MeetingController
+  const { refetch } = useRoomStatus(room.friendly_id, currentUser.name);
 
   return (
     <tr className="align-middle text-muted border border-2">
@@ -32,11 +37,21 @@ export default function ServerRoomRow({ room }) {
           <Dropdown.Toggle className="hi-s" as={DotsVerticalIcon} />
           <Dropdown.Menu>
             { room.status === 'Active'
-              ? <Dropdown.Item><ExternalLinkIcon className="hi-s text-muted" /> Join </Dropdown.Item>
-              : <Dropdown.Item><ExternalLinkIcon className="hi-s text-muted" onClick={handleStartMeeting} /> Start </Dropdown.Item>}
-            <Dropdown.Item as={Link} to={`/rooms/${room.friendly_id}`}><EyeIcon className="hi-s text-muted" /> View </Dropdown.Item>
+              ? (
+                <Dropdown.Item className="text-muted" onClick={refetch}>
+                  <ExternalLinkIcon className="hi-s pb-1 me-1" /> Join
+                </Dropdown.Item>
+              )
+              : (
+                <Dropdown.Item className="text-muted" onClick={handleStartMeeting}>
+                  <ExternalLinkIcon className="hi-s pb-1 me-1" /> Start
+                </Dropdown.Item>
+              )}
+            <Dropdown.Item className="text-muted" as={Link} to={`/rooms/${room.friendly_id}`}>
+              <EyeIcon className="hi-s pb-1 me-1" /> View
+            </Dropdown.Item>
             <Modal
-              modalButton={<Dropdown.Item><TrashIcon className="hi-s text-muted" /> Delete</Dropdown.Item>}
+              modalButton={<Dropdown.Item className="text-muted"><TrashIcon className="hi-s pb-1 me-1" /> Delete</Dropdown.Item>}
               title="Delete Server Room"
               body={<DeleteRoomForm mutation={mutationWrapper} />}
             />

--- a/app/javascript/components/admin/server_rooms/ServerRoomRow.jsx
+++ b/app/javascript/components/admin/server_rooms/ServerRoomRow.jsx
@@ -1,15 +1,19 @@
 import React from 'react';
-import { CursorClickIcon, DotsVerticalIcon, TrashIcon } from '@heroicons/react/outline';
+import {
+  EyeIcon, DotsVerticalIcon, TrashIcon, ExternalLinkIcon,
+} from '@heroicons/react/outline';
 import { Dropdown, Stack } from 'react-bootstrap';
-import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import useDeleteServerRoom from '../../../hooks/mutations/admins/server-rooms/useDeleteServerRoom';
 import Modal from '../../shared/Modal';
 import DeleteRoomForm from '../../forms/DeleteRoomForm';
+import useStartMeeting from '../../../hooks/mutations/rooms/useStartMeeting';
 
 export default function ServerRoomRow({ room }) {
   const { friendly_id: friendlyId } = room;
   const mutationWrapper = (args) => useDeleteServerRoom({ friendlyId, ...args });
+  const { handleStartMeeting } = useStartMeeting(friendlyId);
 
   return (
     <tr className="align-middle text-muted border border-2">
@@ -27,9 +31,12 @@ export default function ServerRoomRow({ room }) {
         <Dropdown className="float-end cursor-pointer">
           <Dropdown.Toggle className="hi-s" as={DotsVerticalIcon} />
           <Dropdown.Menu>
-            <Dropdown.Item as={Link} to={`/rooms/${room.friendly_id}`}><CursorClickIcon className="hi-s" /> View</Dropdown.Item>
+            { room.status === 'Active'
+              ? <Dropdown.Item><ExternalLinkIcon className="hi-s text-muted" /> Join </Dropdown.Item>
+              : <Dropdown.Item><ExternalLinkIcon className="hi-s text-muted" onClick={handleStartMeeting} /> Start </Dropdown.Item>}
+            <Dropdown.Item as={Link} to={`/rooms/${room.friendly_id}`}><EyeIcon className="hi-s text-muted" /> View </Dropdown.Item>
             <Modal
-              modalButton={<Dropdown.Item><TrashIcon className="hi-s" /> Delete</Dropdown.Item>}
+              modalButton={<Dropdown.Item><TrashIcon className="hi-s text-muted" /> Delete</Dropdown.Item>}
               title="Delete Server Room"
               body={<DeleteRoomForm mutation={mutationWrapper} />}
             />


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Admin has option to join room if room is active.
Admin has option to start room if room is not running.

Nothing new on the backend, been re-using the hooks from past features.

Note: 
The join feature will not work if the room has `access_code` enabled.
Will need to eventually implement a bypass in MeetingController.
Maybe something like:
```
def authorized_as_moderator?
<current logic...> || @current_user.role_id == 3
end
```

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

- Create a few rooms
- Start a meeting
- Go to Admin/Server Rooms
- Join a meeting if it's already active, if not you should be able to start it.

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/43917914/179057959-50bd793c-1ba6-4b76-837c-1a7b3c974912.png)
