### PR TITLE
Updating mutations for edit and delete server recordings

### DIFF
--- a/app/javascript/hooks/mutations/recordings/useDeleteRecording.jsx
+++ b/app/javascript/hooks/mutations/recordings/useDeleteRecording.jsx
@@ -11,6 +11,7 @@ export default function useDeleteRecording({ recordId, onSettled }) {
       onSuccess: () => {
         queryClient.invalidateQueries('getRecordings');
         queryClient.invalidateQueries('getRoomRecordings');
+        queryClient.invalidateQueries('getServerRecordings');
         toast.success('Recording deleted');
       },
       onError: () => {

--- a/app/javascript/hooks/mutations/recordings/useUpdateRecording.jsx
+++ b/app/javascript/hooks/mutations/recordings/useUpdateRecording.jsx
@@ -10,6 +10,7 @@ export default function useUpdateRecording(recordId) {
     {
       onSuccess: () => {
         queryClient.invalidateQueries('getRecordings');
+        queryClient.invalidateQueries('getServerRecordings');
         toast.success('Recording name updated');
       },
       onError: () => {


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Just adding invalidateQueries for getServerRecordings so that when the edit and delete mutations are used in server recordings, the UI is updated automatically
## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
