### PR TITLE
Roles Mapping 0: Added Registration UI and dynamic form.

### DIFF
--- a/app/javascript/components/admin/site_settings/Registration.jsx
+++ b/app/javascript/components/admin/site_settings/Registration.jsx
@@ -1,7 +1,37 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Alert, Container, Row } from 'react-bootstrap';
+import RegistrationForm from '../../forms/admin/RegistrationForm';
+
+const DUMMY_ROLES_MAP = [
+  { name: 'User', suffix: 'users.com' },
+  { name: 'Admin', suffix: 'admins.com' },
+  { name: 'Teacher', suffix: 'teachers.com' },
+  { name: 'Presenter', suffix: 'presenters.com' },
+];
 
 export default function Appearance() {
+  const [showInfo, setShowInfo] = useState(true);
+
   return (
-    <p>Registration</p>
+    <Container>
+      {
+        showInfo && (
+          <Row className="mt-2 mb-0">
+            <Alert variant="light" onClick={() => setShowInfo(false)} dismissible>
+              <Alert.Heading>Roles Mapping By Email</Alert.Heading>
+              <p className="text-muted">
+                Map a user to a role based on their email address suffix.<br />
+                Example:<br />
+                For a role name=&apos;Teacher&apos; and an email suffix=&apos;teachers.com&apos;.<br />
+                A user that signs up with email &apos;teacher@teachers.com&apos; will automatically have the role &apos;Teacher&apos; assigned.
+              </p>
+            </Alert>
+          </Row>
+        )
+      }
+      <Row className="mt-2">
+        <RegistrationForm value={DUMMY_ROLES_MAP} />
+      </Row>
+    </Container>
   );
 }

--- a/app/javascript/components/forms/FormControl.jsx
+++ b/app/javascript/components/forms/FormControl.jsx
@@ -6,12 +6,13 @@ import { useFormContext } from 'react-hook-form';
 import PropTypes from 'prop-types';
 
 export default function FormControl({
-  field, control: Control, children, noLabel, ...props
+  field, control: Control, children, fieldError, noLabel, ...props
 }) {
   const { register, formState: { errors } } = useFormContext();
   const { hookForm } = field;
   const { id, validations } = hookForm;
-  const error = errors[id];
+  const error = fieldError ?? errors[id];
+
   return (
     <BootStrapForm.Group className="mb-2" controlId={field.controlId}>
       {
@@ -30,10 +31,12 @@ export default function FormControl({
         && (
           (error.types
             && Object.keys(error.types).map(
-              (key) => <BootStrapForm.Control.Feedback key={key} type="invalid">{error.types[key]}</BootStrapForm.Control.Feedback>,
+              (key) => (
+                error.types[key] && <BootStrapForm.Control.Feedback key={key} type="invalid">{error.types[key]}</BootStrapForm.Control.Feedback>
+              ),
             )
           )
-          || <BootStrapForm.Control.Feedback type="invalid">{error.message}</BootStrapForm.Control.Feedback>
+          || (error.message && <BootStrapForm.Control.Feedback type="invalid">{error.message}</BootStrapForm.Control.Feedback>)
         )
 
       }
@@ -45,6 +48,7 @@ FormControl.defaultProps = {
   noLabel: false,
   control: BootStrapForm.Control,
   children: undefined,
+  fieldError: undefined,
 };
 
 FormControl.propTypes = {
@@ -66,4 +70,13 @@ FormControl.propTypes = {
   noLabel: PropTypes.bool,
   control: PropTypes.shape({}),
   children: PropTypes.node,
+  fieldError: PropTypes.shape({
+    types: PropTypes.objectOf(
+      PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+      ]),
+    ),
+    message: PropTypes.string,
+  }),
 };

--- a/app/javascript/components/forms/admin/RegistrationForm.jsx
+++ b/app/javascript/components/forms/admin/RegistrationForm.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, Stack, Table,
+} from 'react-bootstrap';
+import { useFieldArray, useForm } from 'react-hook-form';
+import Form from '../Form';
+import { RegistrationFormConfig } from '../../../helpers/forms/RegistrationFormHelpers';
+import RegistrationRow from './RegistrationRow';
+
+export default function RegistrationForm({ value }) {
+  const { defaultValues } = RegistrationFormConfig;
+  defaultValues.value = value;
+
+  const methods = useForm(RegistrationFormConfig);
+  const errors = methods.formState.errors.value;
+  const { fields, append, remove } = useFieldArray({ control: methods.control, name: 'value' });
+
+  return (
+    <Form methods={methods} onSubmit={(data) => console.log(data)}>
+      <Table hover bordered className="text-secondary mb-0">
+        <thead>
+          <tr className="text-muted small">
+            <th className="fw-normal border-end-0">Role Name</th>
+            <th className="fw-normal border-0">Email Suffix</th>
+            <th className="border-start-0" aria-label="options" />
+          </tr>
+        </thead>
+        <tbody className="border-top-0">
+          {(
+            fields.length && (fields.map((item, index) => (
+              <RegistrationRow
+                key={item.id}
+                index={index}
+                errors={errors}
+                remove={remove}
+              />
+            )))
+          ) || (
+            <tr>
+              <td className="text-center" colSpan="3">
+                No roles mapping rule, click <strong>Add</strong> to add new one.
+              </td>
+            </tr>
+          )}
+        </tbody>
+        <tfoot className="text-muted small">
+          <tr>
+            <td colSpan="3">
+              <Stack className="mt-1" direction="horizontal" gap={1}>
+                <Button variant="outline-primary" className="" onClick={() => methods.reset(defaultValues)}>
+                  Reset
+                </Button>
+                <Button variant="outline-primary" onClick={() => append({ name: '', suffix: '' })}>
+                  Add
+                </Button>
+                <Button className="ms-auto" variant="primary" type="submit">
+                  Update
+                </Button>
+              </Stack>
+            </td>
+          </tr>
+        </tfoot>
+      </Table>
+    </Form>
+  );
+}
+
+RegistrationForm.defaultProps = {
+  value: [],
+};
+
+RegistrationForm.propTypes = {
+  value: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    suffix: PropTypes.string.isRequired,
+  }).isRequired),
+};

--- a/app/javascript/components/forms/admin/RegistrationRow.jsx
+++ b/app/javascript/components/forms/admin/RegistrationRow.jsx
@@ -1,0 +1,48 @@
+/* eslint-disable react/jsx-props-no-spreading */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { TrashIcon } from '@heroicons/react/outline';
+import { RegistrationFormFields } from '../../../helpers/forms/RegistrationFormHelpers';
+import FormControl from '../FormControl';
+
+export default function RegistrationRow({ index, remove, errors }) {
+  return (
+    <tr>
+      <td className="fw-normal border-end-0">
+        <FormControl
+          fieldError={errors && errors[index]?.name}
+          field={RegistrationFormFields(index).name}
+          type="text"
+          noLabel
+        />
+      </td>
+      <td className="fw-normal border-0">
+        <FormControl
+          fieldError={errors && errors[index]?.suffix}
+          field={RegistrationFormFields(index).suffix}
+          type="text"
+          noLabel
+        />
+      </td>
+      <td className="border-start-0">
+        <TrashIcon className="cursor-pointer hi-s text-danger ms-4 me-0" onClick={() => remove(index)} />
+      </td>
+    </tr>
+  );
+}
+
+RegistrationRow.defaultProps = {
+  errors: [],
+};
+
+RegistrationRow.propTypes = {
+  index: PropTypes.number.isRequired,
+  remove: PropTypes.func.isRequired,
+  errors: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.shape({ message: PropTypes.string }),
+      suffix: PropTypes.shape({ message: PropTypes.string }),
+    }),
+  ),
+};

--- a/app/javascript/helpers/forms/RegistrationFormHelpers.jsx
+++ b/app/javascript/helpers/forms/RegistrationFormHelpers.jsx
@@ -1,0 +1,42 @@
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+
+const validationSchema = yup.object({
+  // TODO: amir - Revisit validations.
+  value: yup.array()
+    .of(
+      yup.object().shape(
+        {
+          name: yup.string().required(''),
+          suffix: yup.string().required(''),
+        },
+      ),
+    ),
+});
+
+export const RegistrationFormConfig = {
+  mode: 'onChange',
+  defaultValues: {
+    value: [],
+  },
+  resolver: yupResolver(validationSchema),
+};
+
+export const RegistrationFormFields = (index) => ({
+  name: {
+    label: 'Role Name',
+    placeHolder: 'Enter a role name...',
+    controlId: `RegistrationForm.${index}.name`,
+    hookForm: {
+      id: `value.${index}.name`,
+    },
+  },
+  suffix: {
+    label: 'Email Suffix',
+    placeHolder: 'Enter an email suffix...',
+    controlId: `RegistrationForm.${index}.suffix`,
+    hookForm: {
+      id: `value.${index}.suffix`,
+    },
+  },
+});


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users with the right set of privileges to edit roles mappers.

This PR completes **0.** 
--
~~0. Add Registration UI and dynamic form.~~
1. Add `SiteSettings#index`.
2. Add `Admin::SiteSettings#update` .
3. Integrate with the APIs.
4.Extend `UsersController#create` to infer the user role.

### User story [Role Mapping]:
---
0. A user with the right set of permissions signs in.
1. User navigates to the Manage site settings page in administration panel.
2. User selects the Registration tab.
3. User can edit the list of roles and their corresponding email suffixes.
5. User can update the list and have adequate feedbacks from the client app.
Note: There's no checks for the list content, it's a string comma sperated list
that can be empty or filled.
## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/29759616/179225320-5d974d5d-a5dc-451b-b273-d7199a8bdb32.png)
![image](https://user-images.githubusercontent.com/29759616/179228043-dc521a0e-fa64-4a19-8812-bd1d8f55eff4.png)
