### PR TITLE
Role mapping 2: Added `Admin::SiteSettings#update` API.

### DIFF
--- a/app/controllers/api/v1/admin/site_settings_controller.rb
+++ b/app/controllers/api/v1/admin/site_settings_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class SiteSettingsController < ApiController
+        # PUT /api/v1/admin/site_settings/:name.json
+        # Expects: { site_setting: { :value } }
+        # Returns: { data: Array[serializable objects] , errors: Array[String] }
+        # Does: Update a site setting :value with its json representation.
+
+        def update
+          return render_error status: :bad_request unless params[:site_setting] && params[:site_setting][:value]
+
+          site_setting = SiteSetting.joins(:setting)
+                                    .find_by(
+                                      provider: 'greenlight',
+                                      setting: { name: params[:name] }
+                                    )
+
+          return render_error status: :not_found unless site_setting
+
+          # Some site settings :value will hold a stringified json representation.
+          value = if params[:name] == 'RoleMapping'
+                    params[:site_setting][:value].to_json
+                  else
+                    params[:site_setting][:value]
+                  end
+
+          return render_error status: :bad_request unless site_setting.update(value:)
+
+          render_json
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/site_settings_controller.rb
+++ b/app/controllers/api/v1/site_settings_controller.rb
@@ -3,6 +3,24 @@
 module Api
   module V1
     class SiteSettingsController < ApiController
+      # GET /api/v1/site_settings.json
+      # Expects: {}
+      # Returns: { data: Array[serializable objects] , errors: Array[String] }
+      # Does: Fetches and returns a Hash :name => :value of all site settings.
+      def index
+        site_settings = Setting.joins(:site_settings)
+                               .where(site_settings: { provider: 'greenlight' })
+                               .pluck(:name, :value)
+                               .to_h
+
+        return render_error status: :internal_server_error if site_settings.blank?
+
+        # RoleMapping encapsulates a list of rules in a json string, so it needs to be parsed before responding.
+        site_settings['RoleMapping'] = JSON.parse(site_settings['RoleMapping']) if site_settings.key?('RoleMapping')
+
+        render_json data: site_settings
+      end
+
       # GET /api/v1/site_settings/:name
       def show
         render_json data: SettingGetter.new(setting_name: params[:name], provider: 'greenlight').call # TODO: - ahmad: fix provider

--- a/app/javascript/components/admin/site_settings/Registration.jsx
+++ b/app/javascript/components/admin/site_settings/Registration.jsx
@@ -1,7 +1,37 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Alert, Container, Row } from 'react-bootstrap';
+import RegistrationForm from '../../forms/admin/RegistrationForm';
+
+const DUMMY_ROLES_MAP = [
+  { name: 'User', suffix: 'users.com' },
+  { name: 'Admin', suffix: 'admins.com' },
+  { name: 'Teacher', suffix: 'teachers.com' },
+  { name: 'Presenter', suffix: 'presenters.com' },
+];
 
 export default function Appearance() {
+  const [showInfo, setShowInfo] = useState(true);
+
   return (
-    <p>Registration</p>
+    <Container>
+      {
+        showInfo && (
+          <Row className="mt-2 mb-0">
+            <Alert variant="light" onClick={() => setShowInfo(false)} dismissible>
+              <Alert.Heading>Roles Mapping By Email</Alert.Heading>
+              <p className="text-muted">
+                Map a user to a role based on their email address suffix.<br />
+                Example:<br />
+                For a role name=&apos;Teacher&apos; and an email suffix=&apos;teachers.com&apos;.<br />
+                A user that signs up with email &apos;teacher@teachers.com&apos; will automatically have the role &apos;Teacher&apos; assigned.
+              </p>
+            </Alert>
+          </Row>
+        )
+      }
+      <Row className="mt-2">
+        <RegistrationForm value={DUMMY_ROLES_MAP} />
+      </Row>
+    </Container>
   );
 }

--- a/app/javascript/components/forms/FormControl.jsx
+++ b/app/javascript/components/forms/FormControl.jsx
@@ -6,12 +6,13 @@ import { useFormContext } from 'react-hook-form';
 import PropTypes from 'prop-types';
 
 export default function FormControl({
-  field, control: Control, children, noLabel, ...props
+  field, control: Control, children, fieldError, noLabel, ...props
 }) {
   const { register, formState: { errors } } = useFormContext();
   const { hookForm } = field;
   const { id, validations } = hookForm;
-  const error = errors[id];
+  const error = fieldError ?? errors[id];
+
   return (
     <BootStrapForm.Group className="mb-2" controlId={field.controlId}>
       {
@@ -30,10 +31,12 @@ export default function FormControl({
         && (
           (error.types
             && Object.keys(error.types).map(
-              (key) => <BootStrapForm.Control.Feedback key={key} type="invalid">{error.types[key]}</BootStrapForm.Control.Feedback>,
+              (key) => (
+                error.types[key] && <BootStrapForm.Control.Feedback key={key} type="invalid">{error.types[key]}</BootStrapForm.Control.Feedback>
+              ),
             )
           )
-          || <BootStrapForm.Control.Feedback type="invalid">{error.message}</BootStrapForm.Control.Feedback>
+          || (error.message && <BootStrapForm.Control.Feedback type="invalid">{error.message}</BootStrapForm.Control.Feedback>)
         )
 
       }
@@ -45,6 +48,7 @@ FormControl.defaultProps = {
   noLabel: false,
   control: BootStrapForm.Control,
   children: undefined,
+  fieldError: undefined,
 };
 
 FormControl.propTypes = {
@@ -66,4 +70,13 @@ FormControl.propTypes = {
   noLabel: PropTypes.bool,
   control: PropTypes.shape({}),
   children: PropTypes.node,
+  fieldError: PropTypes.shape({
+    types: PropTypes.objectOf(
+      PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+      ]),
+    ),
+    message: PropTypes.string,
+  }),
 };

--- a/app/javascript/components/forms/admin/RegistrationForm.jsx
+++ b/app/javascript/components/forms/admin/RegistrationForm.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, Stack, Table,
+} from 'react-bootstrap';
+import { useFieldArray, useForm } from 'react-hook-form';
+import Form from '../Form';
+import { RegistrationFormConfig } from '../../../helpers/forms/RegistrationFormHelpers';
+import RegistrationRow from './RegistrationRow';
+
+export default function RegistrationForm({ value }) {
+  const { defaultValues } = RegistrationFormConfig;
+  defaultValues.value = value;
+
+  const methods = useForm(RegistrationFormConfig);
+  const errors = methods.formState.errors.value;
+  const { fields, append, remove } = useFieldArray({ control: methods.control, name: 'value' });
+
+  return (
+    <Form methods={methods} onSubmit={(data) => console.log(data)}>
+      <Table hover bordered className="text-secondary mb-0">
+        <thead>
+          <tr className="text-muted small">
+            <th className="fw-normal border-end-0">Role Name</th>
+            <th className="fw-normal border-0">Email Suffix</th>
+            <th className="border-start-0" aria-label="options" />
+          </tr>
+        </thead>
+        <tbody className="border-top-0">
+          {(
+            fields.length && (fields.map((item, index) => (
+              <RegistrationRow
+                key={item.id}
+                index={index}
+                errors={errors}
+                remove={remove}
+              />
+            )))
+          ) || (
+            <tr>
+              <td className="text-center" colSpan="3">
+                No roles mapping rule, click <strong>Add</strong> to add new one.
+              </td>
+            </tr>
+          )}
+        </tbody>
+        <tfoot className="text-muted small">
+          <tr>
+            <td colSpan="3">
+              <Stack className="mt-1" direction="horizontal" gap={1}>
+                <Button variant="outline-primary" className="" onClick={() => methods.reset(defaultValues)}>
+                  Reset
+                </Button>
+                <Button variant="outline-primary" onClick={() => append({ name: '', suffix: '' })}>
+                  Add
+                </Button>
+                <Button className="ms-auto" variant="primary" type="submit">
+                  Update
+                </Button>
+              </Stack>
+            </td>
+          </tr>
+        </tfoot>
+      </Table>
+    </Form>
+  );
+}
+
+RegistrationForm.defaultProps = {
+  value: [],
+};
+
+RegistrationForm.propTypes = {
+  value: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    suffix: PropTypes.string.isRequired,
+  }).isRequired),
+};

--- a/app/javascript/components/forms/admin/RegistrationRow.jsx
+++ b/app/javascript/components/forms/admin/RegistrationRow.jsx
@@ -1,0 +1,48 @@
+/* eslint-disable react/jsx-props-no-spreading */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { TrashIcon } from '@heroicons/react/outline';
+import { RegistrationFormFields } from '../../../helpers/forms/RegistrationFormHelpers';
+import FormControl from '../FormControl';
+
+export default function RegistrationRow({ index, remove, errors }) {
+  return (
+    <tr>
+      <td className="fw-normal border-end-0">
+        <FormControl
+          fieldError={errors && errors[index]?.name}
+          field={RegistrationFormFields(index).name}
+          type="text"
+          noLabel
+        />
+      </td>
+      <td className="fw-normal border-0">
+        <FormControl
+          fieldError={errors && errors[index]?.suffix}
+          field={RegistrationFormFields(index).suffix}
+          type="text"
+          noLabel
+        />
+      </td>
+      <td className="border-start-0">
+        <TrashIcon className="cursor-pointer hi-s text-danger ms-4 me-0" onClick={() => remove(index)} />
+      </td>
+    </tr>
+  );
+}
+
+RegistrationRow.defaultProps = {
+  errors: [],
+};
+
+RegistrationRow.propTypes = {
+  index: PropTypes.number.isRequired,
+  remove: PropTypes.func.isRequired,
+  errors: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.shape({ message: PropTypes.string }),
+      suffix: PropTypes.shape({ message: PropTypes.string }),
+    }),
+  ),
+};

--- a/app/javascript/helpers/forms/RegistrationFormHelpers.jsx
+++ b/app/javascript/helpers/forms/RegistrationFormHelpers.jsx
@@ -1,0 +1,42 @@
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+
+const validationSchema = yup.object({
+  // TODO: amir - Revisit validations.
+  value: yup.array()
+    .of(
+      yup.object().shape(
+        {
+          name: yup.string().required(''),
+          suffix: yup.string().required(''),
+        },
+      ),
+    ),
+});
+
+export const RegistrationFormConfig = {
+  mode: 'onChange',
+  defaultValues: {
+    value: [],
+  },
+  resolver: yupResolver(validationSchema),
+};
+
+export const RegistrationFormFields = (index) => ({
+  name: {
+    label: 'Role Name',
+    placeHolder: 'Enter a role name...',
+    controlId: `RegistrationForm.${index}.name`,
+    hookForm: {
+      id: `value.${index}.name`,
+    },
+  },
+  suffix: {
+    label: 'Email Suffix',
+    placeHolder: 'Enter an email suffix...',
+    controlId: `RegistrationForm.${index}.suffix`,
+    hookForm: {
+      id: `value.${index}.suffix`,
+    },
+  },
+});

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,7 @@ Rails.application.routes.draw do
       resources :verify_account, only: :create do
         post '/activate', to: 'verify_account#activate', on: :collection
       end
-      resources :site_settings, only: :show, param: :name
+      resources :site_settings, only: %i[index show], param: :name
 
       namespace :admin do
         resources :users, only: %i[create destroy]  do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
         resources :server_rooms, only: %i[index destroy], param: :friendly_id
         resources :server_recordings, only: %i[index]
         resources :roles, only: %i[index create update show]
+        resources :site_settings, only: :update, param: :name
       end
     end
   end

--- a/db/data/20220713143528_populate_site_settings.rb
+++ b/db/data/20220713143528_populate_site_settings.rb
@@ -12,7 +12,7 @@ class PopulateSiteSettings < ActiveRecord::Migration[7.0]
       { setting: Setting.find_by(name: 'RegistrationMethod'), value: SiteSetting::REGISTRATION_METHODS[:open], provider: 'greenlight' },
       { setting: Setting.find_by(name: 'ShareRooms'), value: 'true', provider: 'greenlight' },
       { setting: Setting.find_by(name: 'PreuploadPresentation'), value: 'true', provider: 'greenlight' },
-      { setting: Setting.find_by(name: 'RoleMapping'), value: '', provider: 'greenlight' }
+      { setting: Setting.find_by(name: 'RoleMapping'), value: '[]', provider: 'greenlight' }
     ]
   end
 

--- a/spec/controllers/admin/site_settings_controller_spec.rb
+++ b/spec/controllers/admin/site_settings_controller_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::Admin::SiteSettingsController, type: :controller do
+  before { request.headers['ACCEPT'] = 'application/json' }
+
+  describe 'site_settings#update' do
+    it 'updates the site setting :value' do
+      setting = create(:setting, name: 'Setting')
+      site_setting = create(:site_setting, setting:, value: 'OLD', provider: 'greenlight')
+
+      put :update, params: { name: 'Setting', site_setting: { value: 'NEW' } }
+
+      expect(response).to have_http_status(:ok)
+      expect(site_setting.reload.value).to eq('NEW')
+    end
+
+    it 'updates the site setting :value with a json stringified version for "RoleMapping"' do
+      setting = create(:setting, name: 'RoleMapping')
+      site_setting = create(:site_setting, setting:, value: '[]', provider: 'greenlight')
+
+      value = { 'foo' => 'foo', 'bar' => 'bar', 'zoo' => 'zoo' }
+
+      put :update, params: { name: 'RoleMapping', site_setting: { value: } }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(site_setting.reload.value)).to eq(value)
+    end
+
+    it 'returns :not_found for invalid :name' do
+      put :update, params: { name: 'Unkown', site_setting: { value: 'GOOD' } }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns :bad_request for invalid params' do
+      setting = create(:setting, name: 'Setting')
+      create(:site_setting, setting:, value: 'OLD', provider: 'greenlight')
+
+      put :update, params: { name: 'Setting', not_site_setting: { not_value: 'BAD' } }
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end

--- a/spec/controllers/site_settings_controller_spec.rb
+++ b/spec/controllers/site_settings_controller_spec.rb
@@ -7,6 +7,49 @@ RSpec.describe Api::V1::SiteSettingsController, type: :controller do
     request.headers['ACCEPT'] = 'application/json'
   end
 
+  describe 'site_settings#index' do
+    it 'returns a hash of site settings :name => :value' do
+      settings = [
+        create(:setting, name: 'Leonardo'), create(:setting, name: 'Michelangelo'),
+        create(:setting, name: 'Donatello'), create(:setting, name: 'Raphael')
+      ]
+
+      create(:site_setting, setting: settings[0], value: 'Blue', provider: 'greenlight')
+      create(:site_setting, setting: settings[1], value: 'Orange', provider: 'greenlight')
+      create(:site_setting, setting: settings[2], value: 'Purple', provider: 'greenlight')
+      create(:site_setting, setting: settings[3], value: 'Red', provider: 'greenlight')
+
+      get :index
+
+      expect(JSON.parse(response.body)['data']).to eq({
+                                                        'Leonardo' => 'Blue',
+                                                        'Michelangelo' => 'Orange',
+                                                        'Donatello' => 'Purple',
+                                                        'Raphael' => 'Red'
+                                                      })
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns :internal_server_error if there\'s no site settings for the provider' do
+      create(:site_setting, provider: 'BROVIDER')
+
+      get :index
+
+      expect(response).to have_http_status(:internal_server_error)
+    end
+
+    it 'JSON parses "RoleMapping"' do
+      value = [{ 'foo' => 'foo' }, { 'bar' => 'bar' }, [{ 'zoo' => 'zoo' }]]
+      setting = create(:setting, name: 'RoleMapping')
+      create(:site_setting, setting:, provider: 'greenlight', value: value.to_json)
+
+      get :index
+
+      expect(JSON.parse(response.body)['data']['RoleMapping']).to eq(value)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe '#show' do
     it 'calls SettingGetter and returns the value from it' do
       expect(SettingGetter).to receive(:new).with(setting_name: 'SettingName', provider: 'greenlight').and_call_original

--- a/spec/services/setting_getter_spec.rb
+++ b/spec/services/setting_getter_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 describe SettingGetter, type: :service do
+  before do
+    Faker::Vehicle.unique.clear # Required for avoiding Faker::UniqueGenerator::RetryLimitExceeded.
+  end
+
   describe '#call' do
     it 'returns true if the setting value is "true"' do
       site_setting = create(:site_setting, value: 'true')


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users with the right set of privileges to edit roles mappers.

This PR completes **2.** 
--
~~0. Add Registration UI and dynamic form.~~
~~1. Add `SiteSettings#index`.~~
~~2. Add `Admin::SiteSettings#update`.~~
3. Integrate with the APIs.
4.Extend `UsersController#create` to infer the user role.

### User story [Role Mapping]:
---
0. A user with the right set of permissions signs in.
1. User navigates to the Manage site settings page in administration panel.
2. User selects the Registration tab.
3. User can edit the list of roles and their corresponding email suffixes.
5. User can update the list and have adequate feedbacks from the client app.
Note: There's no checks for the list content, it's a string comma sperated list
that can be empty or filled.
## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
