### PR TITLE
Add Extended Sessions

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -28,19 +28,34 @@ module Api
 
       # DELETE /api/v1/sessions/signout
       def destroy
-        session[:user_id] = nil
+        sign_out
         render_data status: :ok
       end
 
       private
 
       def session_params
-        params.require(:session).permit(:email, :password)
+        params.require(:session).permit(:email, :password, :extend_session)
       end
 
-      # Signs In the user
       def sign_in(user)
-        session[:user_id] = user.id
+        # Creates an extended_session cookie instead of a session cookie if extend_session is selected in sign in form.
+        if session_params[:extend_session]
+          cookies.encrypted[:_extended_session] = {
+            value: {
+              user_id: user.id
+            },
+            expires: 7.days,
+            httponly: true
+          }
+        else
+          session[:user_id] = user.id
+        end
+      end
+
+      def sign_out
+        reset_session
+        cookies.delete :_extended_session
       end
     end
   end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -39,7 +39,7 @@ module Api
       end
 
       def sign_in(user)
-        # Creates an extended_session cookie instead of a session cookie if extend_session is selected in sign in form.
+        # Creates an extended_session cookie if extend_session is selected in sign in form.
         if session_params[:extend_session]
           cookies.encrypted[:_extended_session] = {
             value: {
@@ -48,9 +48,8 @@ module Api
             expires: 7.days,
             httponly: true
           }
-        else
-          session[:user_id] = user.id
         end
+        session[:user_id] = user.id
       end
 
       def sign_out

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   # Returns the current signed in User (if any)
   def current_user
     # Overwrites the session cookie if an extended_session cookie exists
-    session[:user_id] = cookies.encrypted[:_extended_session]['user_id'] if cookies.encrypted[:_extended_session].present?
+    session[:user_id] ||= cookies.encrypted[:_extended_session]['user_id'] if cookies.encrypted[:_extended_session].present?
     @current_user ||= User.find_by(id: session[:user_id])
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@
 class ApplicationController < ActionController::Base
   # Returns the current signed in User (if any)
   def current_user
+    # Overwrites the session cookie if an extended_session cookie exists
+    session[:user_id] = cookies.encrypted[:_extended_session]['user_id'] if cookies.encrypted[:_extended_session].present?
     @current_user ||= User.find_by(id: session[:user_id])
   end
 

--- a/app/javascript/components/forms/SigninForm.jsx
+++ b/app/javascript/components/forms/SigninForm.jsx
@@ -46,9 +46,13 @@ export default function SigninForm() {
       <FormControl field={fields.password} type="password" />
       <Row>
         <Col>
-          <BootstrapForm.Group className="mb-2" controlId="rememberMeCheckbox">
-            <BootstrapForm.Check type="checkbox" label="Remember me" className="small" {...methods.register('extend_session')} />
-          </BootstrapForm.Group>
+          <FormControl
+            control={BootstrapForm.Check}
+            field={fields.extend_session}
+            label={fields.extend_session.label}
+            type="checkbox"
+            noLabel
+          />
         </Col>
         <Col>
           <Link to="/forget_password" className="text-link float-end small"> Forgot password? </Link>

--- a/app/javascript/components/forms/SigninForm.jsx
+++ b/app/javascript/components/forms/SigninForm.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/jsx-props-no-spreading */
+
 import React, { useState, useRef } from 'react';
 import {
   Button, Col, Row, Stack, Form as BootstrapForm,
@@ -44,8 +46,8 @@ export default function SigninForm() {
       <FormControl field={fields.password} type="password" />
       <Row>
         <Col>
-          <BootstrapForm.Group className="mb-2" controlId="formBasicCheckbox">
-            <BootstrapForm.Check type="checkbox" label="Remember me" className="small" />
+          <BootstrapForm.Group className="mb-2" controlId="rememberMeCheckbox">
+            <BootstrapForm.Check type="checkbox" label="Remember me" className="small" {...methods.register('extend_session')} />
           </BootstrapForm.Group>
         </Col>
         <Col>

--- a/app/javascript/helpers/forms/SigninFormHelpers.jsx
+++ b/app/javascript/helpers/forms/SigninFormHelpers.jsx
@@ -4,12 +4,14 @@ import { yupResolver } from '@hookform/resolvers/yup';
 const validationSchema = yup.object({
   email: yup.string().required('Please enter your email.').email('Entered value does not match email format.'),
   password: yup.string().required('Please enter your password.'),
+  extend_session: yup.bool(),
 });
 
 export const signinFormConfig = {
   defaultValues: {
     email: '',
     password: '',
+    extend_session: false,
   },
   resolver: yupResolver(validationSchema),
 };
@@ -29,6 +31,13 @@ export const signinFormFields = {
     controlId: 'signinFormPwd',
     hookForm: {
       id: 'password',
+    },
+  },
+  extend_session: {
+    label: 'Remember me',
+    controlId: 'signInFormRememberMe',
+    hookForm: {
+      id: 'extend_session',
     },
   },
 };

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe Api::V1::SessionsController, type: :controller do
 
       delete :destroy
 
+      expect(cookies.encrypted[:_extended_session]).to be_nil
       expect(session[:user_id]).to be_nil
     end
   end
 end
-

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::SessionsController, type: :controller do
+  before do
+    request.headers['ACCEPT'] = 'application/json'
+  end
+
+  describe '#create' do
+    it 'creates a regular session if the remember me checkbox is not selected' do
+      user = create(:user, email: 'email@email.com', password: 'password', password_confirmation: 'password')
+
+      post :create, params: {
+        session: {
+          email: 'email@email.com',
+          password: 'password',
+          extend_session: false
+        }
+      }, as: :json
+
+      expect(cookies.encrypted[:_extended_session]).to be_nil
+      expect(session[:user_id]).to eq(user.id)
+    end
+
+    it 'creates an extended session if the remember me checkbox is selected' do
+      user = create(:user, email: 'email@email.com', password: 'password', password_confirmation: 'password')
+      post :create, params: {
+        session: {
+          email: 'email@email.com',
+          password: 'password',
+          extend_session: true
+        }
+      }, as: :json
+
+      expect(cookies.encrypted[:_extended_session]['user_id']).to eq(user.id)
+      expect(session[:user_id]).to eq(user.id)
+    end
+  end
+
+  describe '#destroy' do
+    it 'signs off the user' do
+      user = create(:user)
+      session[:user_id] = user.id
+
+      delete :destroy
+
+      expect(session[:user_id]).to be_nil
+    end
+  end
+end
+


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add Extended Session feature.

- If the "Remember Me" checkbox is selected by the User, the `extended_session` cookie (in addition to the session cookie) will be created upon signing in.
- The `extended_session` cookie is set to expire in 2 weeks from it's creation.
- The `current_user` method will check for the `extended_session` cookie before settling for the session cookie.
- On sign out, both cookies are set to nil.

Initially, I tried to overwrite the session[:_APPNAME_session] cookie with an extra { expires: x days } field, but Rails would complain.
I figured creating an extra cookie is not too cumbersome. 





## Testing Steps
<!--- Please describe in detail how to test your changes. -->

NOTE: CHROME BROWSERS HAVE THIS FEATURE BUILT-IN. PLEASE DISABLE IT OR TEST WITH MOZILLA FIREFOX INSTEAD.

**Test if the session cookie has the default behaviour - or the browser does not have the built-in feature:**
1. Sign in without checking the "Remember Me" checkbox. 
2. Close the browser
3. Navigate back to the app, you should be logged out.

**Test the extended session feature:**
1. Sign in with the "Remember Me" checkbox checked.
2. Close the browser
3. Navigate back to the app, you should be still logged in.

## TODO: Add RSpec
