### PR TITLE
Administration Settings 0: Added `Administration` UI.

### DIFF
--- a/app/javascript/components/admin/SiteSettings.jsx
+++ b/app/javascript/components/admin/SiteSettings.jsx
@@ -31,7 +31,10 @@ export default function SiteSettings() {
                         <Appearance />
                       </Tab>
                       <Tab eventKey="administration" title="Administration">
-                        <Administration />
+                        <Administration
+                          terms="https://www.terms.com"
+                          privacy="https://www.privacy.com"
+                        />
                       </Tab>
                       <Tab eventKey="settings" title="Settings">
                         <Settings />

--- a/app/javascript/components/admin/site_settings/Administration.jsx
+++ b/app/javascript/components/admin/site_settings/Administration.jsx
@@ -1,7 +1,38 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { Container, Row } from 'react-bootstrap';
+import LinksForm from '../../forms/admin/LinksForm';
 
-export default function Appearance() {
+export default function Administration({ terms, privacy }) {
   return (
-    <p>Admin</p>
+    <Container className="w-75 mt-2 ms-0">
+      <Row className="mb-3">
+        <Row> <h6> Terms </h6> </Row>
+        <Row> <p className="text-muted"> Change the Terms Link that appears in the bottom of the page </p> </Row>
+        <Row>
+          <LinksForm
+            id="termsForm"
+            mutation={() => ({ mutate: (data) => console.log(data) })}
+            value={terms}
+          />
+        </Row>
+      </Row>
+      <Row>
+        <Row> <h6> Privacy </h6> </Row>
+        <Row> <p className="text-muted"> Change the Privacy Link that appears in the bottom of the page </p> </Row>
+        <Row>
+          <LinksForm
+            id="privacyForm"
+            mutation={() => ({ mutate: (data) => console.log(data) })}
+            value={privacy}
+          />
+        </Row>
+      </Row>
+    </Container>
   );
 }
+
+Administration.propTypes = {
+  terms: PropTypes.string.isRequired,
+  privacy: PropTypes.string.isRequired,
+};

--- a/app/javascript/components/forms/admin/LinksForm.jsx
+++ b/app/javascript/components/forms/admin/LinksForm.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, InputGroup,
+} from 'react-bootstrap';
+import { useForm } from 'react-hook-form';
+import Form from '../Form';
+import { linksFormConfig, linksFormFields } from '../../../helpers/forms/LinksFormHelpers';
+import Spinner from '../../shared/stylings/Spinner';
+import FormControlGeneric from '../FormControlGeneric';
+
+export default function LinksForm({ id, value, mutation: useUpdateSiteSettingsAPI }) {
+  const updateSiteSettingsAPI = useUpdateSiteSettingsAPI();
+
+  const { defaultValues } = linksFormConfig;
+  defaultValues.value = value;
+  const fields = linksFormFields;
+  const methods = useForm(linksFormConfig);
+
+  return (
+    <Form id={id} methods={methods} onSubmit={updateSiteSettingsAPI.mutate}>
+      <InputGroup>
+        <FormControlGeneric
+          field={fields.value}
+          aria-describedby={`${id}-submit-btn`}
+          type="text"
+        />
+        <Button id={`${id}-submit-btn`} variant="primary" type="submit" disabled={updateSiteSettingsAPI.isLoading}>
+          Change URL
+          {updateSiteSettingsAPI.isLoading && <Spinner />}
+        </Button>
+      </InputGroup>
+    </Form>
+  );
+}
+
+LinksForm.propTypes = {
+  id: PropTypes.string.isRequired,
+  mutation: PropTypes.func.isRequired,
+  value: PropTypes.string.isRequired,
+};

--- a/app/javascript/helpers/forms/LinksFormHelpers.jsx
+++ b/app/javascript/helpers/forms/LinksFormHelpers.jsx
@@ -1,0 +1,24 @@
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+
+const validationSchema = yup.object({
+  // TODO: amir - Revisit validations.
+  value: yup.string().url(),
+});
+
+export const linksFormConfig = {
+  mode: 'onChange',
+  defaultValues: {
+    value: '',
+  },
+  resolver: yupResolver(validationSchema),
+};
+
+export const linksFormFields = {
+  value: {
+    placeHolder: 'Enter link here...',
+    hookForm: {
+      id: 'value',
+    },
+  },
+};


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users with the right set of privileges to edit Terms and Privacy Policy links.

This PR completes **0.** 
--
~~0. Add Administration settings UI.~~
1. Integrate with the `Admin::SiteSettings` APIs.

### User story [Administration settings]:
---
0. A user with the right set of permissions signs in.
1. User navigates to the Manage site settings page in administration panel.
3. User selects the Administration tab.
4. User can edit the terms or privacy policy links and have adequate feedbacks from the client app.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/29759616/180025831-12cee219-f8be-4122-9cd9-5b2a62b0890b.png)
