### PR TITLE
Role Mapping 0: Added `RoleMapping` UI

### DIFF
--- a/app/javascript/components/admin/site_settings/Registration.jsx
+++ b/app/javascript/components/admin/site_settings/Registration.jsx
@@ -1,7 +1,20 @@
 import React from 'react';
+import { Container, Row } from 'react-bootstrap';
+import RegistrationForm from '../../forms/admin/RegistrationForm';
 
-export default function Appearance() {
+export default function Registration() {
   return (
-    <p>Registration</p>
+    <Container className="w-75 mt-2 ms-0">
+      <Row className="mb-3">
+        <Row> <h6> Role Mapping By Email </h6> </Row>
+        <Row> <p className="text-muted"> Map the user to a role using their email.Must be in the format: role1=email1, role2=email2  </p> </Row>
+        <Row>
+          <RegistrationForm
+            mutation={() => ({ mutate: (data) => console.log(data) })}
+            value="User=users.com"
+          />
+        </Row>
+      </Row>
+    </Container>
   );
 }

--- a/app/javascript/components/forms/admin/RegistrationForm.jsx
+++ b/app/javascript/components/forms/admin/RegistrationForm.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, InputGroup,
+} from 'react-bootstrap';
+import { useForm } from 'react-hook-form';
+import Form from '../Form';
+import { RegistrationFormFields, RegistrationFormConfig } from '../../../helpers/forms/RegistrationFormHelpers';
+import Spinner from '../../shared/stylings/Spinner';
+import FormControlGeneric from '../FormControlGeneric';
+
+export default function RegistrationForm({ value, mutation: useUpdateSiteSettingsAPI }) {
+  const updateSiteSettingsAPI = useUpdateSiteSettingsAPI();
+
+  const { defaultValues } = RegistrationFormConfig;
+  defaultValues.value = value;
+  const fields = RegistrationFormFields;
+  const methods = useForm(RegistrationFormConfig);
+
+  return (
+    <Form methods={methods} onSubmit={updateSiteSettingsAPI.mutate}>
+      <InputGroup>
+        <FormControlGeneric
+          field={fields.value}
+          aria-describedby="RegistrationForm-submit-btn"
+          type="text"
+        />
+        <Button id="RegistrationForm-submit-btn" variant="primary" type="submit" disabled={updateSiteSettingsAPI.isLoading}>
+          Update
+          {updateSiteSettingsAPI.isLoading && <Spinner />}
+        </Button>
+      </InputGroup>
+    </Form>
+  );
+}
+
+RegistrationForm.defaultProps = {
+  value: '',
+};
+
+RegistrationForm.propTypes = {
+  value: PropTypes.string,
+  mutation: PropTypes.func.isRequired,
+};

--- a/app/javascript/helpers/forms/RegistrationFormHelpers.jsx
+++ b/app/javascript/helpers/forms/RegistrationFormHelpers.jsx
@@ -1,0 +1,25 @@
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+
+const validationSchema = yup.object({
+  // TODO: amir - Revisit validations.
+  value: yup.string(),
+});
+
+export const RegistrationFormConfig = {
+  mode: 'onChange',
+  defaultValues: {
+    value: '',
+  },
+  resolver: yupResolver(validationSchema),
+};
+
+export const RegistrationFormFields = {
+  value: {
+    placeHolder: 'Enter a role mapping rule...',
+    controlId: 'RegistrationFormvalue',
+    hookForm: {
+      id: 'value',
+    },
+  },
+};


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users with the right set of privileges to edit roles mappers.

This PR completes **1.** 
--
~~0. Add Registration UI.~~
1. Integrate with the `Admin::SiteSettings` APIs.
2.Extend `UsersController#create` to infer the user role.

### User story [Role Mapping]:
---
0. A user with the right set of permissions signs in.
1. User navigates to the Manage site settings page in administration panel.
2. User selects the Registration tab.
3. User can edit the list of roles and their corresponding email suffixes.
5. User can update the list and have adequate feedbacks from the client app.
Note: There's no checks for the list content, it's a string comma speparated list
that can be empty or filled.
## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/29759616/180064699-e6fd4417-41f3-4427-b28d-3663423f39b1.png)
