### PR TITLE
Forms: Added `FormsControlGenric` component.

### DIFF
--- a/app/javascript/components/forms/FormControl.jsx
+++ b/app/javascript/components/forms/FormControl.jsx
@@ -4,14 +4,14 @@ import React from 'react';
 import { Form as BootStrapForm } from 'react-bootstrap';
 import { useFormContext } from 'react-hook-form';
 import PropTypes from 'prop-types';
+import FormControlGeneric from './FormControlGeneric';
 
 export default function FormControl({
-  field, control: Control, children, noLabel, ...props
+  field, control, children, noLabel, ...props
 }) {
-  const { register, formState: { errors } } = useFormContext();
-  const { hookForm } = field;
-  const { id, validations } = hookForm;
-  const error = errors[id];
+  const { formState: { errors } } = useFormContext();
+  const error = errors[field.hookForm.id];
+
   return (
     <BootStrapForm.Group className="mb-2" controlId={field.controlId}>
       {
@@ -22,18 +22,20 @@ export default function FormControl({
           </BootStrapForm.Label>
         )
       }
-      <Control {...props} placeholder={field.placeHolder} isInvalid={error} {...register(id, validations)}>
+      <FormControlGeneric {...props} field={field} control={control}>
         {children}
-      </Control>
+      </FormControlGeneric>
       {
         error
         && (
           (error.types
             && Object.keys(error.types).map(
-              (key) => <BootStrapForm.Control.Feedback key={key} type="invalid">{error.types[key]}</BootStrapForm.Control.Feedback>,
+              (key) => (
+                error.types[key] && <BootStrapForm.Control.Feedback key={key} type="invalid">{error.types[key]}</BootStrapForm.Control.Feedback>
+              ),
             )
           )
-          || <BootStrapForm.Control.Feedback type="invalid">{error.message}</BootStrapForm.Control.Feedback>
+          || (error.message && <BootStrapForm.Control.Feedback type="invalid">{error.message}</BootStrapForm.Control.Feedback>)
         )
 
       }
@@ -43,14 +45,14 @@ export default function FormControl({
 
 FormControl.defaultProps = {
   noLabel: false,
-  control: BootStrapForm.Control,
+  control: undefined,
   children: undefined,
 };
 
 FormControl.propTypes = {
   field: PropTypes.shape(
     {
-      label: PropTypes.string.isRequired,
+      label: PropTypes.string,
       placeHolder: PropTypes.string,
       controlId: PropTypes.string.isRequired,
       hookForm: PropTypes.shape(

--- a/app/javascript/components/forms/FormControlGeneric.jsx
+++ b/app/javascript/components/forms/FormControlGeneric.jsx
@@ -1,0 +1,46 @@
+/* eslint-disable react/jsx-props-no-spreading */
+
+import React from 'react';
+import { Form as BootStrapForm } from 'react-bootstrap';
+import { useFormContext } from 'react-hook-form';
+import PropTypes from 'prop-types';
+
+export default function FormControlGeneric({
+  field, control: Control, children, ...props
+}) {
+  const { register, formState: { errors } } = useFormContext();
+  const { hookForm } = field;
+  const { id, validations } = hookForm;
+  const error = errors[id];
+
+  return (
+    <Control {...props} placeholder={field.placeHolder} isInvalid={error} {...register(id, validations)}>
+      {children}
+    </Control>
+  );
+}
+
+FormControlGeneric.defaultProps = {
+  control: BootStrapForm.Control,
+  children: undefined,
+};
+
+FormControlGeneric.propTypes = {
+  field: PropTypes.shape(
+    {
+      label: PropTypes.string,
+      placeHolder: PropTypes.string,
+      controlId: PropTypes.string,
+      hookForm: PropTypes.shape(
+        {
+          id: PropTypes.string.isRequired,
+          validations: PropTypes.shape({
+            deps: PropTypes.arrayOf(PropTypes.string),
+          }),
+        },
+      ).isRequired,
+    },
+  ).isRequired,
+  control: PropTypes.shape({}),
+  children: PropTypes.node,
+};


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR create `FormsControlGenric` component which is the same as `FormControl` except that it does not encapsulate (group) the control element inside of a container to hold its label and errors.

`FormControl` itself will use `FormsControlGenric`, for cases where there's no need for having a label and error messages using `FormsControlGenric` can be adequate.


## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
