### PR TITLE
Rooms Configurations: Added `RoomsConfiguration` model.

### DIFF
--- a/app/models/meeting_option.rb
+++ b/app/models/meeting_option.rb
@@ -2,6 +2,7 @@
 
 class MeetingOption < ApplicationRecord
   has_many :room_meeting_options, dependent: :restrict_with_exception
+  has_many :rooms_configurations, dependent: :restrict_with_exception
 
   validates :name, presence: true, uniqueness: true
 

--- a/app/models/rooms_configuration.rb
+++ b/app/models/rooms_configuration.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RoomsConfiguration < ApplicationRecord
+  belongs_to :meeting_option
+  validates :provider, presence: true
+  # 'option': Optional config, 'true': Force enabled, 'false': Disabled.
+  validates :value, inclusion: { in: %w[optional true false] }
+  validates :meeting_option_id, uniqueness: { scope: :provider }
+
+  delegate :name, to: :meeting_option
+end

--- a/db/data/20220721131636_populate_rooms_configurations.rb
+++ b/db/data/20220721131636_populate_rooms_configurations.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class PopulateRoomsConfigurations < ActiveRecord::Migration[7.0]
+  def up
+    RoomsConfiguration.create! [
+      { meeting_option: MeetingOption.find_by(name: 'record'), value: 'optional', provider: 'greenlight' },
+      { meeting_option: MeetingOption.find_by(name: 'muteOnStart'), value: 'optional', provider: 'greenlight' },
+      { meeting_option: MeetingOption.find_by(name: 'guestPolicy'), value: 'optional', provider: 'greenlight' },
+      { meeting_option: MeetingOption.find_by(name: 'glAnyoneCanStart'), value: 'optional', provider: 'greenlight' },
+      { meeting_option: MeetingOption.find_by(name: 'glAnyoneJoinAsModerator'), value: 'optional', provider: 'greenlight' }
+    ]
+  end
+
+  def down
+    RoomsConfiguration.destroy_all
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20220713143528)
+DataMigrate::Data.define(version: 20220721131636)

--- a/db/migrate/20220721131241_create_rooms_configurations.rb
+++ b/db/migrate/20220721131241_create_rooms_configurations.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateRoomsConfigurations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :rooms_configurations do |t|
+      t.belongs_to :meeting_option, foreign_key: true
+      t.string :provider, null: false
+      t.string :value, null: false
+      t.timestamps
+    end
+
+    add_index :rooms_configurations, %i[meeting_option_id provider], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_13_143235) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_21_131241) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -108,6 +108,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_13_143235) do
     t.index ["user_id"], name: "index_rooms_on_user_id"
   end
 
+  create_table "rooms_configurations", force: :cascade do |t|
+    t.bigint "meeting_option_id"
+    t.string "provider", null: false
+    t.string "value", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["meeting_option_id", "provider"], name: "index_rooms_configurations_on_meeting_option_id_and_provider", unique: true
+    t.index ["meeting_option_id"], name: "index_rooms_configurations_on_meeting_option_id"
+  end
+
   create_table "settings", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -163,6 +173,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_13_143235) do
   add_foreign_key "room_meeting_options", "meeting_options"
   add_foreign_key "room_meeting_options", "rooms"
   add_foreign_key "rooms", "users"
+  add_foreign_key "rooms_configurations", "meeting_options"
   add_foreign_key "shared_accesses", "rooms"
   add_foreign_key "shared_accesses", "users"
   add_foreign_key "site_settings", "settings"

--- a/spec/factories/rooms_configuration_factory.rb
+++ b/spec/factories/rooms_configuration_factory.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :rooms_configuration do
+    meeting_option
+    provider { Faker::Company.name.downcase }
+    value { %w[true false optional].sample }
+  end
+end

--- a/spec/models/rooms_configuration_spec.rb
+++ b/spec/models/rooms_configuration_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RoomsConfiguration, type: :model do
+  describe 'validations' do
+    subject { create(:rooms_configuration) }
+
+    it { is_expected.to belong_to(:meeting_option) }
+    it { is_expected.to validate_presence_of(:provider) }
+    it { is_expected.to validate_inclusion_of(:value).in_array(%w[optional true false]) }
+    it { is_expected.to validate_uniqueness_of(:meeting_option_id).scoped_to(:provider) }
+    it { is_expected.to delegate_method(:name).to(:meeting_option) }
+  end
+end

--- a/spec/services/setting_getter_spec.rb
+++ b/spec/services/setting_getter_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 describe SettingGetter, type: :service do
+  before do
+    Faker::Vehicle.unique.clear # Required for avoiding Faker::UniqueGenerator::RetryLimitExceeded.
+  end
+
   describe '#call' do
     it 'returns true if the setting value is "true"' do
       site_setting = create(:site_setting, value: 'true')


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users with the right set of privileges to configure rooms settings.

This PR completes prepares the `RoomsConfiguration` model that will hold the configuration for each available meeting option (room settings).

### User story [Rooms Configuration]:
---
0. A user with the right set of permissions signs in.
1. User navigates to the Manage site settings page in administration panel.
2. User selects the Rooms Configuration tab.
3. User can edit all available rooms settings (force enabling or disabling, making it optional).
5. User can edit those settings while having adequate feedbacks from the client app.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
