### PR TITLE
Rooms Configurations: Added `RoomsConfiguration` APIs.

### DIFF
--- a/app/controllers/api/v1/admin/rooms_configurations_controller.rb
+++ b/app/controllers/api/v1/admin/rooms_configurations_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class RoomsConfigurationsController < ApiController
+        # PUT /api/v1/admin/rooms_configurations/:name.json
+        # Expects: { RoomsConfig: { :value } }
+        # Returns: { data: Array[serializable objects] , errors: Array[String] }
+        # Does: Update a rooms configuration :value.
+        def update
+          return render_error status: :bad_request unless params[:RoomsConfig] && params[:RoomsConfig][:value]
+
+          rooms_config = RoomsConfiguration.joins(:meeting_option)
+                                           .find_by(
+                                             provider: 'greenlight',
+                                             meeting_option: { name: params[:name] }
+                                           )
+
+          return render_error status: :not_found unless rooms_config
+
+          return render_error status: :bad_request unless rooms_config.update(value: params[:RoomsConfig][:value])
+
+          render_data status: :ok
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/rooms_configurations_controller.rb
+++ b/app/controllers/api/v1/rooms_configurations_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class RoomsConfigurationsController < ApiController
+      # GET /api/v1/rooms_configurations.json
+      # Expects: {}
+      # Returns: { data: Array[serializable objects] , errors: Array[String] }
+      # Does: Fetches and returns a Hash :name => :value of all rooms configurations.
+      def index
+        rooms_configs = MeetingOption.joins(:rooms_configurations)
+                                     .where(rooms_configurations: { provider: 'greenlight' })
+                                     .pluck(:name, :value)
+                                     .to_h
+
+        render_data data: rooms_configs, status: :ok
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
         post '/activate', to: 'verify_account#activate', on: :collection
       end
       resources :site_settings, only: :show, param: :name
+      resources :rooms_configurations, only: :index
 
       namespace :admin do
         resources :users, only: %i[create destroy]  do
@@ -73,6 +74,7 @@ Rails.application.routes.draw do
         end
         resources :server_rooms, only: %i[index destroy], param: :friendly_id
         resources :server_recordings, only: %i[index]
+        resources :rooms_configurations, only: :update, param: :name
         resources :roles
       end
     end

--- a/spec/controllers/admin/rooms_configurations_controller_spec.rb
+++ b/spec/controllers/admin/rooms_configurations_controller_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::Admin::RoomsConfigurationsController, type: :controller do
+  before { request.headers['ACCEPT'] = 'application/json' }
+
+  describe 'rooms_configurations#update' do
+    it 'updates the rooms configuration :value' do
+      meeting_option = create(:meeting_option, name: 'Option')
+      rooms_config = create(:rooms_configuration, meeting_option:, value: 'optional', provider: 'greenlight')
+
+      put :update, params: { name: 'Option', RoomsConfig: { value: 'true' } }
+
+      expect(response).to have_http_status(:ok)
+      expect(rooms_config.reload.value).to eq('true')
+    end
+
+    it 'returns :not_found for unfound record by :name' do
+      put :update, params: { name: 'Unkown', RoomsConfig: { value: 'true' } }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns :bad_request for invalid params' do
+      meeting_option = create(:meeting_option, name: 'Option')
+      create(:rooms_configuration, meeting_option:, value: 'optional', provider: 'greenlight')
+
+      put :update, params: { name: 'Option', NotRoomsConfig: { not_value: 'true' } }
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it 'returns :bad_request for failed updates' do
+      meeting_option = create(:meeting_option, name: 'Option')
+      create(:rooms_configuration, meeting_option:, value: 'optional', provider: 'greenlight')
+
+      put :update, params: { name: 'Option', RoomsConfig: { value: 'invalid' } }
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end

--- a/spec/controllers/rooms_configurations_controller_spec.rb
+++ b/spec/controllers/rooms_configurations_controller_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::RoomsConfigurationsController, type: :controller do
+  before { request.headers['ACCEPT'] = 'application/json' }
+
+  describe 'rooms_configurations#index' do
+    it 'returns a hash of rooms configurations :name => :value' do
+      meeting_options = [
+        create(:meeting_option, name: 'TRUE'), create(:meeting_option, name: 'FALSE'), create(:meeting_option, name: 'OPTIONAL')
+      ]
+
+      create(:rooms_configuration, meeting_option: meeting_options[0], value: 'true', provider: 'greenlight')
+      create(:rooms_configuration, meeting_option: meeting_options[1], value: 'false', provider: 'greenlight')
+      create(:rooms_configuration, meeting_option: meeting_options[2], value: 'optional', provider: 'greenlight')
+
+      get :index
+
+      expect(JSON.parse(response.body)['data']).to eq({
+                                                        'TRUE' => 'true',
+                                                        'FALSE' => 'false',
+                                                        'OPTIONAL' => 'optional'
+                                                      })
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users with the right set of privileges to configure rooms settings.

This PR completes adds the `Admin::RoomsConfiguration#update` and `RoomsConfiguration#index` APIs.

### User story [Rooms Configuration]:
---
0. A user with the right set of permissions signs in.
1. User navigates to the Manage site settings page in administration panel.
2. User selects the Rooms Configuration tab.
3. User can edit all available rooms settings (force enabling or disabling, making it optional).
5. User can edit those settings while having adequate feedbacks from the client app.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
