### PR TITLE
Role mapping 2: Extended `UsersController#create` API and Added `UserCreator` svc.

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -18,10 +18,7 @@ module Api
         # TODO: amir - ensure accessibility for unauthenticated requests only.
         params[:user][:language] = I18n.default_locale if params[:user][:language].blank?
 
-        user = User.new({
-          provider: 'greenlight',
-          role: Role.find_by(name: 'User') # TODO: - Ahmad: Move to service
-        }.merge(user_params)) # TMP fix for presence validation of :provider
+        user = UserCreator.new(user_params:, provider: 'greenlight').call
 
         # TODO: Add proper error logging for non-verified token hcaptcha
         return render_error errors: user.errors.to_a if hcaptcha_enabled? && !verify_hcaptcha(response: params[:token])

--- a/app/services/user_creator.rb
+++ b/app/services/user_creator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class UserCreator
+  def initialize(user_params:, provider:)
+    @user_params = user_params
+    @provider = provider
+    @roles_mappers = SettingGetter.new(setting_name: 'RoleMapping', provider:).call
+  end
+
+  def call
+    role = infer_role_from_email(@user_params[:email])
+
+    User.new({
+      provider: @provider,
+      role:
+    }.merge(@user_params))
+  end
+
+  private
+
+  def infer_role_from_email(email)
+    matched_rule = if @roles_mappers
+                     rules = @roles_mappers.split(',').map { |rule| rule.split('=') }
+
+                     rules.find { |rule| email.ends_with? rule.second if rule.second }
+                   end
+
+    Role.find_by(name: matched_rule&.first) || Role.find_by(name: 'User')
+  end
+end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -70,5 +70,29 @@ RSpec.describe Api::V1::UsersController, type: :request do
         expect(JSON.parse(response.body)['errors']).to be_present
       end
     end
+
+    context 'Role mapping' do
+      before do
+        setting = create(:setting, name: 'RoleMapping')
+        create(:site_setting, setting:, provider: 'greenlight', value: 'Decepticons=@decepticons.cybertron,Autobots=autobots.cybertron')
+      end
+
+      it 'Creates a User and assign a role if a rule matches their email' do
+        autobots = create(:role, name: 'Autobots')
+        user_params = {
+          name: 'Optimus Prime',
+          email: 'optimus@autobots.cybertron',
+          password: 'Autobots',
+          password_confirmation: 'Autobots',
+          language: 'teletraan'
+        }
+
+        expect { post api_v1_users_path, params: { user: user_params }, headers: }.to change(User, :count).from(0).to(1)
+        expect(User.take.role).to eq(autobots)
+        expect(response.content_type).to eq('application/json; charset=utf-8')
+        expect(response).to have_http_status(:created)
+        expect(JSON.parse(response.body)['errors']).to be_nil
+      end
+    end
   end
 end

--- a/spec/services/user_creator_spec.rb
+++ b/spec/services/user_creator_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UserCreator, type: :service do
+  describe '#call' do
+    let!(:users) { create(:role, name: 'User') }
+
+    before do
+      setting = create(:setting, name: 'RoleMapping')
+      create(:site_setting, setting:, provider: 'greenlight', value: 'Decepticons=@decepticons.cybertron,Autobots=autobots.cybertron')
+    end
+
+    it 'creates a user with the role matching a rule if role found' do
+      decepticons = create(:role, name: 'Decepticons')
+      user_params = {
+        name: 'Megatron',
+        email: 'megatron@decepticons.cybertron',
+        password: 'Decepticons',
+        password_confirmation: 'Decepticons',
+        language: 'teletraan'
+      }
+      res = described_class.new(user_params:, provider: 'greenlight').call
+
+      expect(res).to be_instance_of(User)
+      expect(res).not_to be_persisted
+      expect(res.name).to eq(user_params[:name])
+      expect(res.email).to eq(user_params[:email])
+      expect(res.language).to eq(user_params[:language])
+      expect(res.authenticate(user_params[:password])).to be_truthy
+      expect(res.role).to eq(decepticons)
+    end
+
+    it 'creates user with the \'User\' role if there is no matching rule' do
+      user_params = {
+        name: 'Megatron Prime',
+        email: 'mega-prime@auto-decepticons.cybertron',
+        password: 'Cybertron',
+        password_confirmation: 'Cybertron',
+        language: 'teletraan'
+      }
+      res = described_class.new(user_params:, provider: 'greenlight').call
+
+      expect(res).to be_instance_of(User)
+      expect(res).not_to be_persisted
+      expect(res.name).to eq(user_params[:name])
+      expect(res.email).to eq(user_params[:email])
+      expect(res.language).to eq(user_params[:language])
+      expect(res.authenticate(user_params[:password])).to be_truthy
+      expect(res.role).to eq(users)
+    end
+
+    it 'creates a user with the \'User\' role if role not found' do
+      user_params = {
+        name: 'Optimus Prime',
+        email: 'optimus@autobots.cybertron',
+        password: 'Autobots',
+        password_confirmation: 'Autobots',
+        language: 'teletraan'
+      }
+      res = described_class.new(user_params:, provider: 'greenlight').call
+
+      expect(res).to be_instance_of(User)
+      expect(res).not_to be_persisted
+      expect(res.name).to eq(user_params[:name])
+      expect(res.email).to eq(user_params[:email])
+      expect(res.language).to eq(user_params[:language])
+      expect(res.authenticate(user_params[:password])).to be_truthy
+      expect(res.role).to eq(users)
+    end
+  end
+end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable users with the right set of privileges to edit roles mappers.

This PR completes **2.** 
--
~~0. Add Registration UI.~~
~~1. Integrate with the `Admin::SiteSettings` APIs.~~
~~2.Extend `UsersController#create` to infer the user role.~~
### User story [Role Mapping]:
---
0. A user with the right set of permissions signs in.
1. User navigates to the Manage site settings page in administration panel.
2. User selects the Registration tab.
3. User can edit the list of roles and their corresponding email suffixes.
5. User can update the list and have adequate feedbacks from the client app.
Note: There's no checks for the list content, it's a string comma speparated list
that can be empty or filled.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/29759616/180064699-e6fd4417-41f3-4427-b28d-3663423f39b1.png)
