### PR TITLE
Brand Theming: basic UI + endpoints hookup

### DIFF
--- a/app/javascript/App.jsx
+++ b/app/javascript/App.jsx
@@ -1,14 +1,21 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Container } from 'react-bootstrap';
 import { Outlet } from 'react-router-dom';
 import { Toaster } from 'react-hot-toast';
 import Header from './components/shared/Header';
 import { useAuth } from './contexts/auth/AuthProvider';
 import Footer from './components/shared/Footer';
+import useSiteSettings from './hooks/queries/admin/site_settings/useSiteSettings';
 
 export default function App() {
   const currentUser = useAuth();
   const containerHeight = currentUser?.signed_in ? 'full-height' : 'h-100';
+  const { data: siteSettings } = useSiteSettings();
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--brand-color', siteSettings?.PrimaryColor);
+  }, [siteSettings]);
+
   return (
     <>
       {currentUser?.signed_in && <Header /> }

--- a/app/javascript/App.jsx
+++ b/app/javascript/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Container } from 'react-bootstrap';
 import { Outlet } from 'react-router-dom';
 import { Toaster } from 'react-hot-toast';
@@ -12,9 +12,7 @@ export default function App() {
   const containerHeight = currentUser?.signed_in ? 'full-height' : 'h-100';
   const { data: siteSettings } = useSiteSettings();
 
-  useEffect(() => {
-    document.documentElement.style.setProperty('--brand-color', siteSettings?.PrimaryColor);
-  }, [siteSettings]);
+  document.documentElement.style.setProperty('--brand-color', siteSettings?.PrimaryColor);
 
   return (
     <>

--- a/app/javascript/components/admin/site_settings/Appearance.jsx
+++ b/app/javascript/components/admin/site_settings/Appearance.jsx
@@ -1,7 +1,36 @@
+/* eslint-disable react/jsx-props-no-spreading */
+
 import React from 'react';
+import { Form } from 'react-bootstrap';
+import Button from 'react-bootstrap/Button';
+import { useForm } from 'react-hook-form';
+import useUpdateSiteSetting
+  from '../../../hooks/mutations/admins/site_settings/useUpdateSiteSetting';
+import useSiteSettings from '../../../hooks/queries/admin/site_settings/useSiteSettings';
 
 export default function Appearance() {
+  const { register, handleSubmit } = useForm();
+  const updateSiteSetting = useUpdateSiteSetting('PrimaryColor');
+  const { data: siteSettings } = useSiteSettings();
+
   return (
-    <p>Appearance</p>
+    <>
+      <h6>Primary Color</h6>
+      <Form onSubmit={handleSubmit(updateSiteSetting.mutate)}>
+        <Form.Group className="mb-3">
+          <Form.Control
+            type="color"
+            id="brandColor"
+            defaultValue={siteSettings?.PrimaryColor}
+            title="Choose your color"
+            {...register('value')}
+          />
+        </Form.Group>
+
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
+      </Form>
+    </>
   );
 }


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
User can now set a Brand/Primary color.
Basic form using Bootstrap color picker for now.

This PR just shows off the mechanic to propagate the Brand/Primary color value to the application.

Please use #3692 instead to test the feature.

The line below basically does all the work for the theming.
`document.documentElement.style.setProperty('--brand-color', siteSettings?.PrimaryColor);`

It adds styling to the root of the app, at `<html> ... </html>`
I'm not sure how it works - I assume the whole DOM gets re-loaded if the value of --brand-color changes?
Some say it goes against the principle of React to act on the DOM itself, some says it makes sense. 
So far, it's working pretty good IMO.
The other solution would be to add inline styling everywhere the brand color is needed.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

For the full experience, you should test with #3692.

1. Choose a new color and click on submit.
2. Go to http://localhost:3000/api/v1/admin/site_settings and make sure the PrimaryColor value has changed accordingly. 