### PR TITLE
Room Settings 1: Added `RoomSettingsGetter` service.

### DIFF
--- a/app/services/room_settings_getter.rb
+++ b/app/services/room_settings_getter.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class RoomSettingsGetter
+  # Special options are meeting options that have different values other than `true|false` to represent postives and negatives.
+  # The `special_options` hash is a registry that keeps hold of all of the special options used in GL3 along with their postive and negative values.
+  # When adding a new special option just register it in this Hash respecting the fallowing format:
+  # Hash(`<option_name> => {'true' => <Postive>, 'false' => <Negative>})`
+  SPECIAL_OPTIONS = { 'guestPolicy' => { 'true' => 'ASK_MODERATOR', 'false' => 'ALWAYS_ACCEPT' } }.freeze
+
+  def initialize(room_id:, provider:, only_bbb_options: false)
+    @room_id = room_id
+    @only_bbb_options = only_bbb_options
+    # Fetching only rooms configs that are not optional to overwrite the settings values.
+    @rooms_configs = MeetingOption.joins(:rooms_configurations)
+                                  .where(rooms_configurations: { provider: })
+                                  .where.not(rooms_configurations: { value: 'optional' })
+                                  .pluck(:name, :value)
+                                  .to_h
+  end
+
+  def call
+    room_settings = MeetingOption.joins(:room_meeting_options).where(room_meeting_options: { room_id: @room_id })
+    room_settings = room_settings.where.not('name ILIKE :prefix', prefix: 'gl%') if @only_bbb_options
+    room_settings = room_settings.pluck(:name, :value).to_h
+
+    room_settings.merge!(@rooms_configs) # Merging rooms settings with its none optional configurations prioritizing forced configs over settings.
+    room_settings_special_options = SPECIAL_OPTIONS.slice(*room_settings.keys) # Extracting the room settings special options to minimize iterations.
+
+    # Configs are enum of ['true', 'false', 'optional'], after merging none optional settings with their configs only the room
+    # special options have to map positive/negative values.
+    room_settings_special_options.each_key do |name|
+      config = room_settings[name]
+      room_settings[name] = SPECIAL_OPTIONS[name][config] if %w[true false].include? config # Config values are expected to be 'true'|'false'
+    end
+
+    room_settings
+  end
+end

--- a/spec/services/room_settings_getter_spec.rb
+++ b/spec/services/room_settings_getter_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RoomSettingsGetter, type: :service do
+  describe '#call' do
+    context 'Normal room settings' do
+      it 'returns a Hash("name" => "value") of room settings according to the configurations' do
+        room = create(:room)
+        setting1 = create(:meeting_option, name: 'glSetting1')
+        setting2 = create(:meeting_option, name: 'glSetting2')
+        setting3 = create(:meeting_option, name: 'setting3')
+
+        create(:room_meeting_option, room:, meeting_option: setting1, value: 'value1')
+        create(:room_meeting_option, room:, meeting_option: setting2, value: 'value2')
+        create(:room_meeting_option, room:, meeting_option: setting3, value: 'value3')
+
+        create(:rooms_configuration, meeting_option: setting1, provider: 'greenlight', value: 'true')
+        create(:rooms_configuration, meeting_option: setting2, provider: 'greenlight', value: 'optional')
+        create(:rooms_configuration, meeting_option: setting3, provider: 'greenlight', value: 'false')
+
+        res = described_class.new(room_id: room.id, provider: 'greenlight').call
+
+        expect(res).to eq({
+                            'glSetting1' => 'true',
+                            'glSetting2' => 'value2',
+                            'setting3' => 'false'
+                          })
+      end
+    end
+
+    context 'special room settings' do
+      it 'returns a Hash("name" => "value") of room settings according to the configurations' do
+        stub_const('RoomSettingsGetter::SPECIAL_OPTIONS', {
+                     'glSpecial!' => { 'true' => 'SPECIAL_FORCE', 'false' => 'NOT_SPECIAL' },
+                     'glSpecialToo!!' => { 'true' => 'SPECIAL_FORCE', 'false' => 'NOT_SPECIAL' },
+                     'KingOfSpecials!!!' => { 'true' => 'SPECIAL_FORCE', 'false' => 'NOT_SPECIAL' }
+                   })
+        room = create(:room)
+        setting1 = create(:meeting_option, name: 'glSpecial!')
+        setting2 = create(:meeting_option, name: 'glSpecialToo!!')
+        setting3 = create(:meeting_option, name: 'KingOfSpecials!!!')
+
+        create(:room_meeting_option, room:, meeting_option: setting1, value: 'SPECIAL')
+        create(:room_meeting_option, room:, meeting_option: setting2, value: 'SPECIAL')
+        create(:room_meeting_option, room:, meeting_option: setting3, value: 'SPECIAL')
+
+        create(:rooms_configuration, meeting_option: setting1, provider: 'greenlight', value: 'true')
+        create(:rooms_configuration, meeting_option: setting2, provider: 'greenlight', value: 'optional')
+        create(:rooms_configuration, meeting_option: setting3, provider: 'greenlight', value: 'false')
+
+        res = described_class.new(room_id: room.id, provider: 'greenlight').call
+
+        expect(res).to eq({
+                            'glSpecial!' => 'SPECIAL_FORCE',
+                            'glSpecialToo!!' => 'SPECIAL',
+                            'KingOfSpecials!!!' => 'NOT_SPECIAL'
+                          })
+      end
+    end
+
+    context 'bbb options only' do
+      it 'returns a filtered Hash("name" => "value") of room settings that does not start with a :prefix' do
+        room = create(:room)
+        setting1 = create(:meeting_option, name: 'glSetting')
+        setting2 = create(:meeting_option, name: 'GlGLSetting')
+        setting3 = create(:meeting_option, name: 'YourOnlyBBBSetting')
+
+        create(:room_meeting_option, room:, meeting_option: setting1, value: 'GL')
+        create(:room_meeting_option, room:, meeting_option: setting2, value: 'GL')
+        create(:room_meeting_option, room:, meeting_option: setting3, value: 'BBB')
+
+        create(:rooms_configuration, meeting_option: setting1, provider: 'greenlight', value: 'optional')
+        create(:rooms_configuration, meeting_option: setting2, provider: 'greenlight', value: 'optional')
+        create(:rooms_configuration, meeting_option: setting3, provider: 'greenlight', value: 'optional')
+
+        res = described_class.new(room_id: room.id, provider: 'greenlight', only_bbb_options: true).call
+
+        expect(res).to eq({
+                            'YourOnlyBBBSetting' => 'BBB'
+                          })
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Synchronize room settings with rooms configurations.

This PR completes **1.** 
--
~~1. Create `RoomSettingsGetter` service that can take a room and return its settings as a `Hash: :name => :value` making sense of each setting and its config.~~
2. Integrate the service in `RoomSettingsController#show`.
3. Extend the `RoomSettings` and `RoomSettingsRow` UIs.


### User story [Room Settings show]:
---
1. A user authenticates.
2. A user creates and accesses a room and its settings.

[If the setting config is "true" for the room setting]:
4. User will have the setting enabled and user cannot disable it.
>NOTE: The API will set the setting value as if it was enabled, the front end only will disable the setting for editing but will not change its value.

[If the setting config is "false" for the room setting]:
3. User will not see the setting.
>NOTE: The frontend will not mount the setting component to the DOM.

[If the setting config is "optional" for the room setting]:
3. User will have their setting with its registered status 'enabled|disbaled'.
5. User can alter the status of the setting and have proper feedbacks.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
