### PR TITLE
Room Settings 2: Integrated `RoomSettingsGetter` svc in `RoomSettingsController#show` API.

### DIFF
--- a/app/controllers/api/v1/room_settings_controller.rb
+++ b/app/controllers/api/v1/room_settings_controller.rb
@@ -7,11 +7,9 @@ module Api
 
       # GET /api/v1/room_settings/:friendly_id
       def show
-        options = MeetingOption.joins(:room_meeting_options)
-                               .where(room_meeting_options: { room_id: @room.id })
-                               .select(:name, :value)
+        options = RoomSettingsGetter.new(room_id: @room.id, provider: 'greenlight').call
 
-        render_data data: options, serializer: RoomSettingsSerializer, status: :ok
+        render_data data: options, status: :ok
       end
 
       # PATCH /api/v1/room_settings/:friendly_id

--- a/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
+++ b/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
@@ -17,7 +17,7 @@ export default function RoomSettings() {
   const mutationWrapper = (args) => useDeleteRoom({ friendlyId, ...args });
 
   const checkedValue = (settingId) => {
-    const { value } = roomSetting.data.find((setting) => setting.name === settingId);
+    const value = roomSetting.data[settingId];
 
     if (value === 'true' || value === 'ASK_MODERATOR') {
       return true;

--- a/spec/controllers/room_settings_controller_spec.rb
+++ b/spec/controllers/room_settings_controller_spec.rb
@@ -12,8 +12,29 @@ RSpec.describe Api::V1::RoomSettingsController, type: :controller do
   end
 
   describe '#show' do
-    skip 'TODO' do
-      # TODO
+    let(:room_setting_getter_service) { instance_double(RoomSettingsGetter) }
+
+    before do
+      allow(RoomSettingsGetter).to receive(:new).and_return(room_setting_getter_service)
+      allow(room_setting_getter_service).to receive(:call).and_return({ 'setting' => 'value' })
+    end
+
+    it 'uses "RoomSettingGetter" service and render its returned value' do
+      expect(RoomSettingsGetter).to receive(:new).with(room_id: room.id, provider: 'greenlight')
+      expect(room_setting_getter_service).to receive(:call)
+
+      get :show, params: { friendly_id: room.friendly_id }
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['data']).to eq({ 'setting' => 'value' })
+    end
+
+    context 'AuthN' do
+      it 'returns :unauthorized response for unauthenticated requests' do
+        session[:user_id] = nil
+
+        get :show, params: { friendly_id: room.friendly_id }
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Synchronize room settings with rooms configurations.

This PR completes **2.** 
--
~~1. Create `RoomSettingsGetter` service that can take a room and return its settings as a `Hash: :name => :value` making sense of each setting and its config.~~
~~2. Integrate the service in `RoomSettingsController#show`.~~
3. Extend the `RoomSettings` and `RoomSettingsRow` UIs.


### User story [Room Settings show]:
---
1. A user authenticates.
2. A user creates and accesses a room and its settings.

[If the setting config is "true" for the room setting]:
4. User will have the setting enabled and user cannot disable it.
>NOTE: The API will set the setting value as if it was enabled, the front end only will disable the setting for editing but will not change its value.

[If the setting config is "false" for the room setting]:
3. User will not see the setting.
>NOTE: The frontend will not mount the setting component to the DOM.

[If the setting config is "optional" for the room setting]:
3. User will have their setting with its registered status 'enabled|disbaled'.
5. User can alter the status of the setting and have proper feedbacks.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
