### PR TITLE
Meeting starter: Integrated `RoomSettingsGetter` svc in `MeetingStarter`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,9 @@ Metrics/ClassLength:
 Metrics/AbcSize:
   Max: 65
 
+Metrics/ParameterLists:
+  CountKeywordArgs: false
+
 RSpec/AnyInstance:
   Enabled: false
 

--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -17,7 +17,8 @@ module Api
           logout_url: request.referer,
           presentation_url:,
           meeting_ended: meeting_ended_url,
-          recording_ready: recording_ready_url
+          recording_ready: recording_ready_url,
+          provider: 'greenlight'
         ).call
 
         render_data data: BigBlueButtonApi.new.join_meeting(room: @room, name: current_user.name, role: 'Moderator'), status: :created

--- a/app/services/meeting_starter.rb
+++ b/app/services/meeting_starter.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
 class MeetingStarter
-  def initialize(room:, logout_url:, presentation_url:, meeting_ended:, recording_ready:)
+  def initialize(room:, logout_url:, presentation_url:, meeting_ended:, recording_ready:, provider:)
     @room = room
     @logout_url = logout_url
     @presentation_url = presentation_url
     @meeting_ended = meeting_ended
     @recording_ready = recording_ready
+    @provider = provider
   end
 
   def call
     # TODO: amir - Check the legitimately of the action.
-    options = MeetingOption.bbb_options(room_id: @room.id).to_h
+    options = RoomSettingsGetter.new(room_id: @room.id, provider: @provider, only_bbb_options: true).call
 
     options.merge!(computed_options)
 

--- a/spec/controllers/meetings_controller_spec.rb
+++ b/spec/controllers/meetings_controller_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Api::V1::MeetingsController, type: :controller do
         logout_url: logout,
         presentation_url:,
         meeting_ended: meeting_ended_url,
-        recording_ready: recording_ready_url
+        recording_ready: recording_ready_url,
+        provider: 'greenlight'
       )
 
       post :start, params: { friendly_id: room.friendly_id }
@@ -50,7 +51,8 @@ RSpec.describe Api::V1::MeetingsController, type: :controller do
         logout_url: logout,
         presentation_url:,
         meeting_ended: meeting_ended_url,
-        recording_ready: recording_ready_url
+        recording_ready: recording_ready_url,
+        provider: 'greenlight'
       )
 
       post :start, params: { friendly_id: room.friendly_id }


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Synchronize room settings with rooms configurations.

This PR completes **2.** 
--
~~1. Create `RoomSettingsGetter` service that can take a room and return its settings as a `Hash: :name => :value` making sense of each setting and its config.~~
~~2. Integrate the service in `MeetingStarter` service.~~


### User story [Meeting start]:
---
1. A user authenticates and creates a room.
2. user starts a meeting on  the room.
3. user will have a BBB meeting configured according to the room settings.

>NOTE:The API will start a BBB meeting where all disabled options will be falsey, force enabled options will be truthy and optional options will have what the user has configured.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
