### PR TITLE
Room Settings update 1: Added `MeetingOption::get_config_value`.

### DIFF
--- a/app/models/meeting_option.rb
+++ b/app/models/meeting_option.rb
@@ -14,12 +14,21 @@ class MeetingOption < ApplicationRecord
       .pluck(:name, :value)
   end
 
-  def self.get_value(name:, room_id:)
+  def self.get_setting_value(name:, room_id:)
     joins(:room_meeting_options)
       .select(:value)
       .find_by(
         name:,
         room_meeting_options: { room_id: }
+      )
+  end
+
+  def self.get_config_value(name:, provider:)
+    joins(:rooms_configurations)
+      .select(:value)
+      .find_by(
+        name:,
+        rooms_configurations: { provider: }
       )
   end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -27,7 +27,7 @@ class Room < ApplicationRecord
   end
 
   def anyone_joins_as_moderator?
-    MeetingOption.get_value(name: 'glAnyoneJoinAsModerator', room_id: id)&.value == 'true'
+    MeetingOption.get_setting_value(name: 'glAnyoneJoinAsModerator', room_id: id)&.value == 'true'
   end
 
   private

--- a/spec/models/meeting_option_spec.rb
+++ b/spec/models/meeting_option_spec.rb
@@ -9,44 +9,70 @@ RSpec.describe MeetingOption, type: :model do
     it { is_expected.to validate_uniqueness_of(:name) }
   end
 
-  describe '#bbb_options' do
-    it 'returns all non-greenlight options' do
-      room = create(:room)
-      setting1 = create(:meeting_option, name: 'glSetting1')
-      setting2 = create(:meeting_option, name: 'glSetting2')
-      setting3 = create(:meeting_option, name: 'setting1')
-      setting4 = create(:meeting_option, name: 'setting2')
+  describe 'classs methods' do
+    describe '#bbb_options' do
+      it 'returns all non-greenlight options' do
+        room = create(:room)
+        setting1 = create(:meeting_option, name: 'glSetting1')
+        setting2 = create(:meeting_option, name: 'glSetting2')
+        setting3 = create(:meeting_option, name: 'setting1')
+        setting4 = create(:meeting_option, name: 'setting2')
 
-      create(:room_meeting_option, room:, meeting_option: setting1)
-      create(:room_meeting_option, room:, meeting_option: setting2)
-      room_option1 = create(:room_meeting_option, room:, meeting_option: setting3, value: 'value1')
-      room_option2 = create(:room_meeting_option, room:, meeting_option: setting4, value: 'value2')
+        create(:room_meeting_option, room:, meeting_option: setting1)
+        create(:room_meeting_option, room:, meeting_option: setting2)
+        room_option1 = create(:room_meeting_option, room:, meeting_option: setting3, value: 'value1')
+        room_option2 = create(:room_meeting_option, room:, meeting_option: setting4, value: 'value2')
 
-      expect(
-        described_class.bbb_options(room_id: room.id)
-      ).to eq([
-                [setting3.name, room_option1.value],
-                [setting4.name, room_option2.value]
-              ])
-    end
-  end
-
-  describe '#get_value' do
-    it 'returns the room meeting option for a room by name' do
-      room = create(:room)
-
-      meeting_option1 = create(:meeting_option, name: 'setting')
-      create(:room_meeting_option, room:, meeting_option: meeting_option1, value: 'value1')
-
-      room_meeting_option = described_class.get_value(name: 'setting', room_id: room.id)
-
-      expect(room_meeting_option.value).to eq('value1')
+        expect(
+          described_class.bbb_options(room_id: room.id)
+        ).to eq([
+                  [setting3.name, room_option1.value],
+                  [setting4.name, room_option2.value]
+                ])
+      end
     end
 
-    it 'returns nil for unfound room meeting option' do
-      expect(
-        described_class.get_value(name: 'notASettingTrustMe', room_id: 'YouAlreadyTrustedMe')
-      ).to be_nil
+    describe '#get_setting_value' do
+      context 'existing setting' do
+        it 'returns the room meeting option value' do
+          room = create(:room)
+
+          meeting_option1 = create(:meeting_option, name: 'setting')
+          create(:room_meeting_option, room:, meeting_option: meeting_option1, value: 'value1')
+
+          room_meeting_option = described_class.get_setting_value(name: 'setting', room_id: room.id)
+
+          expect(room_meeting_option.value).to eq('value1')
+        end
+      end
+
+      context 'inexisting setting' do
+        it 'returns nil' do
+          expect(
+            described_class.get_setting_value(name: 'notASettingTrustMe', room_id: 'YouAlreadyTrustedMe')
+          ).to be_nil
+        end
+      end
+    end
+
+    describe '#get_config_value' do
+      context 'existing configuration' do
+        it 'returns the rooms configuration value' do
+          meeting_option = create(:meeting_option, name: 'setting')
+          create(:rooms_configuration, meeting_option:, provider: 'greenlight', value: 'optional')
+
+          rooms_config = described_class.get_config_value(name: 'setting', provider: 'greenlight')
+          expect(rooms_config.value).to eq('optional')
+        end
+      end
+
+      context 'inexisting configuration' do
+        it 'returns nil' do
+          expect(
+            described_class.get_config_value(name: 'notAConfigTrustMe', provider: 'YouShould\'ve')
+          ).to be_nil
+        end
+      end
     end
   end
 end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -32,23 +32,23 @@ RSpec.describe Room, type: :model do
   describe '#anyone_joins_as_moderator?' do
     let!(:room) { create(:room) }
 
-    it 'calls MeetingOption::get_value and returns true if "glAnyoneJoinAsModerator" is set to "true"' do
-      allow(MeetingOption).to receive(:get_value).and_return(instance_double(RoomMeetingOption, value: 'true'))
-      expect(MeetingOption).to receive(:get_value).with(name: 'glAnyoneJoinAsModerator', room_id: room.id)
+    it 'calls MeetingOption::get_setting_value and returns true if "glAnyoneJoinAsModerator" is set to "true"' do
+      allow(MeetingOption).to receive(:get_setting_value).and_return(instance_double(RoomMeetingOption, value: 'true'))
+      expect(MeetingOption).to receive(:get_setting_value).with(name: 'glAnyoneJoinAsModerator', room_id: room.id)
 
       expect(room).to be_anyone_joins_as_moderator
     end
 
-    it 'calls MeetingOption::get_value and returns false if "glAnyoneJoinAsModerator" is NOT set to "true"' do
-      allow(MeetingOption).to receive(:get_value).and_return(instance_double(RoomMeetingOption, value: 'false'))
-      expect(MeetingOption).to receive(:get_value).with(name: 'glAnyoneJoinAsModerator', room_id: room.id)
+    it 'calls MeetingOption::get_setting_value and returns false if "glAnyoneJoinAsModerator" is NOT set to "true"' do
+      allow(MeetingOption).to receive(:get_setting_value).and_return(instance_double(RoomMeetingOption, value: 'false'))
+      expect(MeetingOption).to receive(:get_setting_value).with(name: 'glAnyoneJoinAsModerator', room_id: room.id)
 
       expect(room).not_to be_anyone_joins_as_moderator
     end
 
-    it 'calls MeetingOption::get_value and returns false if "glAnyoneJoinAsModerator" is NOT set' do
-      allow(MeetingOption).to receive(:get_value).and_return(nil)
-      expect(MeetingOption).to receive(:get_value).with(name: 'glAnyoneJoinAsModerator', room_id: room.id)
+    it 'calls MeetingOption::get_setting_value and returns false if "glAnyoneJoinAsModerator" is NOT set' do
+      allow(MeetingOption).to receive(:get_setting_value).and_return(nil)
+      expect(MeetingOption).to receive(:get_setting_value).with(name: 'glAnyoneJoinAsModerator', room_id: room.id)
 
       expect(room).not_to be_anyone_joins_as_moderator
     end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Synchronize room settings with rooms configurations.

This PR completes **1.** 
--
~~1. Create `RoomsConfigGetter` service that can take a setting name and return its value.~~
2. Integrate the service in `RoomSettingsController#update` API.


### User story [Room setting update]:
---
1. A user authenticates.
2. A user creates a Room and access it.
[If the setting config is "optional" for the room setting]:
3. user can edit the setting status and have proper feedbacks.
[If the setting config is **not** "optional" for the room setting]:
3. user should not be able to edit the setting (by not seing the setting if it's disabled or by having the setting edit disabled when it's force enabled).

>NOTE: update API calls and access codes removal for a setting that is not configured as optional should fail with adequate error.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
