### PR TITLE
Room Settings update 2: Integrated `MeetingOption::get_config_value` in `RoomSettingsController#update`.

### DIFF
--- a/app/controllers/api/v1/room_settings_controller.rb
+++ b/app/controllers/api/v1/room_settings_controller.rb
@@ -16,12 +16,13 @@ module Api
 
       # PATCH /api/v1/room_settings/:friendly_id
       def update
-        RoomMeetingOption
-          .includes(:meeting_option)
-          .joins(:meeting_option)
-          .where(room_id: @room.id)
-          .where(meeting_option: { name: room_setting_params[:settingName] })
-          .update(value: room_setting_params[:settingValue].to_s)
+        config = MeetingOption.get_config_value(name: room_setting_params[:settingName], provider: 'greenlight')&.value
+
+        return render_error status: :forbidden unless config == 'optional'
+
+        option = @room.get_setting(name: room_setting_params[:settingName])
+
+        return render_error status: :bad_request unless option&.update(value: room_setting_params[:settingValue].to_s)
 
         render_data status: :ok
       end

--- a/spec/controllers/room_settings_controller_spec.rb
+++ b/spec/controllers/room_settings_controller_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::RoomSettingsController, type: :controller do
+  let(:user) { create(:user) }
+  let(:room) { create(:room, user:) }
+
+  before do
+    request.headers['ACCEPT'] = 'application/json'
+    session[:user_id] = user.id
+  end
+
+  describe '#show' do
+    skip 'TODO' do
+      # TODO
+    end
+  end
+
+  describe '#update' do
+    it 'uses MeetingOption::get_config_value and updates the setting if its config is "optional"' do
+      expect(MeetingOption).to receive(:get_config_value).with(name: 'setting', provider: 'greenlight').and_call_original
+
+      meeting_option = create(:meeting_option, name: 'setting')
+      create(:rooms_configuration, meeting_option:, provider: 'greenlight', value: 'optional')
+
+      put :update, params: { room_setting: { settingName: 'setting', settingValue: 'notOptionalAnymore' }, friendly_id: room.friendly_id }
+      expect(response).to have_http_status(:ok)
+      expect(room.room_meeting_options.take.value).to eq('notOptionalAnymore')
+    end
+
+    context 'AuthZ' do
+      it 'returns :forbidden if the setting config is "true"' do
+        meeting_option = create(:meeting_option, name: 'setting')
+        create(:rooms_configuration, meeting_option:, provider: 'greenlight', value: 'true')
+
+        put :update, params: { room_setting: { settingName: 'setting', settingValue: 'notTrueAnymore' }, friendly_id: room.friendly_id }
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'returns :forbidden if the setting config is "false"' do
+        meeting_option = create(:meeting_option, name: 'setting')
+        create(:rooms_configuration, meeting_option:, provider: 'greenlight', value: 'false')
+
+        put :update, params: { room_setting: { settingName: 'setting', settingValue: 'notFalseAnymore' }, friendly_id: room.friendly_id }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'AuthN' do
+      it 'returns :unauthorized response for unauthenticated requests' do
+        session[:user_id] = nil
+
+        put :update, params: { friendly_id: room.friendly_id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    it 'returns :forbidden for unfound config' do
+      put :update, params: { room_setting: { settingName: '404', settingValue: 'valueOfWhat?' }, friendly_id: room.friendly_id }
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns :bad_request for invalid params' do
+      put :update, params: { not_room_setting: { notSettingName: 'setting', notSettingValue: 'someValue' }, friendly_id: room.friendly_id }
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it 'returns :not_found for unfound room' do
+      put :update, params: { room_setting: { settingName: 'setting', settingValue: 'someValue' }, friendly_id: '404' }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Synchronize room settings with rooms configurations.

This PR completes **2.** 
--
~~1. Create `RoomsConfigGetter` service that can take a setting name and return its value.~~
~~2. Integrate the service in `RoomSettingsController#update` API.~~


### User story [Room setting update]:
---
1. A user authenticates.
2. A user creates a Room and access it.
[If the setting config is "optional" for the room setting]:
3. user can edit the setting status and have proper feedbacks.
[If the setting config is **not** "optional" for the room setting]:
3. user should not be able to edit the setting (by not seing the setting if it's disabled or by having the setting edit disabled when it's force enabled).

>NOTE: update API calls and access codes removal for a setting that is not configured as optional should fail with adequate error.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
