### PR TITLE
Meeting starter cleanup

### DIFF
--- a/app/models/meeting_option.rb
+++ b/app/models/meeting_option.rb
@@ -6,14 +6,6 @@ class MeetingOption < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
 
-  def self.bbb_options(room_id:)
-    MeetingOption
-      .joins(:room_meeting_options)
-      .where.not('name LIKE :prefix', prefix: 'gl%') # ignore gl settings
-      .where(room_meeting_options: { room_id: })
-      .pluck(:name, :value)
-  end
-
   def self.get_setting_value(name:, room_id:)
     joins(:room_meeting_options)
       .select(:value)

--- a/spec/models/meeting_option_spec.rb
+++ b/spec/models/meeting_option_spec.rb
@@ -10,28 +10,6 @@ RSpec.describe MeetingOption, type: :model do
   end
 
   describe 'classs methods' do
-    describe '#bbb_options' do
-      it 'returns all non-greenlight options' do
-        room = create(:room)
-        setting1 = create(:meeting_option, name: 'glSetting1')
-        setting2 = create(:meeting_option, name: 'glSetting2')
-        setting3 = create(:meeting_option, name: 'setting1')
-        setting4 = create(:meeting_option, name: 'setting2')
-
-        create(:room_meeting_option, room:, meeting_option: setting1)
-        create(:room_meeting_option, room:, meeting_option: setting2)
-        room_option1 = create(:room_meeting_option, room:, meeting_option: setting3, value: 'value1')
-        room_option2 = create(:room_meeting_option, room:, meeting_option: setting4, value: 'value2')
-
-        expect(
-          described_class.bbb_options(room_id: room.id)
-        ).to eq([
-                  [setting3.name, room_option1.value],
-                  [setting4.name, room_option2.value]
-                ])
-      end
-    end
-
     describe '#get_setting_value' do
       context 'existing setting' do
         it 'returns the room meeting option value' do


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Cleaned up `MeetingOption.bbb_options` in favor of `RoomsConfigGetter` svc.

### User story [Meeting start]:
---
1. A user authenticates and creates a room.
2. user starts a meeting on  the room.
3. user will have a BBB meeting configured according to the room settings.

>NOTE:The API will start a BBB meeting where all disabled options will be falsey, force enabled options will be truthy and optional options will have what the user has configured.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
