### PR TITLE
Add Buttons to Color Picker

### DIFF
--- a/app/assets/stylesheets/admin_panel.scss
+++ b/app/assets/stylesheets/admin_panel.scss
@@ -37,6 +37,7 @@
 
 .color-picker {
   width: 200px;
+  min-height: 300px;
 
   .react-colorful__hue {
     border-radius: 0 !important;

--- a/app/javascript/components/admin/site_settings/appearance/BrandColorPopover.jsx
+++ b/app/javascript/components/admin/site_settings/appearance/BrandColorPopover.jsx
@@ -4,6 +4,7 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Button from 'react-bootstrap/Button';
 import PropTypes from 'prop-types';
 import { HexColorPicker, HexColorInput } from 'react-colorful';
+import { Stack } from 'react-bootstrap';
 import useUpdateSiteSetting
   from '../../../../hooks/mutations/admins/site_settings/useUpdateSiteSetting';
 
@@ -18,6 +19,10 @@ export default function BrandColorPopover({
     setColor(inputColor);
   };
 
+  const handleCancel = () => {
+    setColor(initialColor);
+  };
+
   return (
     <OverlayTrigger
       trigger="click"
@@ -25,10 +30,14 @@ export default function BrandColorPopover({
       rootClose
       overlay={(
         <Popover className="border-0">
-          <div className="color-picker pb-3 rounded-3 shadow-sm" onBlur={() => updateSiteSetting.mutate({ value: color })}>
+          <div className="color-picker rounded-3 shadow-sm">
             <HexColorPicker color={color} onChange={handleChange} />
             <div className="mt-3 px-3">
               <HexColorInput className="w-100 form-control" color={color} onChange={handleChange} prefixed />
+              <Stack direction="horizontal" className="mt-2 pb-2 float-end">
+                <Button variant="brand-backward" className="me-2" onClick={handleCancel}> Cancel </Button>
+                <Button variant="brand" onClick={() => updateSiteSetting.mutate({ value: color })}> Save </Button>
+              </Stack>
             </div>
           </div>
         </Popover>


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add onClick event to save the Color Picker changes instead of onBlur.
Add cancel button.

Tried to add a function to reset the Color Picker to the initial color on cancel but it's kind off glitchy - IMO it's fine like that.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/43917914/181834667-8f76103c-3890-495e-97d2-5bbfcdfb910c.png)
