### PR TITLE
Access Codes 1..4: Rectified room access codes to be a regular room setting.

### DIFF
--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -81,24 +81,28 @@ module Api
 
       # PATCH /api/v1/room_settings/:friendly_id/viewer_access_code.json
       def generate_access_code
-        case params[:bbb_role]
-        when 'Viewer'
-          @room.update!(viewer_access_code: SecureRandom.alphanumeric(6).downcase)
-        when 'Moderator'
-          @room.update!(moderator_access_code: SecureRandom.alphanumeric(6).downcase)
-        end
+        generated = case params[:bbb_role]
+                    when 'Viewer'
+                      @room.generate_viewer_access_code
+                    when 'Moderator'
+                      @room.generate_moderator_access_code
+                    end
+
+        return render_error status: :bad_request unless generated
 
         render_data status: :ok
       end
 
       # PATCH /api/v1/room_settings/:friendly_id/remove_viewer_access_code.json
       def remove_access_code
-        case params[:bbb_role]
-        when 'Viewer'
-          @room.update!(viewer_access_code: nil)
-        when 'Moderator'
-          @room.update!(moderator_access_code: nil)
-        end
+        removed = case params[:bbb_role]
+                  when 'Viewer'
+                    @room.remove_viewer_access_code
+                  when 'Moderator'
+                    @room.remove_moderator_access_code
+                  end
+
+        return render_error status: :bad_request unless removed
 
         render_data status: :ok
       end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -30,6 +30,35 @@ class Room < ApplicationRecord
     MeetingOption.get_value(name: 'glAnyoneJoinAsModerator', room_id: id)&.value == 'true'
   end
 
+  def viewer_access_code
+    get_setting(name: 'glViewerAccessCode')&.value
+  end
+
+  def moderator_access_code
+    get_setting(name: 'glModeratorAccessCode')&.value
+  end
+
+  def generate_viewer_access_code
+    get_setting(name: 'glViewerAccessCode')&.update(value: generate_code)
+  end
+
+  def remove_viewer_access_code
+    get_setting(name: 'glViewerAccessCode')&.update(value: nil)
+  end
+
+  def generate_moderator_access_code
+    get_setting(name: 'glModeratorAccessCode')&.update(value: generate_code)
+  end
+
+  def remove_moderator_access_code
+    get_setting(name: 'glModeratorAccessCode')&.update(value: nil)
+  end
+
+  def get_setting(name:)
+    room_meeting_options.joins(:meeting_option)
+                        .find_by(meeting_option: { name: })
+  end
+
   private
 
   def set_friendly_id
@@ -56,5 +85,9 @@ class Room < ApplicationRecord
     MeetingOption.all.find_each do |option|
       RoomMeetingOption.create(room: self, meeting_option: option, value: option.default_value)
     end
+  end
+
+  def generate_code
+    SecureRandom.alphanumeric(6).downcase
   end
 end

--- a/db/data/20220421162907_populate_meeting_options.rb
+++ b/db/data/20220421162907_populate_meeting_options.rb
@@ -14,7 +14,9 @@ class PopulateMeetingOptions < ActiveRecord::Migration[7.0]
       { name: 'guestPolicy', default_value: 'ALWAYS_ACCEPT' }, # ALWAYS_ACCEPT | ALWAYS_DENY | ASK_MODERATOR
       # GL only options:
       { name: 'glAnyoneCanStart', default_value: 'false' }, # true | false
-      { name: 'glAnyoneJoinAsModerator', default_value: 'false' } # true | false
+      { name: 'glAnyoneJoinAsModerator', default_value: 'false' }, # true | false
+      { name: 'glModeratorAccessCode', default_value: '' },
+      { name: 'glViewerAccessCode', default_value: '' }
     ]
   end
 

--- a/db/data/20220721131636_populate_rooms_configurations.rb
+++ b/db/data/20220721131636_populate_rooms_configurations.rb
@@ -7,7 +7,9 @@ class PopulateRoomsConfigurations < ActiveRecord::Migration[7.0]
       { meeting_option: MeetingOption.find_by(name: 'muteOnStart'), value: 'optional', provider: 'greenlight' },
       { meeting_option: MeetingOption.find_by(name: 'guestPolicy'), value: 'optional', provider: 'greenlight' },
       { meeting_option: MeetingOption.find_by(name: 'glAnyoneCanStart'), value: 'optional', provider: 'greenlight' },
-      { meeting_option: MeetingOption.find_by(name: 'glAnyoneJoinAsModerator'), value: 'optional', provider: 'greenlight' }
+      { meeting_option: MeetingOption.find_by(name: 'glAnyoneJoinAsModerator'), value: 'optional', provider: 'greenlight' },
+      { meeting_option: MeetingOption.find_by(name: 'glViewerAccessCode'), value: 'optional', provider: 'greenlight' },
+      { meeting_option: MeetingOption.find_by(name: 'glModeratorAccessCode'), value: 'optional', provider: 'greenlight' }
     ]
   end
 

--- a/db/migrate/20220613153834_add_viewer_access_code_to_rooms.rb
+++ b/db/migrate/20220613153834_add_viewer_access_code_to_rooms.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddViewerAccessCodeToRooms < ActiveRecord::Migration[7.0]
-  def change
-    add_column :rooms, :viewer_access_code, :string
-  end
-end

--- a/db/migrate/20220614193921_add_moderator_access_code_to_rooms.rb
+++ b/db/migrate/20220614193921_add_moderator_access_code_to_rooms.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddModeratorAccessCodeToRooms < ActiveRecord::Migration[7.0]
-  def change
-    add_column :rooms, :moderator_access_code, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -117,8 +117,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_21_144137) do
     t.datetime "last_session"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "viewer_access_code"
-    t.string "moderator_access_code"
     t.integer "recordings_processing", default: 0
     t.index ["friendly_id"], name: "index_rooms_on_friendly_id", unique: true
     t.index ["meeting_id"], name: "index_rooms_on_meeting_id", unique: true

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -135,30 +135,78 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
   end
 
   describe '#generate_access_code' do
-    it 'generates a viewer access code' do
-      room = create(:room)
-      patch :generate_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Viewer' }
-      expect(room.reload.viewer_access_code).not_to be_nil
+    context 'bbb_role == "Viewer"' do
+      it 'calls Room#generate_viewer_access_code and returns :ok if it returns true' do
+        allow_any_instance_of(Room).to receive(:generate_viewer_access_code).and_return(true)
+        expect_any_instance_of(Room).to receive(:generate_viewer_access_code)
+        room = create(:room)
+        patch :generate_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Viewer' }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'calls Room#generate_viewer_access_code and returns :bad_request if it returns false' do
+        allow_any_instance_of(Room).to receive(:generate_viewer_access_code).and_return(false)
+        expect_any_instance_of(Room).to receive(:generate_viewer_access_code)
+        room = create(:room)
+        patch :generate_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Viewer' }
+        expect(response).to have_http_status(:bad_request)
+      end
     end
 
-    it 'generates a moderator access code' do
-      room = create(:room)
-      patch :generate_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Moderator' }
-      expect(room.reload.moderator_access_code).not_to be_nil
+    context 'bbb_role == "Moderator"' do
+      it 'calls Room#generate_moderator_access_code and returns :ok if it returns true' do
+        allow_any_instance_of(Room).to receive(:generate_moderator_access_code).and_return(true)
+        expect_any_instance_of(Room).to receive(:generate_moderator_access_code)
+        room = create(:room)
+        patch :generate_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Moderator' }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'calls Room#generate_viewer_access_code and returns :bad_request if it returns false' do
+        allow_any_instance_of(Room).to receive(:generate_moderator_access_code).and_return(false)
+        expect_any_instance_of(Room).to receive(:generate_moderator_access_code)
+        room = create(:room)
+        patch :generate_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Moderator' }
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 
   describe '#remove_access_code' do
-    it 'removes the viewer access code' do
-      room = create(:room, viewer_access_code: 'AAA')
-      patch :remove_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Viewer' }
-      expect(room.reload.viewer_access_code).to be_nil
+    context 'bbb_role == "Viewer"' do
+      it 'calls Room#remove_viewer_access_code and returns :ok if it returns true' do
+        allow_any_instance_of(Room).to receive(:remove_viewer_access_code).and_return(true)
+        expect_any_instance_of(Room).to receive(:remove_viewer_access_code)
+        room = create(:room)
+        patch :remove_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Viewer' }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'calls Room#remove_viewer_access_code and returns :bad_request if it returns false' do
+        allow_any_instance_of(Room).to receive(:remove_viewer_access_code).and_return(false)
+        expect_any_instance_of(Room).to receive(:remove_viewer_access_code)
+        room = create(:room)
+        patch :remove_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Viewer' }
+        expect(response).to have_http_status(:bad_request)
+      end
     end
 
-    it 'removes the moderator access code' do
-      room = create(:room, moderator_access_code: 'BBB')
-      patch :remove_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Moderator' }
-      expect(room.reload.moderator_access_code).to be_nil
+    context 'bbb_role == "Moderator"' do
+      it 'calls Room#remove_moderator_access_code and returns :ok if it returns true' do
+        allow_any_instance_of(Room).to receive(:remove_moderator_access_code).and_return(true)
+        expect_any_instance_of(Room).to receive(:remove_moderator_access_code)
+        room = create(:room)
+        patch :remove_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Moderator' }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'calls Room#remove_moderator_access_code and returns :bad_request if it returns false' do
+        allow_any_instance_of(Room).to receive(:remove_moderator_access_code).and_return(false)
+        expect_any_instance_of(Room).to receive(:remove_moderator_access_code)
+        room = create(:room)
+        patch :remove_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Moderator' }
+        expect(response).to have_http_status(:bad_request)
+      end
     end
   end
 end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Rectifying the rooms access codes to become a room setting that can be configured like any other setting.

This PR completes **1.**..**4.** 
--
~~1. Create and populate `glViewerAccessCode` and `glModeratorAccessCode` in `PopulateRoomsConfigurations` and `PopulateMeetingOptions`.~~
~~2. Remove `:viewer_access_code` and `:moderator_access_code` migrations.~~
~~3. Create `Room#viewer_access_code`, `Room#moderator_access_code`, `Room#generate_viewer_access_code`,
`Room#generate_moderator_access_code`, `Room#remove_viewer_access_code`, `Room#remove_moderator_access_code`.~~
~~4. Update `RoomsController (#generate_access_code, #remove_access_code)` and tests `(meeting_controller_spec and rooms_controller_spec)`.~~
5. Update and extend model spec `room_spec`.
6. Update `RoomSettings#update` **API** to restrict edit to codes.


## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
