### PR TITLE
Access codes rectification 5: Access Codes: Added required tests to `room_spec`.

### DIFF
--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Room, type: :model do
-  describe 'before_validations' do
-    let!(:room) { create(:room) }
+  let!(:room) { create(:room) }
 
+  describe 'before_validations' do
     describe '#set_friendly_id' do
       it 'sets a rooms friendly_id before creating' do
         expect(room.friendly_id).to be_present
@@ -51,6 +51,111 @@ RSpec.describe Room, type: :model do
       expect(MeetingOption).to receive(:get_value).with(name: 'glAnyoneJoinAsModerator', room_id: room.id)
 
       expect(room).not_to be_anyone_joins_as_moderator
+    end
+  end
+
+  describe 'private methods' do
+    describe '#generate_code' do
+      before do
+        allow_any_instance_of(described_class).to receive(:generate_code).and_call_original
+      end
+
+      it 'calls SecureRandom#alphanumeric(6) and downcase its returned value' do
+        allow(SecureRandom).to receive(:alphanumeric).and_return('TEST')
+        expect(SecureRandom).to receive(:alphanumeric).with(6)
+        expect(room.generate_code).to eq('test')
+      end
+    end
+  end
+
+  describe '#viewer_access_code' do
+    it 'calls #get_setting with name "glViewerAccessCode" and returns the value' do
+      allow_any_instance_of(described_class).to receive(:get_setting).and_return(instance_double(RoomMeetingOption, value: 'CODE'))
+      expect_any_instance_of(described_class).to receive(:get_setting).with(name: 'glViewerAccessCode')
+
+      expect(room.viewer_access_code).to eq('CODE')
+    end
+  end
+
+  describe '#moderator_access_code' do
+    it 'calls #get_setting with name "glModeratorAccessCode" and returns the value' do
+      allow_any_instance_of(described_class).to receive(:get_setting).and_return(instance_double(RoomMeetingOption, value: 'CODE'))
+      expect_any_instance_of(described_class).to receive(:get_setting).with(name: 'glModeratorAccessCode')
+
+      expect(room.moderator_access_code).to eq('CODE')
+    end
+  end
+
+  describe '#generate_viewer_access_code' do
+    it 'calls #get_setting with name "glViewerAccessCode" and update it with #generate_code' do
+      fake_room_meeting_option = instance_double(RoomMeetingOption)
+
+      allow(fake_room_meeting_option).to receive(:update).and_return true
+      allow_any_instance_of(described_class).to receive(:get_setting).and_return(fake_room_meeting_option)
+      allow_any_instance_of(described_class).to receive(:generate_code).and_return('NEW_CODE')
+
+      expect_any_instance_of(described_class).to receive(:get_setting).with(name: 'glViewerAccessCode')
+      expect_any_instance_of(described_class).to receive(:generate_code)
+      expect(fake_room_meeting_option).to receive(:update).with value: 'NEW_CODE'
+
+      room.generate_viewer_access_code
+    end
+  end
+
+  describe '#generate_moderator_access_code' do
+    it 'calls #get_setting with name "glModeratorAccessCode" and update it with #generate_code' do
+      fake_room_meeting_option = instance_double(RoomMeetingOption)
+      allow(fake_room_meeting_option).to receive(:update).and_return true
+      allow_any_instance_of(described_class).to receive(:get_setting).and_return(fake_room_meeting_option)
+      allow_any_instance_of(described_class).to receive(:generate_code).and_return('NEW_CODE')
+
+      expect_any_instance_of(described_class).to receive(:get_setting).with(name: 'glModeratorAccessCode')
+      expect_any_instance_of(described_class).to receive(:generate_code)
+      expect(fake_room_meeting_option).to receive(:update).with value: 'NEW_CODE'
+
+      room.generate_moderator_access_code
+    end
+  end
+
+  describe '#remove_moderator_access_code' do
+    it 'calls #get_setting with name "glModeratorAccessCode" and update it with nil' do
+      fake_room_meeting_option = instance_double(RoomMeetingOption)
+      allow(fake_room_meeting_option).to receive(:update).and_return true
+      allow_any_instance_of(described_class).to receive(:get_setting).and_return(fake_room_meeting_option)
+
+      expect_any_instance_of(described_class).to receive(:get_setting).with(name: 'glModeratorAccessCode')
+      expect(fake_room_meeting_option).to receive(:update).with value: nil
+
+      room.remove_moderator_access_code
+    end
+  end
+
+  describe '#remove_viewer_access_code' do
+    it 'calls #get_setting with name "glViewerAccessCode" and update it with nil' do
+      fake_room_meeting_option = instance_double(RoomMeetingOption)
+      allow(fake_room_meeting_option).to receive(:update).and_return true
+      allow_any_instance_of(described_class).to receive(:get_setting).and_return(fake_room_meeting_option)
+
+      expect_any_instance_of(described_class).to receive(:get_setting).with(name: 'glViewerAccessCode')
+      expect(fake_room_meeting_option).to receive(:update).with value: nil
+
+      room.remove_viewer_access_code
+    end
+  end
+
+  describe '#get_setting' do
+    it 'fetches a room setting by :name' do
+      room = create(:room)
+      meeting_option = create(:meeting_option, name: 'setting')
+      room_meeting_option = create(:room_meeting_option, room:, meeting_option:)
+
+      expect(room.get_setting(name: 'setting')).to eq(room_meeting_option)
+    end
+
+    it 'returns nil for unfound setting' do
+      room = create(:room)
+
+      expect(room.get_setting(name: '404')).to be_nil
     end
   end
 


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Rectifying the rooms access codes to become a room setting that can be configured like any other setting.

This PR completes **5.**
--
~~1. Create and populate `glViewerAccessCode` and `glModeratorAccessCode` in `PopulateRoomsConfigurations` and `PopulateMeetingOptions`.~~
~~2. Remove `:viewer_access_code` and `:moderator_access_code` migrations.~~
~~3. Create `Room#viewer_access_code`, `Room#moderator_access_code`, `Room#generate_viewer_access_code`,
`Room#generate_moderator_access_code`, `Room#remove_viewer_access_code`, `Room#remove_moderator_access_code`.~~
~~4. Update `RoomsController (#generate_access_code, #remove_access_code)` and tests `(meeting_controller_spec and rooms_controller_spec)`.~~
~~5. Update and extend model spec `room_spec`.~~
6. Update `RoomSettings#update` **API** to restrict edit to codes.


## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
