### PR TITLE
Add PermissionsChecker service

### DIFF
--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -29,6 +29,7 @@ module Api
           end
         end
 
+        # TODO: Remove duplication, use destroy from users_controller instead
         def destroy
           # TODO: Will need to add additional logic later
           if @user.destroy

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -6,6 +6,10 @@ module Api
       class UsersController < ApiController
         before_action :find_user, only: :destroy
 
+        before_action only: %i[create destroy create_server_room] do
+          ensure_authorized('ManageUsers')
+        end
+
         include Avatarable
 
         def create

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -5,7 +5,7 @@ module Api
     class UsersController < ApiController
       skip_before_action :ensure_authenticated, only: %i[create]
 
-      before_action only: %i[update destroy purge_avatar] do
+      before_action only: %i[update purge_avatar] do
         ensure_authorized('ManageUsers')
       end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -5,6 +5,10 @@ module Api
     class UsersController < ApiController
       skip_before_action :ensure_authenticated, only: %i[create]
 
+      before_action only: %i[update destroy purge_avatar] do
+        ensure_authorized('ManageUsers')
+      end
+
       def show
         user = User.find(params[:id])
 

--- a/app/controllers/concerns/authorizable.rb
+++ b/app/controllers/concerns/authorizable.rb
@@ -13,6 +13,17 @@ module Authorizable
     return render_error status: :unauthorized unless current_user
   end
 
+  # PermissionsChecker service will return a true or false depending on whether the current_user's role has the provided permission_name
+  def ensure_authorized(permission_name)
+    return render_error status: :unauthorized unless PermissionsChecker.new(
+      current_user:,
+      permission_name:,
+      user_id: params[:id],
+      friendly_id: params[:friendly_id],
+      record_id: params[:record_id]
+    ).call
+  end
+
   private
 
   # Ensures that requests to the API are explicit enough.

--- a/app/controllers/concerns/authorizable.rb
+++ b/app/controllers/concerns/authorizable.rb
@@ -16,7 +16,7 @@ module Authorizable
   # PermissionsChecker service will return a true or false depending on whether the current_user's role has the provided permission_name
   def ensure_authorized(permission_name)
     # TODO: - should this return a status: :not_found instead of :unauthorized if the user doesn't have the permission AND the param doesn't exists?
-    return render_error status: :unauthorized unless PermissionsChecker.new(
+    return render_error status: :forbidden unless PermissionsChecker.new(
       current_user:,
       permission_name:,
       user_id: params[:id],

--- a/app/controllers/concerns/authorizable.rb
+++ b/app/controllers/concerns/authorizable.rb
@@ -15,6 +15,7 @@ module Authorizable
 
   # PermissionsChecker service will return a true or false depending on whether the current_user's role has the provided permission_name
   def ensure_authorized(permission_name)
+    # TODO: - should this return a status: :not_found instead of :unauthorized if the user doesn't have the permission AND the param doesn't exists?
     return render_error status: :unauthorized unless PermissionsChecker.new(
       current_user:,
       permission_name:,

--- a/app/services/permissions_checker.rb
+++ b/app/services/permissions_checker.rb
@@ -11,8 +11,7 @@ class PermissionsChecker
 
   def call
     return true if RolePermission.joins(:permission)
-                                 .where(role_id: @current_user.role_id)
-                                 .find_by(permission: { name: @permission_name })&.value == 'true'
+                                 .find_by(role_id: @current_user.role_id, permission: { name: @permission_name })&.value == 'true'
 
     case @permission_name
     when 'ManageUsers'

--- a/app/services/permissions_checker.rb
+++ b/app/services/permissions_checker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PermissionsChecker
-  def initialize(current_user:, permission_name:, user_id:, friendly_id:, record_id:)
+  def initialize(current_user:, permission_name:, user_id: '', friendly_id: '', record_id: '')
     @current_user = current_user
     @permission_name = permission_name
     @user_id = user_id
@@ -29,7 +29,7 @@ class PermissionsChecker
   private
 
   def authorize_manage_user
-    @current_user.id.to_s == @user_id
+    @current_user.id.to_s == @user_id.to_s
   end
 
   def authorize_manage_rooms

--- a/app/services/permissions_checker.rb
+++ b/app/services/permissions_checker.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class PermissionsChecker
+  def initialize(current_user:, permission_name:, user_id:, friendly_id:, record_id:)
+    @current_user = current_user
+    @permission_name = permission_name
+    @user_id = user_id
+    @friendly_id = friendly_id
+    @record_id = record_id
+  end
+
+  def call
+    return true if RolePermission.joins(:permission)
+                                 .where(role_id: @current_user.role_id)
+                                 .find_by(permission: { name: @permission_name })&.value == 'true'
+
+    case @permission_name
+    when 'ManageUsers'
+      return authorize_manage_user
+    when 'ManageRooms'
+      return authorize_manage_rooms
+    when 'ManageRecordings'
+      return authorize_manage_recordings
+    end
+
+    false
+  end
+
+  private
+
+  def authorize_manage_user
+    @current_user.id.to_s == @user_id
+  end
+
+  def authorize_manage_rooms
+    @current_user.rooms.find_by(friendly_id: @friendly_id).present?
+  end
+
+  def authorize_manage_recordings
+    @current_user.recordings.find_by(record_id: @record_id).present?
+  end
+end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Api::V1::Admin::UsersController, type: :controller do
       room_valid_params = { name: 'Awesome Room' }
       create(:role_permission, permission: manage_users_permission, role:, value: 'false', provider: 'greenlight')
       expect { post :create_server_room, params: { user_id: user.id, room: room_valid_params } }.not_to(change { user.rooms.count })
-      expect(response).to have_http_status(:unauthorized)
+      expect(response).to have_http_status(:forbidden)
     end
 
     it 'returns :not_found for unfound users' do

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::Admin::UsersController, type: :controller do
-  let(:user) { create(:user) }
+  let(:role) { create(:role) }
+  let(:user) { create(:user, role:) }
+  let(:manage_users_permission) { create(:permission, name: 'ManageUsers') }
 
   before do
     request.headers['ACCEPT'] = 'application/json'
@@ -31,9 +33,16 @@ RSpec.describe Api::V1::Admin::UsersController, type: :controller do
     end
 
     it 'admin creates a user' do
-      create(:role, name: 'User')
+      create(:role, name: 'User') # Needed for AdminController#create
+      create(:role_permission, permission: manage_users_permission, role:, value: 'true', provider: 'greenlight')
       expect { post :create, params: user_params }.to change(User, :count).by(1)
       expect(response).to have_http_status(:created)
+    end
+
+    it 'admin without the ManageUsers permission cannot create a new user' do
+      create(:role, name: 'User') # Needed for AdminController#create
+      create(:role_permission, permission: manage_users_permission, role:, value: 'false', provider: 'greenlight')
+      expect { post :create, params: user_params }.not_to change(User, :count)
     end
   end
 
@@ -41,23 +50,30 @@ RSpec.describe Api::V1::Admin::UsersController, type: :controller do
     it 'creates a room for a user if params are valid' do
       user = create(:user)
       room_valid_params = { name: 'Awesome Room' }
+      create(:role_permission, permission: manage_users_permission, role:, value: 'true', provider: 'greenlight')
       expect { post :create_server_room, params: { user_id: user.id, room: room_valid_params } }.to(change { user.rooms.count })
-
       expect(response).to have_http_status(:created)
+    end
+
+    it 'admin without the ManageUsers permission cannot create a new server room for another user' do
+      user = create(:user)
+      room_valid_params = { name: 'Awesome Room' }
+      create(:role_permission, permission: manage_users_permission, role:, value: 'false', provider: 'greenlight')
+      expect { post :create_server_room, params: { user_id: user.id, room: room_valid_params } }.not_to(change { user.rooms.count })
+      expect(response).to have_http_status(:unauthorized)
     end
 
     it 'returns :not_found for unfound users' do
       room_valid_params = { name: 'Awesome Room' }
+      create(:role_permission, permission: manage_users_permission, role:, value: 'true', provider: 'greenlight')
       post :create_server_room, params: { user_id: 404, room: room_valid_params }
-
       expect(response).to have_http_status(:not_found)
     end
 
     it 'returns :bad_request for invalid params' do
       user = create(:user)
-
+      create(:role_permission, permission: manage_users_permission, role:, value: 'true', provider: 'greenlight')
       post :create_server_room, params: { user_id: user.id, not_room: {} }
-
       expect(response).to have_http_status(:bad_request)
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -76,8 +76,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
 
     it 'does not delete any user if the user id is invalid' do
       expect { delete :destroy, params: { id: 'invalid-id' } }.not_to change(User, :count)
-      # TODO: - maybe ensure_authorized should return a :not_found if the user is not authorized AND the param doesn't exists?
-      expect(response).to have_http_status(:unauthorized)
+      expect(response).to have_http_status(:not_found)
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -32,30 +32,25 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         email: 'newemail@gmail.com',
         language: 'gl'
       }
-      user = create(:user)
       patch :update, params: { id: user.id, user: updated_params }
-      user.reload
       expect(response).to have_http_status(:ok)
-      expect(user.name).to eq(updated_params[:name])
-      expect(user.email).to eq(updated_params[:email])
-      expect(user.language).to eq(updated_params[:language])
+      expect(user.reload.name).to eq(updated_params[:name])
+      expect(user.reload.email).to eq(updated_params[:email])
+      expect(user.reload.language).to eq(updated_params[:language])
     end
 
     it 'returns an error if the user update fails' do
-      user = create(:user)
       patch :update, params: { id: user.id, user: { name: nil } }
       expect(response).to have_http_status(:bad_request)
       expect(user.reload.name).to eq(user.name)
     end
 
     it 'updates the avatar' do
-      user = create(:user)
       patch :update, params: { id: user.id, user: { avatar: fixture_file_upload(file_fixture('default-avatar.png'), 'image/png') } }
       expect(user.reload.avatar).to be_attached
     end
 
     it 'deletes the avatar' do
-      user = create(:user)
       user.avatar.attach(io: fixture_file_upload('default-avatar.png'), filename: 'default-avatar.png', content_type: 'image/png')
       expect(user.reload.avatar).to be_attached
       delete :purge_avatar, params: { id: user.id }
@@ -63,13 +58,11 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     end
 
     it 'returns an error if the avatar is a pdf' do
-      user = create(:user)
       patch :update, params: { id: user.id, user: { avatar: fixture_file_upload(file_fixture('default-pdf.pdf'), 'pdf') } }
       expect(user.reload.avatar).not_to be_attached
     end
 
     it 'returns an error if the avatar size is too large' do
-      user = create(:user)
       patch :update, params: { id: user.id, user: { avatar: fixture_file_upload(file_fixture('large-avatar.jpg'), 'jpg') } }
       expect(user.reload.avatar).not_to be_attached
     end
@@ -77,14 +70,14 @@ RSpec.describe Api::V1::UsersController, type: :controller do
 
   describe 'DELETE users#destroy' do
     it 'deletes the user' do
-      user = create(:user)
       expect(response).to have_http_status(:ok)
       expect { delete :destroy, params: { id: user.id } }.to change(User, :count).by(-1)
     end
 
     it 'does not delete any user if the user id is invalid' do
       expect { delete :destroy, params: { id: 'invalid-id' } }.not_to change(User, :count)
-      expect(response).to have_http_status(:not_found)
+      # TODO: - maybe ensure_authorized should return a :not_found if the user is not authorized AND the param doesn't exists?
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 

--- a/spec/factories/permission_factory.rb
+++ b/spec/factories/permission_factory.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :permission do
+    name { Faker::App.name }
+  end
+end

--- a/spec/factories/role_permission_factory.rb
+++ b/spec/factories/role_permission_factory.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :role_permission do
+    value { Faker::Boolean.boolean }
+    role
+    permission
+  end
+end

--- a/spec/services/permissions_checker_spec.rb
+++ b/spec/services/permissions_checker_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PermissionsChecker, type: :service do
+  let(:role) { create(:role) }
+  let(:permission) { create(:permission) }
+  let(:user) { create(:user, role:) }
+
+  describe '#call' do
+    it 'returns true if the user role has the provided permission' do
+      create(:role_permission, role:, permission:, value: 'true', provider: 'greenlight')
+      expect(described_class.new(current_user: user, permission_name: permission.name).call).to be(true)
+    end
+
+    it 'returns false if the user role does not have the provided permission' do
+      create(:role_permission, role:, permission:, value: 'false', provider: 'greenlight')
+      expect(described_class.new(current_user: user, permission_name: permission.name).call).to be(false)
+    end
+
+    it 'returns true if the user is trying to act on itself without having the ManageUsers permission' do
+      create(:role_permission, role:, permission:, value: 'false', provider: 'greenlight')
+      expect(described_class.new(current_user: user, permission_name: 'ManageUsers', user_id: user.id).call).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a PermissionsChecker service to be called in a controllers `before_action`.

The PermissionsChecker returns a bool.

The PermissionsChecker will return true if the request to the endpoint either contains:

1. a current_user that has the appropriate permission to act on a resource
2. a params[:resource_id] and a current_user that is trying to act on its own resource as per the matching of current_user.resource_id == params[:ressource_id]

Else, the PermissionsChecker will return false and an unauthorized status.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

- Try to edit the users in the Admin/ManageUsers tab without having the "ManageUsers" permission
- Try to edit the users in the Admin/ManageUsers tab while having the "ManageUsers" permission
- Try to edit your own profile via the Admin/ManageUsers tab and the Profile tab.

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
