### PR TITLE
Access codes rectification 6: Restricted unsupervised updates to access codes.

### DIFF
--- a/spec/controllers/room_settings_controller_spec.rb
+++ b/spec/controllers/room_settings_controller_spec.rb
@@ -61,6 +61,13 @@ RSpec.describe Api::V1::RoomSettingsController, type: :controller do
       expect(response).to have_http_status(:forbidden)
     end
 
+    it 'returns :forbidden when updating a read only setting' do
+      stub_const('RoomSettingsController::READ_ONLY_SETTINGS', %w[read_only])
+
+      put :update, params: { room_setting: { settingName: 'read_only', settingValue: 'notReadOnlyAnymore' }, friendly_id: room.friendly_id }
+      expect(response).to have_http_status(:forbidden)
+    end
+
     it 'returns :bad_request for invalid params' do
       put :update, params: { not_room_setting: { notSettingName: 'setting', notSettingValue: 'someValue' }, friendly_id: room.friendly_id }
       expect(response).to have_http_status(:bad_request)


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Rectifying the rooms access codes to become a room setting that can be configured like any other setting.

This PR completes **6.**
--
~~1. Create and populate `glViewerAccessCode` and `glModeratorAccessCode` in `PopulateRoomsConfigurations` and `PopulateMeetingOptions`.~~
~~2. Remove `:viewer_access_code` and `:moderator_access_code` migrations.~~
~~3. Create `Room#viewer_access_code`, `Room#moderator_access_code`, `Room#generate_viewer_access_code`,
`Room#generate_moderator_access_code`, `Room#remove_viewer_access_code`, `Room#remove_moderator_access_code`.~~
~~4. Update `RoomsController (#generate_access_code, #remove_access_code)` and tests `(meeting_controller_spec and rooms_controller_spec)`.~~
~~5. Update and extend model spec `room_spec`.~~
~~6. Update `RoomSettings#update` **API** to restrict edit to codes.~~


## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
