### PR TITLE
Access Codes: Restricted access codes removal and generation for certain configs.

### DIFF
--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -83,8 +83,14 @@ module Api
       def generate_access_code
         generated = case params[:bbb_role]
                     when 'Viewer'
+                      config = MeetingOption.get_config_value(name: 'glViewerAccessCode', provider: 'greenlight')&.value
+                      return render_error status: :forbidden if config == 'false'
+
                       @room.generate_viewer_access_code
                     when 'Moderator'
+                      config = MeetingOption.get_config_value(name: 'glModeratorAccessCode', provider: 'greenlight')&.value
+                      return render_error status: :forbidden if config == 'false'
+
                       @room.generate_moderator_access_code
                     end
 
@@ -97,8 +103,14 @@ module Api
       def remove_access_code
         removed = case params[:bbb_role]
                   when 'Viewer'
+                    config = MeetingOption.get_config_value(name: 'glViewerAccessCode', provider: 'greenlight')&.value
+                    return render_error status: :forbidden unless config == 'optional'
+
                     @room.remove_viewer_access_code
                   when 'Moderator'
+                    config = MeetingOption.get_config_value(name: 'glModeratorAccessCode', provider: 'greenlight')&.value
+                    return render_error status: :forbidden unless config == 'optional'
+
                     @room.remove_moderator_access_code
                   end
 

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -135,6 +135,10 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
   end
 
   describe '#generate_access_code' do
+    before do
+      allow(MeetingOption).to receive(:get_config_value).and_return(instance_double(RoomMeetingOption, { value: %w[optional true].sample }))
+    end
+
     context 'bbb_role == "Viewer"' do
       it 'calls Room#generate_viewer_access_code and returns :ok if it returns true' do
         allow_any_instance_of(Room).to receive(:generate_viewer_access_code).and_return(true)
@@ -150,6 +154,18 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
         room = create(:room)
         patch :generate_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Viewer' }
         expect(response).to have_http_status(:bad_request)
+      end
+
+      context 'AuthZ' do
+        it 'returns :forbidden when "glViewerAccessCode" config is "false"' do
+          allow(MeetingOption).to receive(:get_config_value).and_return(instance_double(RoomMeetingOption, { value: 'false' }))
+          room = create(:room)
+
+          expect_any_instance_of(Room).not_to receive(:generate_viewer_access_code)
+          expect(MeetingOption).to receive(:get_config_value).with(name: 'glViewerAccessCode', provider: 'greenlight')
+          patch :remove_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Viewer' }
+          expect(response).to have_http_status(:forbidden)
+        end
       end
     end
 
@@ -169,10 +185,26 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
         patch :generate_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Moderator' }
         expect(response).to have_http_status(:bad_request)
       end
+
+      context 'AuthZ' do
+        it 'returns :forbidden when "glModeratorAccessCode" config is "false"' do
+          allow(MeetingOption).to receive(:get_config_value).and_return(instance_double(RoomMeetingOption, { value: 'false' }))
+          room = create(:room)
+
+          expect_any_instance_of(Room).not_to receive(:generate_moderator_access_code)
+          expect(MeetingOption).to receive(:get_config_value).with(name: 'glModeratorAccessCode', provider: 'greenlight')
+          patch :remove_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Moderator' }
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
     end
   end
 
   describe '#remove_access_code' do
+    before do
+      allow(MeetingOption).to receive(:get_config_value).and_return(instance_double(RoomMeetingOption, { value: 'optional' }))
+    end
+
     context 'bbb_role == "Viewer"' do
       it 'calls Room#remove_viewer_access_code and returns :ok if it returns true' do
         allow_any_instance_of(Room).to receive(:remove_viewer_access_code).and_return(true)
@@ -188,6 +220,28 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
         room = create(:room)
         patch :remove_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Viewer' }
         expect(response).to have_http_status(:bad_request)
+      end
+
+      context 'AuthZ' do
+        it 'returns :forbidden when "glViewerAccessCode" config is "true"' do
+          allow(MeetingOption).to receive(:get_config_value).and_return(instance_double(RoomMeetingOption, { value: 'true' }))
+          room = create(:room)
+
+          expect_any_instance_of(Room).not_to receive(:remove_viewer_access_code)
+          expect(MeetingOption).to receive(:get_config_value).with(name: 'glViewerAccessCode', provider: 'greenlight')
+          patch :remove_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Viewer' }
+          expect(response).to have_http_status(:forbidden)
+        end
+
+        it 'returns :forbidden when "glViewerAccessCode" config is "false"' do
+          allow(MeetingOption).to receive(:get_config_value).and_return(instance_double(RoomMeetingOption, { value: 'false' }))
+          room = create(:room)
+
+          expect_any_instance_of(Room).not_to receive(:remove_viewer_access_code)
+          expect(MeetingOption).to receive(:get_config_value).with(name: 'glViewerAccessCode', provider: 'greenlight')
+          patch :remove_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Viewer' }
+          expect(response).to have_http_status(:forbidden)
+        end
       end
     end
 
@@ -206,6 +260,28 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
         room = create(:room)
         patch :remove_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Moderator' }
         expect(response).to have_http_status(:bad_request)
+      end
+
+      context 'AuthZ' do
+        it 'returns :forbidden when "glModeratorAccessCode" config is "true"' do
+          allow(MeetingOption).to receive(:get_config_value).and_return(instance_double(RoomMeetingOption, { value: 'true' }))
+          room = create(:room)
+
+          expect_any_instance_of(Room).not_to receive(:remove_viewer_access_code)
+          expect(MeetingOption).to receive(:get_config_value).with(name: 'glModeratorAccessCode', provider: 'greenlight')
+          patch :remove_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Moderator' }
+          expect(response).to have_http_status(:forbidden)
+        end
+
+        it 'returns :forbidden when "glModeratorAccessCode" config is "false"' do
+          allow(MeetingOption).to receive(:get_config_value).and_return(instance_double(RoomMeetingOption, { value: 'false' }))
+          room = create(:room)
+
+          expect_any_instance_of(Room).not_to receive(:remove_viewer_access_code)
+          expect(MeetingOption).to receive(:get_config_value).with(name: 'glModeratorAccessCode', provider: 'greenlight')
+          patch :remove_access_code, params: { friendly_id: room.friendly_id, bbb_role: 'Moderator' }
+          expect(response).to have_http_status(:forbidden)
+        end
       end
     end
   end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Synchronizing the rooms access codes settings with their rooms configs.

This PR:

- Edits `RoomsController#generate_access_code` and `RoomsController#remove_access_code ` to forbid access for certain configs.

> NOTE: 
>   - When an access code is forced **enabled**, its removal should be **denied** but its regeneration should be **allowed**.
>   - When an access code is forced **disabled**, its (re-)generation and removal should be **denied**.
>   - When an access code is **optional**, its (re-)generation and removal should be **allowed**.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
