### PR TITLE
Access Codes: Extended the access codes fetching logic to hide the codes for forced disabled configs.

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -31,10 +31,16 @@ class Room < ApplicationRecord
   end
 
   def viewer_access_code
+    config = MeetingOption.get_config_value(name: 'glViewerAccessCode', provider: 'greenlight')&.value
+    return nil if config == 'false'
+
     get_setting(name: 'glViewerAccessCode')&.value
   end
 
   def moderator_access_code
+    config = MeetingOption.get_config_value(name: 'glModeratorAccessCode', provider: 'greenlight')&.value
+    return nil if config == 'false'
+
     get_setting(name: 'glModeratorAccessCode')&.value
   end
 

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -69,20 +69,54 @@ RSpec.describe Room, type: :model do
   end
 
   describe '#viewer_access_code' do
+    before do
+      random_positive_value = %w[optional true].sample
+      allow(MeetingOption).to receive(:get_config_value).and_return(instance_double(RoomMeetingOption, value: random_positive_value))
+    end
+
     it 'calls #get_setting with name "glViewerAccessCode" and returns the value' do
       allow_any_instance_of(described_class).to receive(:get_setting).and_return(instance_double(RoomMeetingOption, value: 'CODE'))
-      expect_any_instance_of(described_class).to receive(:get_setting).with(name: 'glViewerAccessCode')
 
+      expect(MeetingOption).to receive(:get_config_value).with(name: 'glViewerAccessCode', provider: 'greenlight')
+      expect_any_instance_of(described_class).to receive(:get_setting).with(name: 'glViewerAccessCode')
       expect(room.viewer_access_code).to eq('CODE')
+    end
+
+    context 'AuthZ' do
+      it 'calls MeetingOption.get_config_value and return :nil if the config is "false"' do
+        allow_any_instance_of(described_class).to receive(:get_setting).and_return(instance_double(RoomMeetingOption, value: 'CODE'))
+        allow(MeetingOption).to receive(:get_config_value).and_return(instance_double(RoomMeetingOption, value: 'false'))
+
+        expect(MeetingOption).to receive(:get_config_value).with(name: 'glViewerAccessCode', provider: 'greenlight')
+        expect_any_instance_of(described_class).not_to receive(:get_setting)
+        expect(room.viewer_access_code).to be_nil
+      end
     end
   end
 
   describe '#moderator_access_code' do
+    before do
+      random_positive_value = %w[optional true].sample
+      allow(MeetingOption).to receive(:get_config_value).and_return(instance_double(RoomMeetingOption, value: random_positive_value))
+    end
+
     it 'calls #get_setting with name "glModeratorAccessCode" and returns the value' do
       allow_any_instance_of(described_class).to receive(:get_setting).and_return(instance_double(RoomMeetingOption, value: 'CODE'))
-      expect_any_instance_of(described_class).to receive(:get_setting).with(name: 'glModeratorAccessCode')
 
+      expect(MeetingOption).to receive(:get_config_value).with(name: 'glModeratorAccessCode', provider: 'greenlight')
+      expect_any_instance_of(described_class).to receive(:get_setting).with(name: 'glModeratorAccessCode')
       expect(room.moderator_access_code).to eq('CODE')
+    end
+
+    context 'AuthZ' do
+      it 'calls MeetingOption.get_config_value and return :nil if the config is "false"' do
+        allow_any_instance_of(described_class).to receive(:get_setting).and_return(instance_double(RoomMeetingOption, value: 'CODE'))
+        allow(MeetingOption).to receive(:get_config_value).and_return(instance_double(RoomMeetingOption, value: 'false'))
+
+        expect(MeetingOption).to receive(:get_config_value).with(name: 'glModeratorAccessCode', provider: 'greenlight')
+        expect_any_instance_of(described_class).not_to receive(:get_setting)
+        expect(room.moderator_access_code).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Synchronizing the rooms access codes settings with their rooms configs.

This PR:

- Edits `Rooms` model to extend the access codes fetching logic to hide their values when having a forced disabled config.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
