### PR TITLE
Remove admin::user#create endpoint duplication

### DIFF
--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -6,28 +6,11 @@ module Api
       class UsersController < ApiController
         before_action :find_user, only: :destroy
 
-        before_action only: %i[create destroy create_server_room] do
+        before_action only: %i[destroy create_server_room] do
           ensure_authorized('ManageUsers')
         end
 
         include Avatarable
-
-        def create
-          # TODO: amir - ensure accessibility for unauthenticated requests only.
-          params[:user][:language] = I18n.default_locale if params[:user][:language].blank?
-
-          user = User.new({
-            provider: 'greenlight',
-            role: Role.find_by(name: 'User') # TODO: - Ahmad: Move to service
-          }.merge(user_params)) # TMP fix for presence validation of :provider
-
-          if user.save
-            render_data status: :created
-          else
-            # TODO: amir - Improve logging.
-            render_error errors: user.errors.to_a, status: :bad_request
-          end
-        end
 
         # TODO: Remove duplication, use destroy from users_controller instead
         def destroy
@@ -60,10 +43,6 @@ module Api
         end
 
         private
-
-        def user_params
-          params.require(:user).permit(:name, :email, :password, :password_confirmation, :avatar, :language)
-        end
 
         def create_server_room_params
           params.require(:room).permit(:name)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -30,7 +30,7 @@ module Api
         return render_error errors: user.errors.to_a if hcaptcha_enabled? && !verify_hcaptcha(response: params[:token])
 
         if user.save
-          session[:user_id] = user.id
+          session[:user_id] ||= user.id
           token = user.generate_activation_token!
           render_data data: { token: }, status: :created # TODO: enable activation email sending.
         else

--- a/app/javascript/hooks/mutations/admin/manage_users/useAdminCreateUser.jsx
+++ b/app/javascript/hooks/mutations/admin/manage_users/useAdminCreateUser.jsx
@@ -14,11 +14,12 @@ export default function useAdminCreateUser({ onSettled }) {
   };
 
   return useMutation(
-    (user) => axios.post('/admin/users.json', { user }),
+    (user) => axios.post('/users.json', { user }),
     {
       onMutate: addInferredLanguage,
       onSuccess: () => {
         queryClient.invalidateQueries('getAdminUsers');
+        toast.success('User was created');
       },
       onError: () => {
         toast.error('There was a problem completing that action. \n Please try again.');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,7 @@ Rails.application.routes.draw do
       resources :rooms_configurations, only: :index
 
       namespace :admin do
-        resources :users, only: %i[create destroy]  do
+        resources :users, only: %i[destroy]  do
           collection do
             get '/active_users', to: 'users#active_users'
             post '/:user_id/create_server_room', to: 'users#create_server_room'

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -32,26 +32,6 @@ RSpec.describe Api::V1::Admin::UsersController, type: :controller do
     end
   end
 
-  describe '#create' do
-    let(:user_params) do
-      {
-        user: { name: Faker::Name.name, email: Faker::Internet.email, password: Faker::Internet.password }
-      }
-    end
-
-    it 'admin creates a user' do
-      create(:role, name: 'User') # Needed for AdminController#create
-      expect { post :create, params: user_params }.to change(User, :count).by(1)
-      expect(response).to have_http_status(:created)
-    end
-
-    it 'admin without the ManageUsers permission cannot create a new user' do
-      create(:role, name: 'User') # Needed for AdminController#create
-      manage_users_role_permission.update!(value: 'false')
-      expect { post :create, params: user_params }.not_to change(User, :count)
-    end
-  end
-
   describe '#create_server_room' do
     it 'creates a room for a user if params are valid' do
       new_user = create(:user)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -23,16 +23,16 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       }
     end
 
-    it 'creates a current user if the new user is created' do
+    it 'creates a current_user if a new user is created' do
       session[:user_id] = nil
       create(:role, name: 'User') # Needed for admin#create
-      post :create, params: user_params
-      expect(session[:user_id]).to eql(User.last.id)
+      expect { post :create, params: user_params }.to change(User, :count).by(1)
+      expect(session[:user_id]).to be_present
     end
 
-    it 'creates a new user without changing the current user if the new user is created from a logged in user' do
+    it 'creates a user without changing the current user if the user is created from a logged in user' do
       create(:role, name: 'User') # Needed for admin#create
-      post :create, params: user_params
+      expect { post :create, params: user_params }.to change(User, :count).by(1)
       expect(session[:user_id]).to eql(user.id)
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -10,6 +10,33 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     session[:user_id] = user.id
   end
 
+  describe '#create' do
+    let(:user_params) do
+      {
+        user: {
+          name: Faker::Name.name,
+          email: Faker::Internet.email,
+          password: 'Password123+',
+          password_confirmation: 'Password123+',
+          language: 'language'
+        }
+      }
+    end
+
+    it 'creates a current user if the new user is created' do
+      session[:user_id] = nil
+      create(:role, name: 'User') # Needed for admin#create
+      post :create, params: user_params
+      expect(session[:user_id]).to eql(User.last.id)
+    end
+
+    it 'creates a new user without changing the current user if the new user is created from a logged in user' do
+      create(:role, name: 'User') # Needed for admin#create
+      post :create, params: user_params
+      expect(session[:user_id]).to eql(user.id)
+    end
+  end
+
   describe '#show' do
     it 'returns a user if id is valid' do
       user = create(:user)


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove the admin::user#create endpoint.
Put the logic inside the user#create controller.

Small fix: the logic added to user#create controller is to make sure the current_user is not replaced by the created user if the user creation is made via a logged in user.

Adding #create to the `before_action ensure_authorized` creates a problem with the PermissionsChecker because the service checks if you are either a current_user or have a permission (and a new user is/have neither).

But, ultimately, you don't need a special permission to create an account, so I think it's not needed anyways - correct me if I am wrong.