### PR TITLE
Remove admin::user#destroy endpoint duplication + "admin" specs template proposal

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,9 @@ RSpec/ExampleLength:
 RSpec/FilePath:
   Enabled: false
 
+RSpec/LetSetup:
+  Enabled: false
+
 RSpec/MessageSpies:
   Enabled: false
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -5,7 +5,7 @@ module Api
     class UsersController < ApiController
       skip_before_action :ensure_authenticated, only: %i[create]
 
-      before_action only: %i[update purge_avatar] do
+      before_action only: %i[update destroy purge_avatar] do
         ensure_authorized('ManageUsers', user_id: params[:id])
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,7 @@ Rails.application.routes.draw do
       resources :rooms_configurations, only: :index
 
       namespace :admin do
-        resources :users, only: %i[destroy]  do
+        resources :users do
           collection do
             get '/active_users', to: 'users#active_users'
             post '/:user_id/create_server_room', to: 'users#create_server_room'

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -105,13 +105,8 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     end
   end
 
-<<<<<<< HEAD
-  describe 'DELETE users#destroy' do
-    it 'deletes the user' do
-=======
   describe 'users#destroy' do
     it 'deletes the current_user account' do
->>>>>>> e0266e2d... Fix RSpec + Routes
       expect(response).to have_http_status(:ok)
       expect { delete :destroy, params: { id: user.id } }.to change(User, :count).by(-1)
     end
@@ -124,13 +119,10 @@ RSpec.describe Api::V1::UsersController, type: :controller do
 
     it 'returns status code forbidden if the user id is invalid' do
       expect { delete :destroy, params: { id: 'invalid-id' } }.not_to change(User, :count)
-<<<<<<< HEAD
-      expect(response).to have_http_status(:not_found)
-=======
       expect(response).to have_http_status(:forbidden)
     end
 
-    context 'current_user with ManageUsers permission deletes another user' do
+    context 'current_user with ManageUsers permission' do
       before do
         manage_users_role_permission
         user.update!(role: manage_users_role)
@@ -145,7 +137,6 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         expect { delete :destroy, params: { id: 'invalid-id' } }.not_to change(User, :count)
         expect(response).to have_http_status(:not_found)
       end
->>>>>>> e0266e2d... Fix RSpec + Routes
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
 
   let(:manage_users_role) { create(:role) }
   let(:manage_users_permission) { create(:permission, name: 'ManageUsers') }
-  let(:manage_users_role_permission) do
+  let!(:manage_users_role_permission) do
     create(:role_permission,
            role: manage_users_role,
            permission: manage_users_permission,
@@ -124,7 +124,6 @@ RSpec.describe Api::V1::UsersController, type: :controller do
 
     context 'current_user with ManageUsers permission' do
       before do
-        manage_users_role_permission
         user.update!(role: manage_users_role)
       end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -117,11 +117,6 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it 'returns status code forbidden if the user id is invalid' do
-      expect { delete :destroy, params: { id: 'invalid-id' } }.not_to change(User, :count)
-      expect(response).to have_http_status(:forbidden)
-    end
-
     context 'current_user with ManageUsers permission' do
       before do
         user.update!(role: manage_users_role)
@@ -132,7 +127,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         expect { delete :destroy, params: { id: new_user.id } }.to change(User, :count).by(-1)
       end
 
-      it 'returns status code not found if the user id is invalid' do
+      it 'returns status code not found if the user does not exists' do
         expect { delete :destroy, params: { id: 'invalid-id' } }.not_to change(User, :count)
         expect(response).to have_http_status(:not_found)
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -5,6 +5,16 @@ require 'rails_helper'
 RSpec.describe Api::V1::UsersController, type: :controller do
   let(:user) { create(:user) }
 
+  let(:manage_users_role) { create(:role) }
+  let(:manage_users_permission) { create(:permission, name: 'ManageUsers') }
+  let(:manage_users_role_permission) do
+    create(:role_permission,
+           role: manage_users_role,
+           permission: manage_users_permission,
+           value: 'true',
+           provider: 'greenlight')
+  end
+
   before do
     request.headers['ACCEPT'] = 'application/json'
     session[:user_id] = user.id
@@ -95,15 +105,47 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     end
   end
 
+<<<<<<< HEAD
   describe 'DELETE users#destroy' do
     it 'deletes the user' do
+=======
+  describe 'users#destroy' do
+    it 'deletes the current_user account' do
+>>>>>>> e0266e2d... Fix RSpec + Routes
       expect(response).to have_http_status(:ok)
       expect { delete :destroy, params: { id: user.id } }.to change(User, :count).by(-1)
     end
 
-    it 'does not delete any user if the user id is invalid' do
+    it 'returns status code forbidden if the user tries to delete another user' do
+      new_user = create(:user)
+      expect { delete :destroy, params: { id: new_user.id } }.not_to change(User, :count)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns status code forbidden if the user id is invalid' do
       expect { delete :destroy, params: { id: 'invalid-id' } }.not_to change(User, :count)
+<<<<<<< HEAD
       expect(response).to have_http_status(:not_found)
+=======
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    context 'current_user with ManageUsers permission deletes another user' do
+      before do
+        manage_users_role_permission
+        user.update!(role: manage_users_role)
+      end
+
+      it 'deletes a user' do
+        new_user = create(:user)
+        expect { delete :destroy, params: { id: new_user.id } }.to change(User, :count).by(-1)
+      end
+
+      it 'returns status code not found if the user id is invalid' do
+        expect { delete :destroy, params: { id: 'invalid-id' } }.not_to change(User, :count)
+        expect(response).to have_http_status(:not_found)
+      end
+>>>>>>> e0266e2d... Fix RSpec + Routes
     end
   end
 


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove the duplicated user#destroy endpoint.

**Propose a new template for "admin" specs:**
In specs, it can be difficult to differentiate regular user specs from "admin" users specs.
1. The roles/permissions are set on top of the resource spec files (this can be moved in another module eventually)

```
  let(:<permission>_role) { create(:role) }
  let(:<permission>_permission) { create(:permission, name: '<permission>') }
  let(:<permission>_role_permission) do
    create(:role_permission,
           role: <permission>_role,
           permission: <permission>_permission,
           value: 'true',
           provider: 'greenlight')
  end
```

2. A context is created inside the `describe <endpoint>`

```
describe 'some#endpoint' do
  it 'does something' do 
    test something
  end

  context 'user with <permission> is doing something' do
     before do 
       <permission>_role_permission ## instantiate the role_permission
       user.update!(role: <permission>_role) ## assign current_user the permission
     end

     it 'does something' do 
       test something
     end 
end
```

