### PR TITLE
Remove admin::create_server_room endpoint duplication

### DIFF
--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -4,52 +4,17 @@ module Api
   module V1
     module Admin
       class UsersController < ApiController
-        before_action :find_user, only: :destroy
-
-        before_action only: %i[destroy create_server_room] do
+        before_action only: %i[active_users] do
           ensure_authorized('ManageUsers')
         end
 
         include Avatarable
-
-        # TODO: Remove duplication, use destroy from users_controller instead
-        def destroy
-          # TODO: Will need to add additional logic later
-          if @user.destroy
-            render_data status: :ok
-          else
-            render_error errors: @user.errors.to_a
-          end
-        end
 
         def active_users
           # TODO: Change to get active users only
           pagy, users = pagy_array(User.with_attached_avatar.all.search(params[:search]))
 
           render_data data: users, meta: pagy_metadata(pagy), serializer: ServerUserSerializer, status: :ok
-        end
-
-        # POST /api/v1/admin/users/:user_id/create_server_room.json
-        # Expects: {}
-        # Returns: { data: Array[serializable objects] , errors: Array[String] }
-        # Does: Creates a server room for a given user.
-
-        def create_server_room
-          user = User.find params[:user_id]
-          room = Room.create!(create_server_room_params.merge(user_id: user.id))
-
-          logger.info "room(friendly_id):#{room.friendly_id} created for user(id):#{room.user_id}"
-          render_data status: :created
-        end
-
-        private
-
-        def create_server_room_params
-          params.require(:room).permit(:name)
-        end
-
-        def find_user
-          @user = User.find params[:id]
         end
       end
     end

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -10,7 +10,7 @@ module Api
 
       skip_before_action :ensure_authenticated, only: %i[show]
       before_action only: %i[show] do
-        ensure_authorized('ManageRooms')
+        ensure_authorized('ManageRooms', friendly_id: params[:friendly_id])
       end
       before_action only: %i[create] do
         ensure_authorized('ManageUsers', user_id: room_params[:user_id])

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -13,7 +13,7 @@ module Api
         ensure_authorized('ManageRooms')
       end
       before_action only: %i[create] do
-        ensure_authorized('ManageUsers', user_id: params[:user_id])
+        ensure_authorized('ManageUsers', user_id: room_params[:user_id])
       end
 
       include Avatarable
@@ -41,13 +41,13 @@ module Api
       def create
         # TODO: amir - ensure accessibility for authenticated requests only.
         # The created room will be the current user's unless a user_id param is provided with the request.
-        user_id = room_params[:user_id] || current_user.id
-        room = Room.create(name: room_params[:name], user_id:)
+        # user_id = room_params[:user_id]
+        room = Room.create(name: room_params[:name], user_id: room_params[:user_id])
 
         return render_error errors: user.errors.to_a if hcaptcha_enabled? && !verify_hcaptcha(response: params[:token])
 
         if room.save
-          logger.info "room(friendly_id):#{room.friendly_id} created for user(id):#{user_id}"
+          logger.info "room(friendly_id):#{room.friendly_id} created for user(id):#{room.user_id}"
           render_data status: :created
         else
           render_error status: :bad_request

--- a/app/javascript/components/admin/manage_users/ManageUserRow.jsx
+++ b/app/javascript/components/admin/manage_users/ManageUserRow.jsx
@@ -14,7 +14,7 @@ import useCreateServerRoom from '../../../hooks/mutations/admin/manage_users/use
 import DeleteUserForm from './forms/DeleteUserForm';
 
 export default function ManageUserRow({ user }) {
-  const mutationWrapper = (args) => useCreateServerRoom({ userID: user.id, ...args });
+  const mutationWrapper = (args) => useCreateServerRoom({ userId: user.id, ...args });
 
   return (
     <tr key={user.id} className="align-middle text-muted">
@@ -47,7 +47,7 @@ export default function ManageUserRow({ user }) {
                 <Modal
                   modalButton={<NavDropdown.Item><HomeIcon className="hi-s" /> Create Room</NavDropdown.Item>}
                   title="Create New Room"
-                  body={<CreateRoomForm mutation={mutationWrapper} />}
+                  body={<CreateRoomForm mutation={mutationWrapper} userId={user.id} />}
                 />
               </NavDropdown>
             </div>

--- a/app/javascript/components/rooms/RoomsList.jsx
+++ b/app/javascript/components/rooms/RoomsList.jsx
@@ -10,10 +10,13 @@ import RoomPlaceHolder from './RoomPlaceHolder';
 import Modal from '../shared_components/modals/Modal';
 import CreateRoomForm from './room/forms/CreateRoomForm';
 import SearchBar from '../shared_components/search/SearchBar';
+import { useAuth } from '../../contexts/auth/AuthProvider';
 
 export default function RoomsList() {
   const { isLoading, data: rooms } = useRooms();
   const [search, setSearch] = useState('');
+  const currentUser = useAuth();
+  const mutationWrapper = (args) => useCreateRoom({ userId: currentUser.id, ...args });
 
   if (isLoading) return <Spinner />;
 
@@ -26,7 +29,7 @@ export default function RoomsList() {
         <Modal
           modalButton={<Button variant="brand" className="ms-auto">+ New Room </Button>}
           title="Create New Room"
-          body={<CreateRoomForm mutation={useCreateRoom} />}
+          body={<CreateRoomForm mutation={mutationWrapper} userId={currentUser.id} />}
         />
       </Stack>
       <Row md={4} className="g-4 pb-4 mt-4">

--- a/app/javascript/components/rooms/room/forms/CreateRoomForm.jsx
+++ b/app/javascript/components/rooms/room/forms/CreateRoomForm.jsx
@@ -10,11 +10,11 @@ import FormControl from '../../../shared_components/forms/FormControl';
 import { createRoomFormConfig, createRoomFormFields } from '../../../../helpers/forms/CreateRoomFormHelpers';
 import { useAuth } from '../../../../contexts/auth/AuthProvider';
 
-export default function CreateRoomForm({ mutation: useCreateRoomAPI, handleClose }) {
+export default function CreateRoomForm({ mutation: useCreateRoomAPI, userId, handleClose }) {
   const currentUser = useAuth();
   const createRoomAPI = useCreateRoomAPI({ onSettled: handleClose, id: currentUser.id });
+  createRoomFormConfig.defaultValues.user_id = userId;
   const methods = useForm(createRoomFormConfig);
-
   const { name } = createRoomFormFields;
 
   return (
@@ -36,6 +36,7 @@ export default function CreateRoomForm({ mutation: useCreateRoomAPI, handleClose
 CreateRoomForm.propTypes = {
   handleClose: PropTypes.func,
   mutation: PropTypes.func.isRequired,
+  userId: PropTypes.string.isRequired,
 };
 
 CreateRoomForm.defaultProps = {

--- a/app/javascript/components/rooms/room/forms/CreateRoomForm.jsx
+++ b/app/javascript/components/rooms/room/forms/CreateRoomForm.jsx
@@ -8,9 +8,11 @@ import Form from '../../../shared_components/forms/Form';
 import Spinner from '../../../shared_components/utilities/Spinner';
 import FormControl from '../../../shared_components/forms/FormControl';
 import { createRoomFormConfig, createRoomFormFields } from '../../../../helpers/forms/CreateRoomFormHelpers';
+import { useAuth } from '../../../../contexts/auth/AuthProvider';
 
 export default function CreateRoomForm({ mutation: useCreateRoomAPI, handleClose }) {
-  const createRoomAPI = useCreateRoomAPI({ onSettled: handleClose });
+  const currentUser = useAuth();
+  const createRoomAPI = useCreateRoomAPI({ onSettled: handleClose, id: currentUser.id });
   const methods = useForm(createRoomFormConfig);
 
   const { name } = createRoomFormFields;

--- a/app/javascript/components/rooms/room/forms/CreateRoomForm.jsx
+++ b/app/javascript/components/rooms/room/forms/CreateRoomForm.jsx
@@ -12,7 +12,7 @@ import { useAuth } from '../../../../contexts/auth/AuthProvider';
 
 export default function CreateRoomForm({ mutation: useCreateRoomAPI, userId, handleClose }) {
   const currentUser = useAuth();
-  const createRoomAPI = useCreateRoomAPI({ onSettled: handleClose, id: currentUser.id });
+  const createRoomAPI = useCreateRoomAPI({ onSettled: handleClose, user_id: currentUser.id });
   createRoomFormConfig.defaultValues.user_id = userId;
   const methods = useForm(createRoomFormConfig);
   const { name } = createRoomFormFields;

--- a/app/javascript/helpers/forms/CreateRoomFormHelpers.jsx
+++ b/app/javascript/helpers/forms/CreateRoomFormHelpers.jsx
@@ -11,6 +11,7 @@ export const createRoomFormConfig = {
   criteriaMode: 'all',
   defaultValues: {
     name: '',
+    user_id: '',
   },
   resolver: yupResolver(validationSchema),
 };

--- a/app/javascript/hooks/mutations/admin/manage_users/useCreateServerRoom.jsx
+++ b/app/javascript/hooks/mutations/admin/manage_users/useCreateServerRoom.jsx
@@ -2,11 +2,11 @@ import { useMutation, useQueryClient } from 'react-query';
 import { toast } from 'react-hot-toast';
 import axios from '../../../../helpers/Axios';
 
-export default function useCreateServerRoom({ userID, onSettled }) {
+export default function useCreateServerRoom({ userId, onSettled }) {
   const queryClient = useQueryClient();
 
   return useMutation(
-    (room) => axios.post(`/admin/users/${userID}/create_server_room.json`, { room }),
+    (room) => axios.post('/rooms.json', { room, user_id: userId }),
     {
       onSuccess: () => {
         queryClient.invalidateQueries('getServerRooms');

--- a/app/javascript/hooks/mutations/rooms/useCreateRoom.jsx
+++ b/app/javascript/hooks/mutations/rooms/useCreateRoom.jsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from 'react-query';
 import { toast } from 'react-hot-toast';
 import axios from '../../../helpers/Axios';
 
-export default function useCreateRoom({ onSettled, id }) {
+export default function useCreateRoom({ userId, onSettled }) {
   const ROOMSLISTQUERYKEY = 'getRooms'; // TODO: amir - create a central store for query keys.
   const queryClient = useQueryClient();
 
@@ -26,7 +26,7 @@ export default function useCreateRoom({ onSettled, id }) {
   };
 
   return useMutation(
-    (room) => axios.post('/rooms.json', { room, id }),
+    (room) => axios.post('/rooms.json', { room, user_id: userId }),
     { // Mutation config.
       onMutate: optimisticCreateRoom,
       onSuccess: () => { toast.success('Room created'); },

--- a/app/javascript/hooks/mutations/rooms/useCreateRoom.jsx
+++ b/app/javascript/hooks/mutations/rooms/useCreateRoom.jsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from 'react-query';
 import { toast } from 'react-hot-toast';
 import axios from '../../../helpers/Axios';
 
-export default function useCreateRoom({ onSettled }) {
+export default function useCreateRoom({ onSettled, id }) {
   const ROOMSLISTQUERYKEY = 'getRooms'; // TODO: amir - create a central store for query keys.
   const queryClient = useQueryClient();
 
@@ -26,7 +26,7 @@ export default function useCreateRoom({ onSettled }) {
   };
 
   return useMutation(
-    (room) => axios.post('/rooms.json', { room }),
+    (room) => axios.post('/rooms.json', { room, id }),
     { // Mutation config.
       onMutate: optimisticCreateRoom,
       onSuccess: () => { toast.success('Room created'); },

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -113,7 +113,8 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
       {
         user_id: user.id,
         room: {
-          name: Faker::Name.name
+          name: Faker::Name.name,
+          user_id: user.id
         }
       }
     end
@@ -126,7 +127,7 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
     end
 
     it 'cannot create a room for another user' do
-      room_params[:user_id] = new_user.id
+      room_params[:room][:user_id] = new_user.id
       expect { post :create, params: room_params }.not_to(change { new_user.rooms.count })
       expect(response).to have_http_status(:forbidden)
     end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Based on #3757 and #3765 

## Description
<!--- Describe your changes in detail -->
Remove the admin::manage_user#create_server_room endpoint.
Use of room#create instead.

The request to create a room must now contain the following structure:

```
params: {
  user_id: <current_user_id>,
  room: {
    name: <room name>,
    user_id: <room_owner_user_id>
  }
}
```

The user_id on top of the request is the current_user, or the creator of the request - a user without the ManageUsers permission has to authentify that he is creating a room for himself. .
The user_id encapsulated into room is the (to be) room owner. 




## Testing Steps
<!--- Please describe in detail how to test your changes. -->

- Create a room as a regular user
- Create a room for someone else as an admin 
- (try to) Create a room for someone else as a regular user