### PR TITLE
Access Codes: Added Access codes auto generation on certain configs [OPTIMIZED].

### DIFF
--- a/app/models/meeting_option.rb
+++ b/app/models/meeting_option.rb
@@ -31,4 +31,13 @@ class MeetingOption < ApplicationRecord
         rooms_configurations: { provider: }
       )
   end
+
+  def self.access_codes_configs(provider:)
+    joins(:rooms_configurations)
+      .where(
+        name: %w[glViewerAccessCode glModeratorAccessCode],
+        rooms_configurations: { provider: }
+      )
+      .pluck(:name, :value)
+  end
 end

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
   describe '#generate_access_code' do
     before do
       allow(MeetingOption).to receive(:get_config_value).and_return(instance_double(RoomMeetingOption, { value: %w[optional true].sample }))
+      allow_any_instance_of(Room).to receive(:auto_generate_access_codes).and_return(nil)
     end
 
     context 'bbb_role == "Viewer"' do

--- a/spec/models/meeting_option_spec.rb
+++ b/spec/models/meeting_option_spec.rb
@@ -74,5 +74,17 @@ RSpec.describe MeetingOption, type: :model do
         end
       end
     end
+
+    describe '#access_codes_configs' do
+      it 'returns the access codes configs pluck(:name, :value)' do
+        viewer_code_conf = create(:meeting_option, name: 'glViewerAccessCode')
+        moderator_code_conf = create(:meeting_option, name: 'glModeratorAccessCode')
+        create(:rooms_configuration, meeting_option: viewer_code_conf, provider: 'greenlight', value: 'true')
+        create(:rooms_configuration, meeting_option: moderator_code_conf, provider: 'greenlight', value: 'false')
+
+        res = described_class.access_codes_configs(provider: 'greenlight')
+        expect(res).to match_array([%w[glViewerAccessCode true], %w[glModeratorAccessCode false]])
+      end
+    end
   end
 end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Synchronizing the rooms access codes settings with their rooms configs.

This PR:

- Edits `Rooms` model to add in the capability to auto generate access codes on rooms creation and first interaction after having forced enabled configs.


## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
