### PR TITLE
Room settings: Upgraded `RoomSettingsGetter` service.

### DIFF
--- a/app/controllers/api/v1/room_settings_controller.rb
+++ b/app/controllers/api/v1/room_settings_controller.rb
@@ -7,7 +7,7 @@ module Api
 
       # GET /api/v1/room_settings/:friendly_id
       def show
-        options = RoomSettingsGetter.new(room_id: @room.id, provider: current_provider).call
+        options = RoomSettingsGetter.new(room_id: @room.id, provider: current_provider, only_enabled: true).call
 
         render_data data: options, status: :ok
       end

--- a/app/services/room_settings_getter.rb
+++ b/app/services/room_settings_getter.rb
@@ -7,9 +7,10 @@ class RoomSettingsGetter
   # Hash(`<option_name> => {'true' => <Postive>, 'false' => <Negative>})`
   SPECIAL_OPTIONS = { 'guestPolicy' => { 'true' => 'ASK_MODERATOR', 'false' => 'ALWAYS_ACCEPT' } }.freeze
 
-  def initialize(room_id:, provider:, only_bbb_options: false)
+  def initialize(room_id:, provider:, only_enabled: false, only_bbb_options: false)
     @room_id = room_id
     @only_bbb_options = only_bbb_options
+    @only_enabled = only_enabled
     # Fetching only rooms configs that are not optional to overwrite the settings values.
     @rooms_configs = MeetingOption.joins(:rooms_configurations)
                                   .where(rooms_configurations: { provider: })
@@ -23,7 +24,25 @@ class RoomSettingsGetter
     room_settings = room_settings.where.not('name ILIKE :prefix', prefix: 'gl%') if @only_bbb_options
     room_settings = room_settings.pluck(:name, :value).to_h
 
+    access_codes = room_settings.slice('glViewerAccessCode', 'glModeratorAccessCode') # Holding room original access code values.
+
     room_settings.merge!(@rooms_configs) # Merging rooms settings with its none optional configurations prioritizing forced configs over settings.
+
+    filter_disabled(room_settings:) if @only_enabled # Only enabled(optional|force enabled) setting values will be returned.
+    infer_specials(room_settings:) # Special options should map their forced values to what was configured in `SPECIAL_OPTIONS` registry.
+    infer_codes(room_settings:, access_codes:) # Access codes should map their forced values as intended.
+
+    room_settings
+  end
+
+  private
+
+  def filter_disabled(room_settings:)
+    disabled_settings = @rooms_configs.filter { |_k, v| v == 'false' }
+    room_settings.except!(*disabled_settings.keys)
+  end
+
+  def infer_specials(room_settings:)
     room_settings_special_options = SPECIAL_OPTIONS.slice(*room_settings.keys) # Extracting the room settings special options to minimize iterations.
 
     # Configs are enum of ['true', 'false', 'optional'], after merging none optional settings with their configs only the room
@@ -32,7 +51,16 @@ class RoomSettingsGetter
       config = room_settings[name]
       room_settings[name] = SPECIAL_OPTIONS[name][config] if %w[true false].include? config # Config values are expected to be 'true'|'false'
     end
+  end
 
-    room_settings
+  def infer_codes(room_settings:, access_codes:)
+    access_codes.each do |key, code|
+      case room_settings[key]
+      when 'false'
+        room_settings[key] = '' # Forced disbaled access code will have an empty value.
+      when 'true'
+        room_settings[key] = code # Forced enabled access code will conserve its   original value.
+      end
+    end
   end
 end

--- a/spec/controllers/room_settings_controller_spec.rb
+++ b/spec/controllers/room_settings_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Api::V1::RoomSettingsController, type: :controller do
     end
 
     it 'uses "RoomSettingGetter" service and render its returned value' do
-      expect(RoomSettingsGetter).to receive(:new).with(room_id: room.id, provider: 'greenlight')
+      expect(RoomSettingsGetter).to receive(:new).with(room_id: room.id, provider: 'greenlight', only_enabled: true)
       expect(room_setting_getter_service).to receive(:call)
 
       get :show, params: { friendly_id: room.friendly_id }

--- a/spec/services/room_settings_getter_spec.rb
+++ b/spec/services/room_settings_getter_spec.rb
@@ -60,7 +60,7 @@ describe RoomSettingsGetter, type: :service do
     end
 
     context 'bbb options only' do
-      it 'returns a filtered Hash("name" => "value") of room settings that does not start with a :prefix' do
+      it 'returns a filtered Hash("name" => "value") of room settings that does not start with "bbb" prefix' do
         room = create(:room)
         setting1 = create(:meeting_option, name: 'glSetting')
         setting2 = create(:meeting_option, name: 'GlGLSetting')
@@ -78,6 +78,81 @@ describe RoomSettingsGetter, type: :service do
 
         expect(res).to eq({
                             'YourOnlyBBBSetting' => 'BBB'
+                          })
+      end
+    end
+
+    context 'enabled options only' do
+      it 'returns a filtered Hash("name => "value") of room settings that are not forced disabled (optional|forced enabled)' do
+        room = create(:room)
+        setting1 = create(:meeting_option, name: 'disabledOne')
+        setting2 = create(:meeting_option, name: 'disabledTwo')
+        setting3 = create(:meeting_option, name: 'forcedEnabled')
+        setting4 = create(:meeting_option, name: 'optional')
+
+        create(:room_meeting_option, room:, meeting_option: setting1, value: 'disabled')
+        create(:room_meeting_option, room:, meeting_option: setting2, value: 'disabled')
+        create(:room_meeting_option, room:, meeting_option: setting3, value: 'enabled')
+        create(:room_meeting_option, room:, meeting_option: setting4, value: 'optional')
+
+        create(:rooms_configuration, meeting_option: setting1, provider: 'greenlight', value: 'false')
+        create(:rooms_configuration, meeting_option: setting2, provider: 'greenlight', value: 'false')
+        create(:rooms_configuration, meeting_option: setting3, provider: 'greenlight', value: 'true')
+        create(:rooms_configuration, meeting_option: setting4, provider: 'greenlight', value: 'optional')
+
+        res = described_class.new(room_id: room.id, provider: 'greenlight', only_enabled: true).call
+
+        expect(res).to eq({
+                            'forcedEnabled' => 'true',
+                            'optional' => 'optional'
+                          })
+      end
+    end
+
+    context 'access codes' do
+      it 'returns an empty code for forced disabled access codes' do
+        room = create(:room)
+        viewer_access_code = create(:meeting_option, name: 'glViewerAccessCode')
+        moderator_access_code = create(:meeting_option, name: 'glModeratorAccessCode')
+        setting = create(:meeting_option, name: 'setting')
+
+        create(:room_meeting_option, room:, meeting_option: viewer_access_code, value: 'VIEWER')
+        create(:room_meeting_option, room:, meeting_option: moderator_access_code, value: 'MODERATOR')
+        create(:room_meeting_option, room:, meeting_option: setting, value: 'VALUE')
+
+        create(:rooms_configuration, meeting_option: viewer_access_code, provider: 'greenlight', value: 'false')
+        create(:rooms_configuration, meeting_option: moderator_access_code, provider: 'greenlight', value: 'false')
+        create(:rooms_configuration, meeting_option: setting, provider: 'greenlight', value: 'optional')
+
+        res = described_class.new(room_id: room.id, provider: 'greenlight').call
+
+        expect(res).to eq({
+                            'setting' => 'VALUE',
+                            'glViewerAccessCode' => '',
+                            'glModeratorAccessCode' => ''
+                          })
+      end
+
+      it 'returns access code value when enabled (optional|forced enabled)' do
+        room = create(:room)
+        viewer_access_code = create(:meeting_option, name: 'glViewerAccessCode')
+        moderator_access_code = create(:meeting_option, name: 'glModeratorAccessCode')
+        setting = create(:meeting_option, name: 'setting')
+
+        create(:room_meeting_option, room:, meeting_option: viewer_access_code, value: 'VIEWER')
+        create(:room_meeting_option, room:, meeting_option: moderator_access_code, value: 'MODERATOR')
+        create(:room_meeting_option, room:, meeting_option: setting, value: 'VALUE')
+
+        create(:rooms_configuration, meeting_option: viewer_access_code, provider: 'greenlight', value: 'true')
+        create(:rooms_configuration, meeting_option: moderator_access_code, provider: 'greenlight', value: 'optional')
+        create(:rooms_configuration, meeting_option: setting, provider: 'greenlight', value: 'optional')
+
+        res = described_class.new(room_id: room.id, provider: 'greenlight').call
+
+        expect(res).to eq({
+                            'setting' => 'VALUE',
+                            'glViewerAccessCode' => 'VIEWER',
+                            'glModeratorAccessCode' => 'MODERATOR'
                           })
       end
     end


### PR DESCRIPTION
	+ Added access codes handling to the service.
	+ Added `only_enabled` mode to fetch only enabled options.

<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
