### PR TITLE
Add named arguments to the ensure_authorized method

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -6,7 +6,7 @@ module Api
       skip_before_action :ensure_authenticated, only: %i[create]
 
       before_action only: %i[update purge_avatar] do
-        ensure_authorized('ManageUsers')
+        ensure_authorized('ManageUsers', user_id: params[:id])
       end
 
       def show

--- a/app/controllers/concerns/authorizable.rb
+++ b/app/controllers/concerns/authorizable.rb
@@ -14,14 +14,14 @@ module Authorizable
   end
 
   # PermissionsChecker service will return a true or false depending on whether the current_user's role has the provided permission_name
-  def ensure_authorized(permission_name)
+  def ensure_authorized(permission_name, user_id: '', friendly_id: '', record_id: '')
     # TODO: - should this return a status: :not_found instead of :unauthorized if the user doesn't have the permission AND the param doesn't exists?
     return render_error status: :forbidden unless PermissionsChecker.new(
       current_user:,
       permission_name:,
-      user_id: params[:id],
-      friendly_id: params[:friendly_id],
-      record_id: params[:record_id]
+      user_id:,
+      friendly_id:,
+      record_id:
     ).call
   end
 

--- a/app/controllers/concerns/authorizable.rb
+++ b/app/controllers/concerns/authorizable.rb
@@ -14,7 +14,7 @@ module Authorizable
   end
 
   # PermissionsChecker service will return a true or false depending on whether the current_user's role has the provided permission_name
-  def ensure_authorized(permission_name, user_id: '', friendly_id: '', record_id: '')
+  def ensure_authorized(permission_name, user_id: nil, friendly_id: nil, record_id: nil)
     # TODO: - should this return a status: :not_found instead of :unauthorized if the user doesn't have the permission AND the param doesn't exists?
     return render_error status: :forbidden unless PermissionsChecker.new(
       current_user:,

--- a/app/services/permissions_checker.rb
+++ b/app/services/permissions_checker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PermissionsChecker
-  def initialize(current_user:, permission_name:, user_id: '', friendly_id: '', record_id: '')
+  def initialize(current_user:, permission_name:, user_id:, friendly_id:, record_id:)
     @current_user = current_user
     @permission_name = permission_name
     @user_id = user_id

--- a/spec/services/permissions_checker_spec.rb
+++ b/spec/services/permissions_checker_spec.rb
@@ -10,17 +10,35 @@ describe PermissionsChecker, type: :service do
   describe '#call' do
     it 'returns true if the user role has the provided permission' do
       create(:role_permission, role:, permission:, value: 'true', provider: 'greenlight')
-      expect(described_class.new(current_user: user, permission_name: permission.name).call).to be(true)
+      expect(described_class.new(
+        current_user: user,
+        permission_name: permission.name,
+        user_id: '',
+        friendly_id: '',
+        record_id: ''
+      ).call).to be(true)
     end
 
     it 'returns false if the user role does not have the provided permission' do
       create(:role_permission, role:, permission:, value: 'false', provider: 'greenlight')
-      expect(described_class.new(current_user: user, permission_name: permission.name).call).to be(false)
+      expect(described_class.new(
+        current_user: user,
+        permission_name: permission.name,
+        user_id: '',
+        friendly_id: '',
+        record_id: ''
+      ).call).to be(false)
     end
 
     it 'returns true if the user is trying to act on itself without having the ManageUsers permission' do
       create(:role_permission, role:, permission:, value: 'false', provider: 'greenlight')
-      expect(described_class.new(current_user: user, permission_name: 'ManageUsers', user_id: user.id).call).to be(true)
+      expect(described_class.new(
+        current_user: user,
+        permission_name: 'ManageUsers',
+        user_id: user.id,
+        friendly_id: '',
+        record_id: ''
+      ).call).to be(true)
     end
   end
 end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add user_id, friendly_id, and record_id as named argument for the `ensure_authorized` method.
This change lets us pass the <user resource> param id into the `before_action` callback. 
