### PR TITLE
Refactor Specs - use of user traits for admin specs

### DIFF
--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -6,7 +6,7 @@ module Api
       before_action :find_room, only: %i[start join status]
       skip_before_action :ensure_authenticated, only: %i[join status]
       before_action only: %i[start] do
-        ensure_authorized('ManageRooms')
+        ensure_authorized('ManageRooms', friendly_id: params[:friendly_id])
       end
 
       # POST /api/v1/meetings/:friendly_id/start.json

--- a/spec/controllers/admin/roles_controller_spec.rb
+++ b/spec/controllers/admin/roles_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::Admin::RolesController, type: :controller do
   let(:user) { create(:user) }
-  let(:user_with_manage_roles_permission) { create(:user, :manage_roles) }
+  let(:user_with_manage_roles_permission) { create(:user, :with_manage_roles_permission) }
 
   before do
     request.headers['ACCEPT'] = 'application/json'

--- a/spec/controllers/admin/roles_controller_spec.rb
+++ b/spec/controllers/admin/roles_controller_spec.rb
@@ -3,18 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::Admin::RolesController, type: :controller do
-  let(:admin_user) { create(:user, :manage_roles) }
   let(:user) { create(:user) }
+  let(:user_with_manage_roles_permission) { create(:user, :manage_roles) }
 
   before do
     request.headers['ACCEPT'] = 'application/json'
-    session[:user_id] = admin_user.id
+    session[:user_id] = user_with_manage_roles_permission.id
   end
 
   describe 'roles#index' do
     it 'returns the list of roles' do
       roles = [create(:role, name: 'Hokage'), create(:role, name: 'Jonin'), create(:role, name: 'Chunin')]
-      roles << admin_user.role
+      roles << user_with_manage_roles_permission.role
 
       get :index
       expect(response).to have_http_status(:ok)
@@ -49,7 +49,7 @@ RSpec.describe Api::V1::Admin::RolesController, type: :controller do
     end
 
     context 'ordering' do
-      let(:roles) { ['P', 'M', 'I', admin_user.role.name] }
+      let(:roles) { ['P', 'M', 'I', user_with_manage_roles_permission.role.name] }
 
       before do
         create(:role, name: 'M')
@@ -180,7 +180,7 @@ RSpec.describe Api::V1::Admin::RolesController, type: :controller do
     end
 
     it 'fails to remove roles with dependant users with :internal_server_error' do
-      expect { delete :destroy, params: { id: admin_user.role.id } }.not_to change(Role, :count).from(1)
+      expect { delete :destroy, params: { id: user_with_manage_roles_permission.role.id } }.not_to change(Role, :count).from(1)
       expect(response).to have_http_status(:internal_server_error)
     end
 

--- a/spec/controllers/admin/server_rooms_controller_spec.rb
+++ b/spec/controllers/admin/server_rooms_controller_spec.rb
@@ -3,19 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::Admin::ServerRoomsController, type: :controller do
-  let(:role) { create(:role) }
-  let(:user) { create(:user, role:) }
-  let(:manage_rooms_permission) { create(:permission, name: 'ManageRooms') }
-  let!(:manage_rooms_role_permission) do
-    create(:role_permission,
-           role_id: user.role_id,
-           permission_id: manage_rooms_permission.id,
-           value: 'true')
-  end
+  let(:user) { create(:user) }
+  let(:user_with_manage_rooms_permission) { create(:user, :with_manage_rooms_permission)}
 
   before do
     request.headers['ACCEPT'] = 'application/json'
-    session[:user_id] = user.id
+    session[:user_id] = user_with_manage_rooms_permission.id
   end
 
   describe '#index' do
@@ -30,18 +23,6 @@ RSpec.describe Api::V1::Admin::ServerRoomsController, type: :controller do
       get :index
       expect(JSON.parse(response.body)['data'].map { |room| room['friendly_id'] })
         .to match_array(Room.all.pluck(:friendly_id))
-    end
-
-    it 'admin without the ManageRooms right cannot return all the Server Rooms from all users' do
-      user_one = create(:user)
-      user_two = create(:user)
-      manage_rooms_role_permission.update!(value: 'false')
-      create_list(:room, 2, user_id: user_one.id)
-      create_list(:room, 2, user_id: user_two.id)
-
-      allow_any_instance_of(BigBlueButtonApi).to receive(:active_meetings).and_return([])
-      get :index
-      expect(response).to have_http_status(:forbidden)
     end
 
     it 'returns the server room status as active if the meeting has started' do
@@ -68,6 +49,23 @@ RSpec.describe Api::V1::Admin::ServerRoomsController, type: :controller do
       allow_any_instance_of(BigBlueButtonApi).to receive(:active_meetings).and_return([])
       get :index
       expect(JSON.parse(response.body)['data'][0]['active']).to be(false)
+    end
+
+    context 'user without ManageRooms permission' do
+      before do
+        session[:user_id] = user.id
+      end
+
+      it 'cannot return the Server Rooms' do
+        user_one = create(:user)
+        user_two = create(:user)
+        create_list(:room, 2, user_id: user_one.id)
+        create_list(:room, 2, user_id: user_two.id)
+
+        allow_any_instance_of(BigBlueButtonApi).to receive(:active_meetings).and_return([])
+        get :index
+        expect(response).to have_http_status(:forbidden)
+      end
     end
   end
 

--- a/spec/controllers/admin/server_rooms_controller_spec.rb
+++ b/spec/controllers/admin/server_rooms_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::Admin::ServerRoomsController, type: :controller do
   let(:user) { create(:user) }
-  let(:user_with_manage_rooms_permission) { create(:user, :with_manage_rooms_permission)}
+  let(:user_with_manage_rooms_permission) { create(:user, :with_manage_rooms_permission) }
 
   before do
     request.headers['ACCEPT'] = 'application/json'

--- a/spec/controllers/admin/site_settings_controller_spec.rb
+++ b/spec/controllers/admin/site_settings_controller_spec.rb
@@ -3,19 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::Admin::SiteSettingsController, type: :controller do
-  let(:manage_site_settings_role) { create(:role) }
-  let(:user) { create(:user, role: manage_site_settings_role) }
-  let(:manage_site_settings_permission) { create(:permission, name: 'ManageSiteSettings') }
-  let!(:manage_site_settings_role_permission) do
-    create(:role_permission,
-           role: manage_site_settings_role,
-           permission: manage_site_settings_permission,
-           value: 'true')
-  end
+  let(:user) { create(:user) }
+  let(:user_with_manage_site_settings_permission) { create(:user, :with_manage_site_settings_permission) }
 
   before do
     request.headers['ACCEPT'] = 'application/json'
-    session[:user_id] = user.id
+    session[:user_id] = user_with_manage_site_settings_permission.id
   end
 
   describe '#index' do
@@ -27,7 +20,7 @@ RSpec.describe Api::V1::Admin::SiteSettingsController, type: :controller do
 
     context 'user without ManageSiteSettings permission' do
       before do
-        manage_site_settings_role_permission.update!(value: 'false')
+        session[:user_id] = user.id
       end
 
       it 'cant return all the SiteSettings' do
@@ -48,7 +41,7 @@ RSpec.describe Api::V1::Admin::SiteSettingsController, type: :controller do
 
     context 'user without ManageSiteSettings permission' do
       before do
-        manage_site_settings_role_permission.update!(value: 'false')
+        session[:user_id] = user.id
       end
 
       it 'cant update the value of SiteSetting' do

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -4,28 +4,19 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::Admin::UsersController, type: :controller do
   let(:user) { create(:user) }
-
-  let(:manage_users_role) { create(:role) }
-  let(:manage_users_permission) { create(:permission, name: 'ManageUsers') }
-  let(:manage_users_role_permission) do
-    create(:role_permission,
-           role: manage_users_role,
-           permission: manage_users_permission,
-           value: 'true')
-  end
+  let(:user_with_manage_users_permission) { create(:user, :with_manage_users_permission) }
 
   before do
     request.headers['ACCEPT'] = 'application/json'
-    session[:user_id] = user.id
-    manage_users_role_permission
-    user.update!(role: manage_users_role)
+    session[:user_id] = user_with_manage_users_permission.id
   end
 
   describe '#active_users' do
-    it 'ids of rooms in response are matching room ids that belong to current_user' do
-      # TODO: Change this test to create active users and not just any users
-      users = create_list(:user, 3)
-      users << user
+    it 'returns the list of active users' do
+      # TODO: this test doesnt test anything
+      # TODO: active, banned, etc users feature has not been implemented yet (19.08)
+      # TODO: Change this test to return active users and not just any users
+      users = User.all
 
       get :active_users
       expect(response).to have_http_status(:ok)

--- a/spec/controllers/shared_accesses_controller_spec.rb
+++ b/spec/controllers/shared_accesses_controller_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::SharedAccessesController, type: :controller do
   let(:user) { create(:user) }
-  let(:shared_list_role) { create(:role) }
-  let(:shared_list_permission) { create(:permission, name: 'SharedList') }
 
   before do
     request.headers['ACCEPT'] = 'application/json'
@@ -57,7 +55,7 @@ RSpec.describe Api::V1::SharedAccessesController, type: :controller do
   end
 
   describe '#shareable_users' do
-    it 'returns no users since they dont have SharedList permission' do
+    it 'does not return the users without SharedList permission' do
       room = create(:room)
       room.shared_users = create_list(:user, 5)
       shareable_users = create_list(:user, 5)
@@ -68,20 +66,11 @@ RSpec.describe Api::V1::SharedAccessesController, type: :controller do
       expect(response_users_ids).to match_array([])
     end
 
-    context 'users are given SharedList permission' do
-      before do
-        user.update!(role: shared_list_role)
-        create(:role_permission,
-               role: shared_list_role,
-               permission: shared_list_permission,
-               value: 'true')
-      end
-
+    context 'users with SharedList permission' do
       it 'returns the users that the room can be shared to' do
         room = create(:room)
-        room.shared_users = create_list(:user, 5)
-        shareable_users = create_list(:user, 5, role: shared_list_role)
-        shareable_users << user
+        room.shared_users = create_list(:user, 5, :with_shared_list_permission)
+        shareable_users = create_list(:user, 5, :with_shared_list_permission)
 
         get :shareable_users, params: { friendly_id: room.friendly_id, search: '' }
         response_users_ids = JSON.parse(response.body)['data'].map { |user| user['id'] }
@@ -91,7 +80,7 @@ RSpec.describe Api::V1::SharedAccessesController, type: :controller do
       it 'returns the shareable users according to the query' do
         room = create(:room)
         room.shared_users = create_list(:user, 5)
-        shareable_users = create_list(:user, 5, name: 'Jane Doe', role: shared_list_role)
+        shareable_users = create_list(:user, 5, :with_shared_list_permission, name: 'Jane Doe')
 
         get :shareable_users, params: { friendly_id: room.friendly_id, search: 'Jane Doe' }
         response_users_ids = JSON.parse(response.body)['data'].map { |user| user['id'] }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -4,15 +4,16 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::UsersController, type: :controller do
   let(:user) { create(:user) }
+  let(:user_with_manage_users_permission) { create(:user, :manage_users) }
 
-  let(:manage_users_role) { create(:role) }
-  let(:manage_users_permission) { create(:permission, name: 'ManageUsers') }
-  let!(:manage_users_role_permission) do
-    create(:role_permission,
-           role: manage_users_role,
-           permission: manage_users_permission,
-           value: 'true')
-  end
+  # let(:manage_users_role) { create(:role) }
+  # let(:manage_users_permission) { create(:permission, name: 'ManageUsers') }
+  # let!(:manage_users_role_permission) do
+  #   create(:role_permission,
+  #          role: manage_users_role,
+  #          permission: manage_users_permission,
+  #          value: 'true')
+  # end
 
   before do
     request.headers['ACCEPT'] = 'application/json'
@@ -61,7 +62,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     end
   end
 
-  describe 'POST users#update' do
+  describe '#update' do
     it 'updates the users attributes' do
       updated_params = {
         name: 'New Name',
@@ -104,7 +105,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     end
   end
 
-  describe 'users#destroy' do
+  describe '#destroy' do
     it 'deletes the current_user account' do
       expect(response).to have_http_status(:ok)
       expect { delete :destroy, params: { id: user.id } }.to change(User, :count).by(-1)
@@ -116,9 +117,9 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       expect(response).to have_http_status(:forbidden)
     end
 
-    context 'current_user with ManageUsers permission' do
+    context 'user with ManageUsers permission' do
       before do
-        user.update!(role: manage_users_role)
+        session[:user_id] = user_with_manage_users_permission.id
       end
 
       it 'deletes a user' do
@@ -133,10 +134,10 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     end
   end
 
-  describe 'POST users#change_password' do
+  describe 'change_password' do
     let!(:user) { create(:user, password: 'Test12345678+') }
 
-    before { session[:user_id] = user.id }
+    # before { session[:user_id] = user.id }
 
     it 'changes current_user password if the params are valid' do
       valid_params = { old_password: 'Test12345678+', new_password: 'Glv3IsAwesome!' }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::UsersController, type: :controller do
   let(:user) { create(:user) }
-  let(:user_with_manage_users_permission) { create(:user, :manage_users) }
+  let(:user_with_manage_users_permission) { create(:user, :with_manage_users_permission) }
 
   before do
     request.headers['ACCEPT'] = 'application/json'

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -6,15 +6,6 @@ RSpec.describe Api::V1::UsersController, type: :controller do
   let(:user) { create(:user) }
   let(:user_with_manage_users_permission) { create(:user, :manage_users) }
 
-  # let(:manage_users_role) { create(:role) }
-  # let(:manage_users_permission) { create(:permission, name: 'ManageUsers') }
-  # let!(:manage_users_role_permission) do
-  #   create(:role_permission,
-  #          role: manage_users_role,
-  #          permission: manage_users_permission,
-  #          value: 'true')
-  # end
-
   before do
     request.headers['ACCEPT'] = 'application/json'
     session[:user_id] = user.id
@@ -136,8 +127,6 @@ RSpec.describe Api::V1::UsersController, type: :controller do
 
   describe 'change_password' do
     let!(:user) { create(:user, password: 'Test12345678+') }
-
-    # before { session[:user_id] = user.id }
 
     it 'changes current_user password if the params are valid' do
       valid_params = { old_password: 'Test12345678+', new_password: 'Glv3IsAwesome!' }

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -12,33 +12,45 @@ FactoryBot.define do
     language { %w[en fr es ar].sample }
   end
 
-  trait :manage_users do
+  trait :with_manage_users_permission do
     after(:create) do |user|
       FactoryBot.create(:role_permission, role: user.role, permission: FactoryBot.create(:permission, name: 'ManageUsers'), value: 'true')
     end
   end
 
-  trait :manage_rooms do
+  trait :with_manage_rooms_permission do
     after(:create) do |user|
       FactoryBot.create(:role_permission, role: user.role, permission: FactoryBot.create(:permission, name: 'ManageRooms'), value: 'true')
     end
   end
 
-  trait :manage_recordings do
+  trait :with_manage_recordings_permission do
     after(:create) do |user|
       FactoryBot.create(:role_permission, role: user.role, permission: FactoryBot.create(:permission, name: 'ManageRecordings'), value: 'true')
     end
   end
 
-  trait :manage_site_settings do
+  trait :with_manage_site_settings_permission do
     after(:create) do |user|
       FactoryBot.create(:role_permission, role: user.role, permission: FactoryBot.create(:permission, name: 'ManageSiteSettings'), value: 'true')
     end
   end
 
-  trait :manage_roles do
+  trait :with_manage_roles_permission do
     after(:create) do |user|
       FactoryBot.create(:role_permission, role: user.role, permission: FactoryBot.create(:permission, name: 'ManageRoles'), value: 'true')
+    end
+  end
+
+  trait :with_shared_list_permission do
+    after(:create) do |user|
+      FactoryBot.create(:role_permission, role: user.role, permission: FactoryBot.create(:permission, name: 'SharedList'), value: 'true')
+    end
+  end
+
+  trait :with_create_room_permission do
+    after(:create) do |user|
+      FactoryBot.create(:role_permission, role: user.role, permission: FactoryBot.create(:permission, name: 'CreateRoom'), value: 'true')
     end
   end
 end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Refactor Specs

- most of the work is to add user traits for admin specs
- fix some specs on the fly

## Specs Template

You create a user with a certain permission
`let(:user_with_manage_rooms_permission) { create(:user, :with_manage_rooms_permission)`

In an admin context, you "log in" the user with the permission
```
context 'user with ManageUser permission' do
  before do
    session[:user_id] = user_with_manage_users_permission.id
  end
 
  it "does stuff" do
    do something
  end
end 
```

In admin::controllers specs, you do the reverse: you "log in" the admin first, and "log in" a regular user in a `"user without ManageRooms permission" `context



## Notes
- In admin::controllers specs, we might want to keep the "regular" user as default instead of an "admin" user for a couple of reasons consistency and cases where we need more than one permission in a controller
- There is no tests for using the recordings#update_visibility of another user's recordings
- meetings#start and meetings#join specs are lacking
- admin::rooms_config tests are empty
- active, pending, banned, deleted feature has not been implemented yet
