### PR TITLE
CanRecord Permission

### DIFF
--- a/app/controllers/api/v1/admin/role_permissions_controller.rb
+++ b/app/controllers/api/v1/admin/role_permissions_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class RolePermissionsController < ApiController
+        def index
+          roles_permissions = RolePermission.joins(:permission)
+                                            .where(role_id: @current_user.role_id)
+                                            .pluck(:name, :value)
+                                            .to_h
+
+          render_data data: roles_permissions, status: :ok
+        end
+
+        def update
+          role_permission = RolePermission.joins(:permission).find_by(role_id: role_params[:role_id], permission: { name: role_params[:name] })
+
+          return render_error status: :not_found unless role_permission
+          return render_error status: :bad_request unless role_permission.update(value: role_params[:value].to_s)
+
+          render_data status: :ok
+        end
+
+        private
+
+        def role_params
+          params.require(:role).permit(:role_id, :name, :value)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/role_permissions_controller.rb
+++ b/app/controllers/api/v1/admin/role_permissions_controller.rb
@@ -6,7 +6,7 @@ module Api
       class RolePermissionsController < ApiController
         def index
           roles_permissions = RolePermission.joins(:permission)
-                                            .where(role_id: current_user.role_id)
+                                            .where(role_id: params[:role_id])
                                             .pluck(:name, :value)
                                             .to_h
 

--- a/app/controllers/api/v1/admin/role_permissions_controller.rb
+++ b/app/controllers/api/v1/admin/role_permissions_controller.rb
@@ -6,7 +6,7 @@ module Api
       class RolePermissionsController < ApiController
         def index
           roles_permissions = RolePermission.joins(:permission)
-                                            .where(role_id: @current_user.role_id)
+                                            .where(role_id: current_user.role_id)
                                             .pluck(:name, :value)
                                             .to_h
 

--- a/app/controllers/api/v1/admin/roles_controller.rb
+++ b/app/controllers/api/v1/admin/roles_controller.rb
@@ -5,9 +5,9 @@ module Api
     module Admin
       class RolesController < ApiController
         before_action :find_role, only: %i[update show destroy]
-        # before_action do
-        #   ensure_authorized('ManageRoles')
-        # end
+        before_action do
+          ensure_authorized('ManageRoles')
+        end
 
         # POST /api/v1/admin/roles.json
         # Expects: {}

--- a/app/controllers/api/v1/admin/roles_controller.rb
+++ b/app/controllers/api/v1/admin/roles_controller.rb
@@ -5,9 +5,9 @@ module Api
     module Admin
       class RolesController < ApiController
         before_action :find_role, only: %i[update show destroy]
-        before_action do
-          ensure_authorized('ManageRoles')
-        end
+        # before_action do
+        #   ensure_authorized('ManageRoles')
+        # end
 
         # POST /api/v1/admin/roles.json
         # Expects: {}

--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -21,6 +21,7 @@ module Api
           presentation_url:,
           meeting_ended: meeting_ended_url,
           recording_ready: recording_ready_url,
+          current_user: @current_user,
           provider: current_provider
         ).call
 

--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -21,7 +21,7 @@ module Api
           presentation_url:,
           meeting_ended: meeting_ended_url,
           recording_ready: recording_ready_url,
-          current_user: @current_user,
+          current_user:,
           provider: current_provider
         ).call
 

--- a/app/controllers/api/v1/room_settings_controller.rb
+++ b/app/controllers/api/v1/room_settings_controller.rb
@@ -7,7 +7,7 @@ module Api
 
       # GET /api/v1/room_settings/:friendly_id
       def show
-        options = RoomSettingsGetter.new(room_id: @room.id, provider: current_provider, current_user: @current_user, show_codes: true,
+        options = RoomSettingsGetter.new(room_id: @room.id, provider: current_provider, current_user:, show_codes: true,
                                          only_enabled: true).call
 
         render_data data: options, status: :ok

--- a/app/controllers/api/v1/room_settings_controller.rb
+++ b/app/controllers/api/v1/room_settings_controller.rb
@@ -7,7 +7,8 @@ module Api
 
       # GET /api/v1/room_settings/:friendly_id
       def show
-        options = RoomSettingsGetter.new(room_id: @room.id, provider: current_provider, show_codes: true, only_enabled: true).call
+        options = RoomSettingsGetter.new(room_id: @room.id, provider: current_provider, current_user: @current_user, show_codes: true,
+                                         only_enabled: true).call
 
         render_data data: options, status: :ok
       end

--- a/app/javascript/components/admin/roles/forms/EditRoleForm.jsx
+++ b/app/javascript/components/admin/roles/forms/EditRoleForm.jsx
@@ -9,37 +9,66 @@ import Spinner from '../../../shared_components/utilities/Spinner';
 import useUpdateRole from '../../../../hooks/mutations/admin/roles/useUpdateRole';
 import Modal from '../../../shared_components/modals/Modal';
 import DeleteRoleForm from './DeleteRoleForm';
+import useUpdateRolePermission from '../../../../hooks/mutations/admin/role_permissions/useUpdateRolePermissions';
+import useRoomConfigs from '../../../../hooks/queries/admin/room_configuration/useRoomConfigs';
+import useRolePermissions from '../../../../hooks/queries/admin/role_permissions/useRolePermissions';
 
 export default function EditRoleForm({ role }) {
   const methods = useForm(editRoleFormConfig);
   const updateRoleAPI = useUpdateRole(role.id);
-
+  const updateRolePermission = useUpdateRolePermission();
   const { defaultValues } = editRoleFormConfig;
   defaultValues.name = role.name;
   const fields = editRoleFormFields;
   fields.name.placeHolder = defaultValues.name;
-
+  const roomConfigs = useRoomConfigs();
+  const rolePermissions = useRolePermissions();
+  console.log(role);
+  if (roomConfigs.isLoading || rolePermissions.isLoading) return <Spinner />;
   return (
-    <Form methods={methods} onSubmit={updateRoleAPI.mutate}>
-      <FormControl field={fields.name} type="text" />
-      <Stack className="mt-1 float-end" gap={2} direction="horizontal">
-        <Modal
-          modalButton={<Button className="danger-light-button"> Delete Role </Button>}
-          title="Delete Role"
-          body={<DeleteRoleForm role={role} />}
-        />
-        <Button
-          variant="outline-primary"
-          onClick={() => methods.reset(defaultValues)}
-        >
-          Cancel
-        </Button>
-        <Button variant="brand" type="submit" disabled={updateRoleAPI.isLoading}>
-          Update
-          {updateRoleAPI.isLoading && <Spinner />}
-        </Button>
-      </Stack>
-    </Form>
+    <div>
+      <Form methods={methods} onSubmit={updateRoleAPI.mutate}>
+        <FormControl field={fields.name} type="text" />
+        <Stack className="mt-1 float-end" gap={2} direction="horizontal">
+          <Modal
+            modalButton={<Button className="danger-light-button"> Delete Role </Button>}
+            title="Delete Role"
+            body={<DeleteRoleForm role={role} />}
+          />
+          <Button
+            variant="outline-primary"
+            onClick={() => methods.reset(defaultValues)}
+          >
+            Cancel
+          </Button>
+          <Button variant="brand" type="submit" disabled={updateRoleAPI.isLoading}>
+            Update
+            {updateRoleAPI.isLoading && <Spinner />}
+          </Button>
+        </Stack>
+      </Form>
+      {/* TODO: Put into row component & classname scss */}
+      {(roomConfigs.isLoading || rolePermissions.isLoading || roomConfigs.data.record === 'optional') && (
+        <div className="room-settings-row text-muted py-3 d-flex">
+          { /* eslint-disable-next-line jsx-a11y/label-has-associated-control */ }
+          <label className="form-check-label me-auto" htmlFor="test">
+            Allow users with this role to record their meetings
+          </label>
+          <div className="form-switch">
+            <input
+              id="test"
+              className="form-check-input fs-5"
+              type="checkbox"
+              defaultChecked={rolePermissions.data.CanRecord === 'true'}
+              onClick={(event) => {
+                // TODO: Currently using role_id and name, review this
+                updateRolePermission.mutate({ role_id: role.id, name: 'CanRecord', value: event.target.checked });
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/app/javascript/components/admin/roles/forms/EditRoleForm.jsx
+++ b/app/javascript/components/admin/roles/forms/EditRoleForm.jsx
@@ -23,7 +23,7 @@ export default function EditRoleForm({ role }) {
   fields.name.placeHolder = defaultValues.name;
   const roomConfigs = useRoomConfigs();
   const rolePermissions = useRolePermissions();
-  console.log(role);
+
   if (roomConfigs.isLoading || rolePermissions.isLoading) return <Spinner />;
   return (
     <div>

--- a/app/javascript/components/admin/roles/forms/EditRoleForm.jsx
+++ b/app/javascript/components/admin/roles/forms/EditRoleForm.jsx
@@ -22,7 +22,7 @@ export default function EditRoleForm({ role }) {
   const fields = editRoleFormFields;
   fields.name.placeHolder = defaultValues.name;
   const roomConfigs = useRoomConfigs();
-  const rolePermissions = useRolePermissions();
+  const rolePermissions = useRolePermissions(role.id);
 
   if (roomConfigs.isLoading || rolePermissions.isLoading) return <Spinner />;
   return (

--- a/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
+++ b/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
@@ -11,8 +11,10 @@ import DeleteRoomForm from '../forms/DeleteRoomForm';
 import useRoomConfigs from '../../../../hooks/queries/admin/room_configuration/useRoomConfigs';
 import AccessCodeRow from './AccessCodeRow';
 import useUpdateRoomSetting from '../../../../hooks/mutations/room_settings/useUpdateRoomSetting';
+import { useAuth } from '../../../../contexts/auth/AuthProvider';
 
 export default function RoomSettings() {
+  const currentUser = useAuth();
   const { friendlyId } = useParams();
   const roomSetting = useRoomSettings(friendlyId);
   const roomsConfigs = useRoomConfigs();
@@ -74,13 +76,15 @@ export default function RoomSettings() {
                 config={roomsConfigs.data.glAnyoneJoinAsModerator}
                 description="All users join as moderators"
               />
-              <RoomSettingsRow
-                settingName="record"
-                updateMutation={updateMutationWrapper}
-                value={roomSetting.data.record}
-                config={roomsConfigs.data.record}
-                description="Allow room to be recorded"
-              />
+              {(currentUser.permissions.CanRecord === 'true') && (
+                <RoomSettingsRow
+                  settingName="record"
+                  updateMutation={updateMutationWrapper}
+                  value={roomSetting.data.record}
+                  config={roomsConfigs.data.record}
+                  description="Allow room to be recorded"
+                />
+              )}
             </Col>
           </Row>
           <Row className="float-end">

--- a/app/javascript/hooks/mutations/admin/role_permissions/useUpdateRolePermissions.jsx
+++ b/app/javascript/hooks/mutations/admin/role_permissions/useUpdateRolePermissions.jsx
@@ -1,14 +1,17 @@
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 import { toast } from 'react-hot-toast';
 import axios from '../../../../helpers/Axios';
 
 export default function useUpdateRolePermission() {
+  const queryClient = useQueryClient();
   return useMutation(
     (role) => axios.post('/admin/role_permissions.json', { role }),
     {
       onError: () => { toast.error('There was a problem completing that action. \n Please try again.'); },
       onSuccess: () => {
         toast.success('Role Permission updated');
+        queryClient.invalidateQueries('getRolePermissions');
+        queryClient.invalidateQueries('useSessions');
       },
     },
   );

--- a/app/javascript/hooks/mutations/admin/role_permissions/useUpdateRolePermissions.jsx
+++ b/app/javascript/hooks/mutations/admin/role_permissions/useUpdateRolePermissions.jsx
@@ -1,0 +1,15 @@
+import { useMutation } from 'react-query';
+import { toast } from 'react-hot-toast';
+import axios from '../../../../helpers/Axios';
+
+export default function useUpdateRolePermission() {
+  return useMutation(
+    (role) => axios.post('/admin/role_permissions.json', { role }),
+    {
+      onError: () => { toast.error('There was a problem completing that action. \n Please try again.'); },
+      onSuccess: () => {
+        toast.success('Role Permission updated');
+      },
+    },
+  );
+}

--- a/app/javascript/hooks/queries/admin/role_permissions/useRolePermissions.jsx
+++ b/app/javascript/hooks/queries/admin/role_permissions/useRolePermissions.jsx
@@ -1,0 +1,9 @@
+import { useQuery } from 'react-query';
+import axios from '../../../../helpers/Axios';
+
+export default function useRolePermissions() {
+  return useQuery(
+    ['getRolePermissions'],
+    () => axios.get('/admin/role_permissions.json').then((resp) => resp.data.data),
+  );
+}

--- a/app/javascript/hooks/queries/admin/role_permissions/useRolePermissions.jsx
+++ b/app/javascript/hooks/queries/admin/role_permissions/useRolePermissions.jsx
@@ -1,9 +1,13 @@
 import { useQuery } from 'react-query';
 import axios from '../../../../helpers/Axios';
 
-export default function useRolePermissions() {
+export default function useRolePermissions(roleId) {
+  const params = {
+    role_id: roleId,
+  };
+
   return useQuery(
-    ['getRolePermissions'],
-    () => axios.get('/admin/role_permissions.json').then((resp) => resp.data.data),
+    ['getRolePermissions', { ...params }],
+    () => axios.get('/admin/role_permissions.json', { params }).then((resp) => resp.data.data),
   );
 }

--- a/app/services/meeting_starter.rb
+++ b/app/services/meeting_starter.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class MeetingStarter
-  def initialize(room:, logout_url:, presentation_url:, meeting_ended:, recording_ready:, provider:)
+  def initialize(room:, logout_url:, presentation_url:, meeting_ended:, recording_ready:, current_user:, provider:)
     @room = room
+    @current_user = current_user
     @logout_url = logout_url
     @presentation_url = presentation_url
     @meeting_ended = meeting_ended
@@ -12,7 +13,7 @@ class MeetingStarter
 
   def call
     # TODO: amir - Check the legitimately of the action.
-    options = RoomSettingsGetter.new(room_id: @room.id, provider: @provider, only_bbb_options: true).call
+    options = RoomSettingsGetter.new(room_id: @room.id, provider: @provider, current_user: @current_user, only_bbb_options: true).call
 
     options.merge!(computed_options)
 

--- a/app/services/room_settings_getter.rb
+++ b/app/services/room_settings_getter.rb
@@ -7,7 +7,7 @@ class RoomSettingsGetter
   # Hash(`<option_name> => {'true' => <Postive>, 'false' => <Negative>})`
   SPECIAL_OPTIONS = { 'guestPolicy' => { 'true' => 'ASK_MODERATOR', 'false' => 'ALWAYS_ACCEPT' } }.freeze
 
-  def initialize(room_id:, provider:, current_user:, show_codes: false, only_enabled: false, only_bbb_options: false)
+  def initialize(room_id:, provider:, current_user:, settings: [], show_codes: false, only_enabled: false, only_bbb_options: false)
     @current_user = current_user
     @room_id = room_id
     @only_bbb_options = only_bbb_options # When used only BBB options (not prefixed with 'gl') will be returned.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,12 @@ Rails.application.routes.draw do
         resources :site_settings, only: %i[index update], param: :name
         resources :rooms_configurations, only: :update, param: :name
         resources :roles
+        # TODO: Review update route
+        resources :role_permissions, only: [:index] do 
+          collection do
+            post '/', to: 'role_permissions#update'
+          end
+        end
       end
     end
   end

--- a/spec/controllers/meetings_controller_spec.rb
+++ b/spec/controllers/meetings_controller_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Api::V1::MeetingsController, type: :controller do
         presentation_url:,
         meeting_ended: meeting_ended_url,
         recording_ready: recording_ready_url,
+        current_user: user,
         provider: 'greenlight'
       )
 
@@ -60,6 +61,7 @@ RSpec.describe Api::V1::MeetingsController, type: :controller do
         presentation_url:,
         meeting_ended: meeting_ended_url,
         recording_ready: recording_ready_url,
+        current_user: user,
         provider: 'greenlight'
       )
 

--- a/spec/controllers/room_settings_controller_spec.rb
+++ b/spec/controllers/room_settings_controller_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Api::V1::RoomSettingsController, type: :controller do
     end
 
     it 'uses "RoomSettingGetter" service and render its returned value' do
-      expect(RoomSettingsGetter).to receive(:new).with(room_id: room.id, provider: 'greenlight', show_codes: true, only_enabled: true)
+      expect(RoomSettingsGetter).to receive(:new).with(room_id: room.id, current_user: user, provider: 'greenlight', show_codes: true,
+                                                       only_enabled: true)
       expect(room_setting_getter_service).to receive(:call)
 
       get :show, params: { friendly_id: room.friendly_id }

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -53,4 +53,10 @@ FactoryBot.define do
       FactoryBot.create(:role_permission, role: user.role, permission: FactoryBot.create(:permission, name: 'CreateRoom'), value: 'true')
     end
   end
+
+  trait :can_record do
+    after(:create) do |user|
+      FactoryBot.create(:role_permission, role: user.role, permission: FactoryBot.create(:permission, name: 'CanRecord'), value: 'true')
+    end
+  end
 end

--- a/spec/services/meeting_starter_spec.rb
+++ b/spec/services/meeting_starter_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 describe MeetingStarter, type: :service do
+  let(:user) { create(:user) }
   let(:room) { create(:room) }
   let(:presentation_url) { 'http://www.samplepdf.com/sample.pdf' }
   let(:service) do
@@ -12,7 +13,8 @@ describe MeetingStarter, type: :service do
       presentation_url:,
       meeting_ended: 'http://example.com/meeting_ended',
       recording_ready: 'http://example.com/recording_ready',
-      provider: 'greenlight'
+      provider: 'greenlight',
+      current_user: user
     )
   end
   let(:options) do
@@ -41,7 +43,7 @@ describe MeetingStarter, type: :service do
 
       expect(RoomSettingsGetter)
         .to receive(:new)
-        .with(room_id: room.id, provider: 'greenlight', only_bbb_options: true)
+        .with(room_id: room.id, provider: 'greenlight', current_user: user, only_bbb_options: true)
 
       expect(room_setting_getter_service)
         .to receive(:call)

--- a/spec/services/room_settings_getter_spec.rb
+++ b/spec/services/room_settings_getter_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe RoomSettingsGetter, type: :service do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, :can_record) }
 
   describe '#call' do
     context 'Normal room settings' do

--- a/spec/services/room_settings_getter_spec.rb
+++ b/spec/services/room_settings_getter_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe RoomSettingsGetter, type: :service do
+  let(:user) { create(:user) }
+
   describe '#call' do
     context 'Normal room settings' do
       it 'returns a Hash("name" => "value") of room settings according to the configurations' do
@@ -19,7 +21,7 @@ describe RoomSettingsGetter, type: :service do
         create(:rooms_configuration, meeting_option: setting2, provider: 'greenlight', value: 'optional')
         create(:rooms_configuration, meeting_option: setting3, provider: 'greenlight', value: 'false')
 
-        res = described_class.new(room_id: room.id, provider: 'greenlight').call
+        res = described_class.new(room_id: room.id, current_user: user, provider: 'greenlight').call
 
         expect(res).to eq({
                             'glSetting1' => 'true',
@@ -49,7 +51,7 @@ describe RoomSettingsGetter, type: :service do
         create(:rooms_configuration, meeting_option: setting2, provider: 'greenlight', value: 'optional')
         create(:rooms_configuration, meeting_option: setting3, provider: 'greenlight', value: 'false')
 
-        res = described_class.new(room_id: room.id, provider: 'greenlight').call
+        res = described_class.new(room_id: room.id, current_user: user, provider: 'greenlight').call
 
         expect(res).to eq({
                             'glSpecial!' => 'SPECIAL_FORCE',
@@ -74,7 +76,7 @@ describe RoomSettingsGetter, type: :service do
         create(:rooms_configuration, meeting_option: moderator_access_code, provider: 'greenlight', value: 'false')
         create(:rooms_configuration, meeting_option: setting, provider: 'greenlight', value: 'optional')
 
-        res = described_class.new(room_id: room.id, provider: 'greenlight', show_codes: true).call
+        res = described_class.new(room_id: room.id, current_user: user, provider: 'greenlight', show_codes: true).call
 
         expect(res).to eq({
                             'setting' => 'VALUE',
@@ -97,7 +99,7 @@ describe RoomSettingsGetter, type: :service do
         create(:rooms_configuration, meeting_option: moderator_access_code, provider: 'greenlight', value: 'optional')
         create(:rooms_configuration, meeting_option: setting, provider: 'greenlight', value: 'optional')
 
-        res = described_class.new(room_id: room.id, provider: 'greenlight', show_codes: true).call
+        res = described_class.new(room_id: room.id, current_user: user, provider: 'greenlight', show_codes: true).call
 
         expect(res).to eq({
                             'setting' => 'VALUE',
@@ -122,7 +124,7 @@ describe RoomSettingsGetter, type: :service do
             create(:rooms_configuration, meeting_option: moderator_access_code, provider: 'greenlight', value: 'optional')
             create(:rooms_configuration, meeting_option: setting, provider: 'greenlight', value: 'optional')
 
-            res = described_class.new(room_id: room.id, provider: 'greenlight', show_codes: false).call
+            res = described_class.new(room_id: room.id, current_user: user, provider: 'greenlight', show_codes: false).call
 
             expect(res).to eq({
                                 'setting' => 'VALUE',
@@ -147,7 +149,7 @@ describe RoomSettingsGetter, type: :service do
             create(:rooms_configuration, meeting_option: setting2, provider: 'greenlight', value: 'false')
             create(:rooms_configuration, meeting_option: setting3, provider: 'greenlight', value: 'optional')
 
-            res = described_class.new(room_id: room.id, provider: 'greenlight', only_bbb_options: true).call
+            res = described_class.new(room_id: room.id, current_user: user, provider: 'greenlight', only_bbb_options: true).call
 
             expect(res).to eq({
                                 'YourOnlyBBBSetting' => 'BBB'
@@ -173,7 +175,7 @@ describe RoomSettingsGetter, type: :service do
             create(:rooms_configuration, meeting_option: setting3, provider: 'greenlight', value: 'true')
             create(:rooms_configuration, meeting_option: setting4, provider: 'greenlight', value: 'optional')
 
-            res = described_class.new(room_id: room.id, provider: 'greenlight', only_enabled: true).call
+            res = described_class.new(room_id: room.id, current_user: user, provider: 'greenlight', only_enabled: true).call
 
             expect(res).to eq({
                                 'forcedEnabled' => 'true',
@@ -197,7 +199,7 @@ describe RoomSettingsGetter, type: :service do
             create(:rooms_configuration, meeting_option: setting2, provider: 'greenlight', value: 'optional')
             create(:rooms_configuration, meeting_option: setting3, provider: 'greenlight', value: 'false')
 
-            res = described_class.new(room_id: room.id, provider: 'greenlight', settings: %w[One Three]).call
+            res = described_class.new(room_id: room.id, current_user: user, provider: 'greenlight', settings: %w[One Three]).call
 
             expect(res).to eq({
                                 'One' => 'true',


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- CanRecord permission 
- Front end:
  - Removes the permission from roles page depending on room config record value
  - Remove the room setting based on room config and CanRecord permission
- Backend:
  - Handles the permission being set as well as accounting for room settings and room config
## Testing Steps
<!--- Please describe in detail how to test your changes. -->
- Pull the code and test the different scenarios such as when room config is optional, and CanRecord permission is set to false, then you shouldn't be able to record and the record room setting shouldn't be displayed


## TODO in other PR's
- Make row component for the roles on roles admin panel page + CSS stuff
- Making the update RolePermission route better?
- Handling the ESLint complaint
- Roles page needs to be re-structured completely 
