### PR TITLE
Fix Avatar shape

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -42,6 +42,9 @@ module Api
       # TODO: Add a before_action callback to update,destory and purge_avatar calling a find_user.
       def update
         user = User.find(params[:id])
+
+        update_avatar if user_params[:avatar]
+
         if user.update(user_params)
           render_data  status: :ok
         else
@@ -94,6 +97,12 @@ module Api
 
       def change_password_params
         params.require(:user).permit(:old_password, :new_password)
+      end
+
+      # The uploaded image will be resized to a 150*150px format before being stored
+      def update_avatar
+        path = user_params[:avatar].tempfile.path
+        ImageProcessing::MiniMagick.source(path).resize_to_fill(150, 150, gravity: 'northwest').call(destination: path)
       end
     end
   end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Problem: Avatar would be displayed as an oval instead of a circle if the uploaded image is rectangular shaped.

Solution:  Before being stored with ActiveStorage, the image is resized to fit within the specified dimensions via the MiniMagick `resize_to_fill` while retaining the aspect ratio of the original image.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
Upload a very tall or very wide image.

## Notes
Could use [this](https://vitobotta.com/2020/09/24/resize-and-optimise-images-on-upload-with-activestorage/) solution if we are doing direct upload to S3, depending on how we plan to store our resources in production.
