### PR TITLE
Attempting to start an inprogress meeting doesnt fail

### DIFF
--- a/app/services/meeting_starter.rb
+++ b/app/services/meeting_starter.rb
@@ -26,7 +26,7 @@ class MeetingStarter
       ActionCable.server.broadcast "#{@room.friendly_id}_rooms_channel", 'started'
     rescue BigBlueButton::BigBlueButtonException => e
       retries += 1
-      retry unless retries >= 3
+      retry if retries < 3 && e.key != 'idNotUnique'
       raise e
     end
   end

--- a/spec/services/meeting_starter_spec.rb
+++ b/spec/services/meeting_starter_spec.rb
@@ -99,11 +99,11 @@ describe MeetingStarter, type: :service do
       it 'retries 3 times if the call fails' do
         allow(BigBlueButtonApi)
           .to receive(:new)
-                .and_raise(BigBlueButton::BigBlueButtonException)
+          .and_raise(BigBlueButton::BigBlueButtonException)
 
         expect(BigBlueButtonApi)
           .to receive(:new)
-                .exactly(3).times
+          .exactly(3).times
 
         expect { service.call }.to raise_error(BigBlueButton::BigBlueButtonException)
       end
@@ -114,11 +114,11 @@ describe MeetingStarter, type: :service do
 
         allow(BigBlueButtonApi)
           .to receive(:new)
-                .and_raise(exception)
+          .and_raise(exception)
 
         expect(BigBlueButtonApi)
           .to receive(:new)
-                .once
+          .once
 
         expect { service.call }.to raise_error(BigBlueButton::BigBlueButtonException)
       end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Attempting to start a room that is already in progress should just join the user directly into the meeting

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
1- Start a meeting
2- Open a new tab and go to Greenlight
3- Try to start the meeting again 
4- Ensure that you join the room and no error is shown

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
