### PR TITLE
Adding all permissions to edit role page

### DIFF
--- a/app/javascript/components/admin/roles/forms/EditRoleForm.jsx
+++ b/app/javascript/components/admin/roles/forms/EditRoleForm.jsx
@@ -13,6 +13,7 @@ import useUpdateRolePermission from '../../../../hooks/mutations/admin/role_perm
 import useRoomConfigs from '../../../../hooks/queries/admin/room_configuration/useRoomConfigs';
 import useRolePermissions from '../../../../hooks/queries/admin/role_permissions/useRolePermissions';
 import RolePermissionRow from '../RolePermissionRow';
+import { useAuth } from '../../../../contexts/auth/AuthProvider';
 
 export default function EditRoleForm({ role }) {
   const methods = useForm(editRoleFormConfig);
@@ -23,6 +24,7 @@ export default function EditRoleForm({ role }) {
   fields.name.placeHolder = defaultValues.name;
   const roomConfigs = useRoomConfigs();
   const rolePermissions = useRolePermissions(role.id);
+  const currentUser = useAuth();
 
   useEffect(
     () => {
@@ -42,10 +44,61 @@ export default function EditRoleForm({ role }) {
         {(roomConfigs.isLoading || rolePermissions.isLoading || roomConfigs.data.record === 'optional') && (
           <Stack>
             <RolePermissionRow
+              permissionName="CreateRoom"
+              description="Can create rooms"
+              roleId={role.id}
+              defaultValue={rolePermissions.data.CreateRoom === 'true'}
+              updateMutation={updateRolePermission}
+            />
+            <RolePermissionRow
+              permissionName="ManageUsers"
+              description="Allow users with this role to manage users"
+              roleId={role.id}
+              defaultValue={rolePermissions.data.ManageUsers === 'true'}
+              updateMutation={updateRolePermission}
+            />
+            <RolePermissionRow
               permissionName="CanRecord"
               description="Allow users with this role to record their meetings"
               roleId={role.id}
               defaultValue={rolePermissions.data.CanRecord === 'true'}
+              updateMutation={updateRolePermission}
+            />
+            <RolePermissionRow
+              permissionName="ManageRooms"
+              description="Allow users with this role to manage server rooms"
+              roleId={role.id}
+              defaultValue={rolePermissions.data.ManageRooms === 'true'}
+              updateMutation={updateRolePermission}
+            />
+            <RolePermissionRow
+              permissionName="ManageRecordings"
+              description="Allow users with this role to manage server recordings"
+              roleId={role.id}
+              defaultValue={rolePermissions.data.ManageRecordings === 'true'}
+              updateMutation={updateRolePermission}
+            />
+            <RolePermissionRow
+              permissionName="ManageSiteSettings"
+              description="Allow users with this role to manage site settings"
+              roleId={role.id}
+              defaultValue={rolePermissions.data.ManageSiteSettings === 'true'}
+              updateMutation={updateRolePermission}
+            />
+            {(currentUser.role.id !== role.id) && (
+              <RolePermissionRow
+                permissionName="ManageRoles"
+                description="Allow users with this role to edit other roles"
+                roleId={role.id}
+                defaultValue={rolePermissions.data.ManageRoles === 'true'}
+                updateMutation={updateRolePermission}
+              />
+            )}
+            <RolePermissionRow
+              permissionName="SharedList"
+              description="Include users with this role in the dropdown for sharing rooms"
+              roleId={role.id}
+              defaultValue={rolePermissions.data.SharedList === 'true'}
               updateMutation={updateRolePermission}
             />
           </Stack>

--- a/app/javascript/components/admin/roles/forms/EditRoleForm.jsx
+++ b/app/javascript/components/admin/roles/forms/EditRoleForm.jsx
@@ -23,7 +23,7 @@ export default function EditRoleForm({ role }) {
   const fields = editRoleFormFields;
   fields.name.placeHolder = defaultValues.name;
   const roomConfigs = useRoomConfigs();
-  const rolePermissions = useRolePermissions(role.id);
+  const { data: rolePermissions, isLoading: rolePermissionsIsLoading } = useRolePermissions(role.id);
   const currentUser = useAuth();
 
   useEffect(
@@ -41,56 +41,57 @@ export default function EditRoleForm({ role }) {
         <Form methods={methods} onBlur={(e) => updateRoleAPI.mutate({ name: e.target.value })}>
           <FormControl field={fields.name} type="text" />
         </Form>
-        {(roomConfigs.isLoading || rolePermissions.isLoading || roomConfigs.data.record === 'optional') && (
+        {(roomConfigs.isLoading || rolePermissionsIsLoading || roomConfigs.data.record === 'optional') && (
           <Stack>
             <RolePermissionRow
               permissionName="CreateRoom"
               description="Can create rooms"
               roleId={role.id}
-              defaultValue={rolePermissions.data.CreateRoom === 'true'}
+              defaultValue={rolePermissions.CreateRoom === 'true'}
               updateMutation={updateRolePermission}
             />
             <RolePermissionRow
               permissionName="ManageUsers"
               description="Allow users with this role to manage users"
               roleId={role.id}
-              defaultValue={rolePermissions.data.ManageUsers === 'true'}
+              defaultValue={rolePermissions.ManageUsers === 'true'}
               updateMutation={updateRolePermission}
             />
             <RolePermissionRow
               permissionName="CanRecord"
               description="Allow users with this role to record their meetings"
               roleId={role.id}
-              defaultValue={rolePermissions.data.CanRecord === 'true'}
+              defaultValue={rolePermissions.CanRecord === 'true'}
               updateMutation={updateRolePermission}
             />
             <RolePermissionRow
               permissionName="ManageRooms"
               description="Allow users with this role to manage server rooms"
               roleId={role.id}
-              defaultValue={rolePermissions.data.ManageRooms === 'true'}
+              defaultValue={rolePermissions.ManageRooms === 'true'}
               updateMutation={updateRolePermission}
             />
             <RolePermissionRow
               permissionName="ManageRecordings"
               description="Allow users with this role to manage server recordings"
               roleId={role.id}
-              defaultValue={rolePermissions.data.ManageRecordings === 'true'}
+              defaultValue={rolePermissions.ManageRecordings === 'true'}
               updateMutation={updateRolePermission}
             />
             <RolePermissionRow
               permissionName="ManageSiteSettings"
               description="Allow users with this role to manage site settings"
               roleId={role.id}
-              defaultValue={rolePermissions.data.ManageSiteSettings === 'true'}
+              defaultValue={rolePermissions.ManageSiteSettings === 'true'}
               updateMutation={updateRolePermission}
             />
+            {/* Don't show ManageRoles if current_user is editing their own role */}
             {(currentUser.role.id !== role.id) && (
               <RolePermissionRow
                 permissionName="ManageRoles"
                 description="Allow users with this role to edit other roles"
                 roleId={role.id}
-                defaultValue={rolePermissions.data.ManageRoles === 'true'}
+                defaultValue={rolePermissions.ManageRoles === 'true'}
                 updateMutation={updateRolePermission}
               />
             )}
@@ -98,7 +99,7 @@ export default function EditRoleForm({ role }) {
               permissionName="SharedList"
               description="Include users with this role in the dropdown for sharing rooms"
               roleId={role.id}
-              defaultValue={rolePermissions.data.SharedList === 'true'}
+              defaultValue={rolePermissions.SharedList === 'true'}
               updateMutation={updateRolePermission}
             />
           </Stack>


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Adding all the permissions to the edit roles page
- `ManageRoles` permission does not show if the current user is looking at their own role's edit page
- Fixed bug that would show the wrong name in the input box
## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/38328371/187934285-d6a52790-efe4-4cff-b206-2f9300c80fad.png)
