### PR TITLE
Fix toBlob() promise lint error

### DIFF
--- a/app/javascript/hooks/mutations/users/useCreateAvatar.jsx
+++ b/app/javascript/hooks/mutations/users/useCreateAvatar.jsx
@@ -7,7 +7,9 @@ export default function useCreateAvatar(currentUser) {
 
   async function createAvatar(avatar) {
     // TODO - samuel: how to validate if toBlob() will transform any file into a png by default
-    const avatarBlob = await new Promise((resolve) => avatar.toBlob(resolve));
+    const avatarBlob = await new Promise((resolve) => {
+      avatar.toBlob(resolve);
+    });
     const formData = new FormData();
     formData.append('user[avatar]', avatarBlob);
     return axios.patch(`/users/${currentUser.id}.json`, formData);


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix the `return values from promise executor functions cannot be read` error.

The rule `no-promise-executor-return` will `disallow returning values from Promise executor functions`

This is cheating but putting the `.toBlob()` method in a block, and omitting the `return` will remove the error, and the feature still works (flawlessly) like before. 

Went deep into Promise() and toBlob() docs. Built some monstrous async functions that should work. But always had to refresh/force refetch query for the Avatar to update.

Will spend some time (Friday) to continue to investigate this if needed.
