### PR TITLE
Add Access Code checker

### DIFF
--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -56,7 +56,6 @@ module Api
         return render_error errors: user.errors.to_a if hcaptcha_enabled? && !verify_hcaptcha(response: params[:token])
 
         if room.save
-          room.create_meeting_options(current_provider)
           logger.info "room(friendly_id):#{room.friendly_id} created for user(id):#{room.user_id}"
           render_data status: :created
         else

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -110,11 +110,13 @@ module Api
 
       # Generates an access code on room create if the access code room configuration is enabled
       def access_code_checker
-        access_code_settings = MeetingOption.joins(:rooms_configurations)
-                                            .where(rooms_configurations: { provider: current_provider, value: 'true' })
-                                            .pluck(:name, :value)
-                                            .to_h
-                                            .slice('glViewerAccessCode', 'glModeratorAccessCode')
+        access_code_settings = RoomSettingsGetter.new(
+          room_id: @new_room.id,
+          provider: current_provider,
+          current_user:,
+          show_codes: false,
+          settings: %w[glViewerAccessCode glModeratorAccessCode]
+        ).call
 
         access_code_settings.each do |access_code_setting|
           room_meeting_option = RoomMeetingOption.joins(:meeting_option).where(room: @new_room, meeting_option: { name: access_code_setting })

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -110,13 +110,11 @@ module Api
 
       # Generates an access code on room create if the access code room configuration is enabled
       def access_code_checker
-        room_settings = MeetingOption.joins(:rooms_configurations)
-                                     .where(rooms_configurations: { provider: current_provider })
-                                     .pluck(:name, :value)
-                                     .to_h
-        access_code_settings = []
-        access_code_settings << 'glModeratorAccessCode' if room_settings['glModeratorAccessCode'] == 'true'
-        access_code_settings << 'glViewerAccessCode' if room_settings['glViewerAccessCode'] == 'true'
+        access_code_settings = MeetingOption.joins(:rooms_configurations)
+                                            .where(rooms_configurations: { provider: current_provider, value: 'true' })
+                                            .pluck(:name, :value)
+                                            .to_h
+                                            .slice('glViewerAccessCode', 'glModeratorAccessCode')
 
         access_code_settings.each do |access_code_setting|
           room_meeting_option = RoomMeetingOption.joins(:meeting_option).where(room: @new_room, meeting_option: { name: access_code_setting })

--- a/spec/controllers/room_settings_controller_spec.rb
+++ b/spec/controllers/room_settings_controller_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Api::V1::RoomSettingsController, type: :controller do
 
   describe '#update' do
     it 'uses MeetingOption::get_config_value and updates the setting if its config is "optional"' do
+      expect(MeetingOption).to receive(:get_config_value).and_call_original
       expect(MeetingOption).to receive(:get_config_value).with(name: 'setting', provider: 'greenlight').and_call_original
 
       meeting_option = create(:meeting_option, name: 'setting')
@@ -54,6 +55,7 @@ RSpec.describe Api::V1::RoomSettingsController, type: :controller do
     context 'Access codes' do
       it 'uses MeetingOption::get_config_value and generates a code if it\'s not disabled and the value is "true"' do
         random_access_code_name = %w[glViewerAccessCode glModeratorAccessCode].sample
+        expect(MeetingOption).to receive(:get_config_value).and_call_original
         expect(MeetingOption).to receive(:get_config_value).with(name: random_access_code_name, provider: 'greenlight').and_call_original
         allow_any_instance_of(described_class).to receive(:generate_code).and_return('CODE!!')
         expect_any_instance_of(described_class).to receive(:generate_code)
@@ -68,6 +70,7 @@ RSpec.describe Api::V1::RoomSettingsController, type: :controller do
 
       it 'uses MeetingOption::get_config_value and removes a code if it\'s optional and the value is "false"' do
         random_access_code_name = %w[glViewerAccessCode glModeratorAccessCode].sample
+        expect(MeetingOption).to receive(:get_config_value).and_call_original
         expect(MeetingOption).to receive(:get_config_value).with(name: random_access_code_name, provider: 'greenlight').and_call_original
         expect_any_instance_of(described_class).not_to receive(:generate_code)
 
@@ -82,6 +85,7 @@ RSpec.describe Api::V1::RoomSettingsController, type: :controller do
       context 'AuthZ' do
         it 'returns :forbidden when value is "true" but the setting is disabled' do
           random_access_code_name = %w[glViewerAccessCode glModeratorAccessCode].sample
+          expect(MeetingOption).to receive(:get_config_value).and_call_original
           expect(MeetingOption).to receive(:get_config_value).with(name: random_access_code_name, provider: 'greenlight').and_call_original
           expect_any_instance_of(described_class).not_to receive(:generate_code)
 
@@ -94,6 +98,7 @@ RSpec.describe Api::V1::RoomSettingsController, type: :controller do
 
         it 'returns :forbidden when value is "false" but the setting is NOT optional' do
           random_access_code_name = %w[glViewerAccessCode glModeratorAccessCode].sample
+          expect(MeetingOption).to receive(:get_config_value).and_call_original
           expect(MeetingOption).to receive(:get_config_value).with(name: random_access_code_name, provider: 'greenlight').and_call_original
           expect_any_instance_of(described_class).not_to receive(:generate_code)
 

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -173,24 +173,9 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
       expect(response).to have_http_status(:forbidden)
     end
 
-    context 'the access code meeting option is enabled' do
-      let(:fake_room_settings_getter) { instance_double(RoomSettingsGetter) }
-      let!(:meeting_option) { create(:meeting_option, name: 'glViewerAccessCode') }
-      let!(:room_meeting_option) { create(:room_meeting_option, meeting_option:) }
-
-      before do
-        allow(RoomSettingsGetter).to receive(:new).and_return(fake_room_settings_getter)
-        allow(fake_room_settings_getter).to receive(:call).and_return(
-          { 'glViewerAccessCode' => true, 'glModeratorAccessCode' => false }
-        )
-        # can we avoid hardcoding the friendly id?
-        allow(SecureRandom).to receive(:alphanumeric).and_return('8ac31fcc-b550-48f3-a1cd-eab7ec413f35', 'abc123')
-      end
-
-      it 'creates a room with pre-generated access codes' do
-        post :create, params: room_params
-        expect(Room.last.room_meeting_options[0].value).to eq('abc123') # there is a better way to access the room resource
-      end
+    it 'calls create_meeting_options on room' do
+      expect_any_instance_of(Room).to receive(:create_meeting_options)
+      post :create, params: room_params
     end
 
     context 'user with ManageUser permission' do

--- a/spec/factories/meeting_option_factory.rb
+++ b/spec/factories/meeting_option_factory.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :meeting_option do
-    name { Faker::Vehicle.unique.make }
+    name { Faker::Address.unique.street_address }
     default_value { [true, false, '12345'].sample }
   end
 end

--- a/spec/factories/meeting_option_factory.rb
+++ b/spec/factories/meeting_option_factory.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :meeting_option do
-    name { Faker::Address.unique.street_address }
+    name { Faker::Lorem.unique.word }
     default_value { [true, false, '12345'].sample }
   end
 end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -62,13 +62,11 @@ RSpec.describe Room, type: :model do
     end
 
     it 'creates a RoomMeetingOption for each MeetingOption' do
-      room = create(:room)
-      expect { room.create_meeting_options('greenlight') }.to change(RoomMeetingOption, :count).from(0).to(6)
+      expect { create(:room) }.to change(RoomMeetingOption, :count).from(0).to(6)
     end
 
     it 'does not generate an access code if the room config is not enabled' do
-      room = create(:room)
-      room.create_meeting_options('greenlight')
+      create(:room)
       expect(RoomMeetingOption.find_by(meeting_option:).value).to eql('')
     end
 
@@ -77,10 +75,20 @@ RSpec.describe Room, type: :model do
         create(:rooms_configuration, provider: 'greenlight', value: 'true', meeting_option:)
       end
 
-      it 'creates a room with a generated access codes' do
-        room = create(:room)
-        room.create_meeting_options('greenlight')
+      it 'creates a room and generates an access code' do
+        create(:room)
         expect(RoomMeetingOption.find_by(meeting_option:).value).not_to eql('')
+      end
+    end
+
+    context 'when access code room config is optional' do
+      before do
+        create(:rooms_configuration, provider: 'greenlight', value: 'optional', meeting_option:)
+      end
+
+      it 'does not generate an access code' do
+        create(:room)
+        expect(RoomMeetingOption.find_by(meeting_option:).value).to eql('')
       end
     end
   end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -56,40 +56,48 @@ RSpec.describe Room, type: :model do
 
   context 'after_create' do
     describe 'create_meeting_options' do
-      let!(:meeting_option) { create(:meeting_option, name: 'glViewerAccessCode', default_value: '') }
+      let!(:viewer_access_code) { create(:meeting_option, name: 'glViewerAccessCode', default_value: '') }
+      let!(:moderator_access_code) { create(:meeting_option, name: 'glModeratorAccessCode', default_value: '') }
 
       before do
-        create_list(:meeting_option, 5)
+        create_list(:meeting_option, 3)
       end
 
       it 'creates a RoomMeetingOption for each MeetingOption' do
-        expect { create(:room) }.to change(RoomMeetingOption, :count).from(0).to(6)
+        expect { create(:room) }.to change(RoomMeetingOption, :count).from(0).to(5)
       end
 
       it 'does not generate an access code if the room config is not enabled' do
         create(:room)
-        expect(RoomMeetingOption.find_by(meeting_option:).value).to eql('')
+        expect(RoomMeetingOption.find_by(meeting_option: viewer_access_code).value).to eql('')
       end
 
       context 'when access code room config is enabled' do
         before do
-          create(:rooms_configuration, provider: 'greenlight', value: 'true', meeting_option:)
+          create(:rooms_configuration, provider: 'greenlight', value: 'true', meeting_option: viewer_access_code)
+          create(:rooms_configuration, provider: 'greenlight', value: 'true', meeting_option: moderator_access_code)
         end
 
-        it 'creates a room and generates an access code' do
+        it 'creates a room and generates an access code if enabled' do
           create(:room)
-          expect(RoomMeetingOption.find_by(meeting_option:).value).not_to eql('')
+          expect(RoomMeetingOption.find_by(meeting_option: viewer_access_code).value).not_to eql('')
+        end
+
+        it 'creates a room and generates both access code if both are enabled' do
+          create(:room)
+          expect(RoomMeetingOption.find_by(meeting_option: viewer_access_code).value).not_to eql('')
+          expect(RoomMeetingOption.find_by(meeting_option: moderator_access_code).value).not_to eql('')
         end
       end
 
       context 'when access code room config is optional' do
         before do
-          create(:rooms_configuration, provider: 'greenlight', value: 'optional', meeting_option:)
+          create(:rooms_configuration, provider: 'greenlight', value: 'optional', meeting_option: viewer_access_code)
         end
 
         it 'does not generate an access code' do
           create(:room)
-          expect(RoomMeetingOption.find_by(meeting_option:).value).to eql('')
+          expect(RoomMeetingOption.find_by(meeting_option: viewer_access_code).value).to eql('')
         end
       end
     end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -54,41 +54,43 @@ RSpec.describe Room, type: :model do
     end
   end
 
-  describe 'create_meeting_options' do
-    let!(:meeting_option) { create(:meeting_option, name: 'glViewerAccessCode', default_value: '') }
+  context 'after_create' do
+    describe 'create_meeting_options' do
+      let!(:meeting_option) { create(:meeting_option, name: 'glViewerAccessCode', default_value: '') }
 
-    before do
-      create_list(:meeting_option, 5)
-    end
-
-    it 'creates a RoomMeetingOption for each MeetingOption' do
-      expect { create(:room) }.to change(RoomMeetingOption, :count).from(0).to(6)
-    end
-
-    it 'does not generate an access code if the room config is not enabled' do
-      create(:room)
-      expect(RoomMeetingOption.find_by(meeting_option:).value).to eql('')
-    end
-
-    context 'when access code room config is enabled' do
       before do
-        create(:rooms_configuration, provider: 'greenlight', value: 'true', meeting_option:)
+        create_list(:meeting_option, 5)
       end
 
-      it 'creates a room and generates an access code' do
-        create(:room)
-        expect(RoomMeetingOption.find_by(meeting_option:).value).not_to eql('')
-      end
-    end
-
-    context 'when access code room config is optional' do
-      before do
-        create(:rooms_configuration, provider: 'greenlight', value: 'optional', meeting_option:)
+      it 'creates a RoomMeetingOption for each MeetingOption' do
+        expect { create(:room) }.to change(RoomMeetingOption, :count).from(0).to(6)
       end
 
-      it 'does not generate an access code' do
+      it 'does not generate an access code if the room config is not enabled' do
         create(:room)
         expect(RoomMeetingOption.find_by(meeting_option:).value).to eql('')
+      end
+
+      context 'when access code room config is enabled' do
+        before do
+          create(:rooms_configuration, provider: 'greenlight', value: 'true', meeting_option:)
+        end
+
+        it 'creates a room and generates an access code' do
+          create(:room)
+          expect(RoomMeetingOption.find_by(meeting_option:).value).not_to eql('')
+        end
+      end
+
+      context 'when access code room config is optional' do
+        before do
+          create(:rooms_configuration, provider: 'greenlight', value: 'optional', meeting_option:)
+        end
+
+        it 'does not generate an access code' do
+          create(:room)
+          expect(RoomMeetingOption.find_by(meeting_option:).value).to eql('')
+        end
       end
     end
   end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe Room, type: :model do
     end
   end
 
-
   context 'instance methods' do
     describe '#anyone_joins_as_moderator?' do
       let!(:room) { create(:room) }


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->
## NEEDS #3903 

## Description
<!--- Describe your changes in detail -->
Update the `create_meeting_options` method in Room to check if the `glViewerAccessCode` and `glModeratorAccessCode `configs are enabled. If so, the upcoming created Rooms will have a generated access code.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

- Enable or disable the access codes options in Admin/Room Configuration
- Create a new room
- Go to Room/Room Settings
- If enabled, the access code(s) should have been generated