### PR TITLE
Add max height to logo

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -288,10 +288,12 @@ input.search-bar {
 
 .medium-logo {
   max-width: 300px;
+  max-height: 150px;
 }
 
 .large-logo {
   max-width: 400px;
+  max-height: 200px;
 }
 
 /********** Range Input Styles **********/

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -283,6 +283,7 @@ input.search-bar {
 //Logo
 .small-logo {
   max-width: 200px;
+  max-height: $header-height;
 }
 
 .medium-logo {


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add max-height to the header logo CSS class else a tall logo would overflow.
Might be a good idea to add a new "logo" CSS class in top of small/medium/large logo instead?
