### PR TITLE
Allow get_config_value to return multiple values

### DIFF
--- a/app/controllers/api/v1/room_settings_controller.rb
+++ b/app/controllers/api/v1/room_settings_controller.rb
@@ -15,15 +15,17 @@ module Api
 
       # PATCH /api/v1/room_settings/:friendly_id
       def update
-        config = MeetingOption.get_config_value(name: room_setting_params[:settingName], provider: current_provider)&.value
-        return render_error status: :bad_request unless config
-
         name = room_setting_params[:settingName]
         value = room_setting_params[:settingValue].to_s
 
+        config = MeetingOption.get_config_value(name:, provider: current_provider)
+        config_value = config[name]
+
+        return render_error status: :bad_request unless config_value
+
         is_access_code = %w[glViewerAccessCode glModeratorAccessCode].include? name
 
-        return render_error status: :forbidden unless config == 'optional' || (config == 'true' && is_access_code && value != 'false')
+        return render_error status: :forbidden unless config_value == 'optional' || (config_value == 'true' && is_access_code && value != 'false')
 
         value = infer_access_code(value:) if is_access_code # Handling access code update.
 

--- a/app/models/meeting_option.rb
+++ b/app/models/meeting_option.rb
@@ -17,10 +17,11 @@ class MeetingOption < ApplicationRecord
 
   def self.get_config_value(name:, provider:)
     joins(:rooms_configurations)
-      .select(:value)
-      .find_by(
+      .where(
         name:,
         rooms_configurations: { provider: }
       )
+      .pluck(:name, :value)
+      .to_h
   end
 end

--- a/spec/models/meeting_option_spec.rb
+++ b/spec/models/meeting_option_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe MeetingOption, type: :model do
     it { is_expected.to validate_uniqueness_of(:name) }
   end
 
-  describe 'classs methods' do
+  describe 'class methods' do
     describe '#get_setting_value' do
       context 'existing setting' do
         it 'returns the room meeting option value' do
@@ -40,7 +40,7 @@ RSpec.describe MeetingOption, type: :model do
           create(:rooms_configuration, meeting_option:, provider: 'greenlight', value: 'optional')
 
           rooms_config = described_class.get_config_value(name: 'setting', provider: 'greenlight')
-          expect(rooms_config.value).to eq('optional')
+          expect(rooms_config['setting']).to eq('optional')
         end
       end
 
@@ -48,7 +48,7 @@ RSpec.describe MeetingOption, type: :model do
         it 'returns nil' do
           expect(
             described_class.get_config_value(name: 'notAConfigTrustMe', provider: 'YouShould\'ve')
-          ).to be_nil
+          ).to be_empty
         end
       end
     end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allow the `get_config_value` method for MeetingOption to return a hash with multiple values.
This is needed as we require to return the values of both `glViewerAccessCode` and `glModeratorAccessCode` in #3852 
