### PR TITLE
Fix Share Access

### DIFF
--- a/app/controllers/api/v1/shared_accesses_controller.rb
+++ b/app/controllers/api/v1/shared_accesses_controller.rb
@@ -7,11 +7,11 @@ module Api
 
       # POST /api/v1/shared_accesses.json
       def create
-        user_ids = params[:shared_users]
+        shared_users_ids = params[:shared_users]
 
-        shared_accesses = user_ids.map { |user_id| { user_id:, room_id: @room.id } }
-
-        SharedAccess.create(shared_accesses)
+        shared_users_ids.each do |shared_user_id|
+          SharedAccess.create(user_id: shared_user_id, room_id: @room.id)
+        end
 
         render_data status: :ok
       end

--- a/app/controllers/api/v1/shared_accesses_controller.rb
+++ b/app/controllers/api/v1/shared_accesses_controller.rb
@@ -7,7 +7,7 @@ module Api
 
       # POST /api/v1/shared_accesses.json
       def create
-        shared_users_ids = params[:shared_users]
+        shared_users_ids = Array(params[:shared_users])
 
         shared_users_ids.each do |shared_user_id|
           SharedAccess.create(user_id: shared_user_id, room_id: @room.id)

--- a/app/javascript/components/rooms/room/FeatureTabs.jsx
+++ b/app/javascript/components/rooms/room/FeatureTabs.jsx
@@ -5,10 +5,12 @@ import RoomRecordings from '../../recordings/room_recordings/RoomRecordings';
 import Presentation from './presentation/Presentation';
 import RoomSettings from './room_settings/RoomSettings';
 import useSiteSetting from '../../../hooks/queries/site_settings/useSiteSetting';
+import SharedAccess from './shared_access/SharedAccess';
 
 export default function FeatureTabs() {
   const { t } = useTranslation();
   const { data: preuploadEnabled } = useSiteSetting('PreuploadPresentation');
+  const { data: shareRoomEnabled } = useSiteSetting('ShareRooms');
 
   return (
     <Row className="pt-4 mx-0">
@@ -22,12 +24,12 @@ export default function FeatureTabs() {
             <Presentation />
           </Tab>
           )}
-        {/* { shareRoomEnabled */}
-        {/*  && ( */}
-        {/*  <Tab eventKey="access" title={t('room.shared_access.access)}> */}
-        {/*    <SharedAccess /> */}
-        {/*  </Tab> */}
-        {/*  )} */}
+        { shareRoomEnabled
+         && (
+         <Tab eventKey="access" title={t('room.shared_access.access')}>
+           <SharedAccess />
+         </Tab>
+         )}
         <Tab eventKey="settings" title={t('room.settings.settings')}>
           <RoomSettings />
         </Tab>

--- a/app/javascript/components/rooms/room/shared_access/SharedAccess.jsx
+++ b/app/javascript/components/rooms/room/shared_access/SharedAccess.jsx
@@ -29,7 +29,7 @@ export default function SharedAccess() {
             <SearchBarQuery setInput={setInput} />
           </div>
           <Modal
-            modalButton={<Button variant="brand-backward" className="ms-auto">{ t('room.shared_access.new_share_access')}</Button>}
+            modalButton={<Button variant="brand-backward" className="ms-auto">{ t('room.shared_access.add_share_access')}</Button>}
             title={t('room.shared_access.share_room_access')}
             body={<SharedAccessForm />}
             size="lg"

--- a/app/javascript/components/rooms/room/shared_access/SharedAccess.jsx
+++ b/app/javascript/components/rooms/room/shared_access/SharedAccess.jsx
@@ -17,8 +17,7 @@ export default function SharedAccess() {
   const { t } = useTranslation();
   const { friendlyId } = useParams();
   const [input, setInput] = useState();
-  const [sharedUsers, setSharedUsers] = useState();
-  useSharedUsers(friendlyId, input, setSharedUsers);
+  const { data: sharedUsers } = useSharedUsers(friendlyId, input);
   const deleteSharedAccess = useDeleteSharedAccess(friendlyId);
 
   if (sharedUsers?.length || input) {

--- a/app/javascript/components/rooms/room/shared_access/forms/SharedAccessForm.jsx
+++ b/app/javascript/components/rooms/room/shared_access/forms/SharedAccessForm.jsx
@@ -19,8 +19,7 @@ export default function SharedAccessForm({ handleClose }) {
   const { friendlyId } = useParams();
   const { onSubmit } = useShareAccess({ friendlyId, closeModal: handleClose });
   const [input, setInput] = useState();
-  const [shareableUsers, setShareableUsers] = useState();
-  useShareableUsers(friendlyId, input, setShareableUsers);
+  const { data: shareableUsers } = useShareableUsers(friendlyId, input);
 
   return (
     <div id="shared-access-form">

--- a/app/javascript/components/rooms/room/shared_access/forms/SharedAccessForm.jsx
+++ b/app/javascript/components/rooms/room/shared_access/forms/SharedAccessForm.jsx
@@ -42,8 +42,8 @@ export default function SharedAccessForm({ handleClose }) {
                       <Stack direction="horizontal" className="py-2">
                         <Form.Check
                           type="checkbox"
+                          key={user.id}
                           value={user.id}
-                          aria-label="tbd"
                           className="pe-3"
                           {...register('shared_users')}
                         />

--- a/app/javascript/components/rooms/room/shared_access/forms/SharedAccessForm.jsx
+++ b/app/javascript/components/rooms/room/shared_access/forms/SharedAccessForm.jsx
@@ -17,14 +17,14 @@ export default function SharedAccessForm({ handleClose }) {
   const { t } = useTranslation();
   const { register, handleSubmit } = useForm();
   const { friendlyId } = useParams();
-  const { onSubmit } = useShareAccess({ friendlyId, closeModal: handleClose });
+  const createSharedUser = useShareAccess({ friendlyId, closeModal: handleClose });
   const [input, setInput] = useState();
   const { data: shareableUsers } = useShareableUsers(friendlyId, input);
 
   return (
     <div id="shared-access-form">
       <SearchBarQuery setInput={setInput} />
-      <Form onSubmit={handleSubmit(onSubmit)}>
+      <Form onSubmit={handleSubmit(createSharedUser.mutate)}>
         <Table hover className="text-secondary my-3">
           <thead>
             <tr className="text-muted small">

--- a/app/javascript/components/rooms/room/shared_access/forms/SharedAccessForm.jsx
+++ b/app/javascript/components/rooms/room/shared_access/forms/SharedAccessForm.jsx
@@ -41,7 +41,6 @@ export default function SharedAccessForm({ handleClose }) {
                       <Stack direction="horizontal" className="py-2">
                         <Form.Check
                           type="checkbox"
-                          key={user.id}
                           value={user.id}
                           className="pe-3"
                           {...register('shared_users')}

--- a/app/javascript/hooks/mutations/shared_accesses/useDeleteSharedAccess.jsx
+++ b/app/javascript/hooks/mutations/shared_accesses/useDeleteSharedAccess.jsx
@@ -12,7 +12,7 @@ export default function useDeleteSharedAccess(friendlyId) {
     {
       onSuccess: () => {
         queryClient.invalidateQueries('getSharedUsers');
-        toast.success(t('success.toast.room_unshared'));
+        toast.success(t('toast.success.room.room_unshared'));
       },
       onError: () => {
         toast.error(t('toast.error.problem_completing_action'));

--- a/app/javascript/hooks/mutations/shared_accesses/useShareAccess.jsx
+++ b/app/javascript/hooks/mutations/shared_accesses/useShareAccess.jsx
@@ -7,17 +7,8 @@ export default function useShareAccess({ friendlyId, closeModal }) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
 
-  const shareAccess = (data) => {
-    let sharedUsers = data.shared_users;
-    if (typeof data.shared_users === 'string') {
-      sharedUsers = [data.shared_users];
-    }
-
-    return axios.post('/shared_accesses.json', { friendly_id: friendlyId, shared_users: sharedUsers });
-  };
-
   return useMutation(
-    shareAccess,
+    (data) => axios.post('/shared_accesses.json', { friendly_id: friendlyId, shared_users: data.shared_users }),
     {
       onSuccess: () => {
         closeModal();

--- a/app/javascript/hooks/mutations/shared_accesses/useShareAccess.jsx
+++ b/app/javascript/hooks/mutations/shared_accesses/useShareAccess.jsx
@@ -16,17 +16,17 @@ export default function useShareAccess({ friendlyId, closeModal }) {
     return axios.post('/shared_accesses.json', { friendly_id: friendlyId, shared_users: sharedUsers });
   };
 
-  const mutation = useMutation(shareAccess, {
-    onSuccess: () => {
-      closeModal();
-      queryClient.invalidateQueries('getSharedUsers');
-      toast.success(t('toast.success.room.room_shared'));
+  return useMutation(
+    shareAccess,
+    {
+      onSuccess: () => {
+        closeModal();
+        queryClient.invalidateQueries('getSharedUsers');
+        toast.success(t('toast.success.room.room_shared'));
+      },
+      onError: () => {
+        toast.error(t('toast.error.problem_completing_action'));
+      },
     },
-    onError: () => {
-      toast.error(t('toast.error.problem_completing_action'));
-    },
-  });
-
-  const onSubmit = (data) => mutation.mutateAsync(data).catch(/* Prevents the promise exception from bubbling */() => {});
-  return { onSubmit, ...mutation };
+  );
 }

--- a/app/javascript/hooks/mutations/shared_accesses/useShareAccess.jsx
+++ b/app/javascript/hooks/mutations/shared_accesses/useShareAccess.jsx
@@ -8,7 +8,11 @@ export default function useShareAccess({ friendlyId, closeModal }) {
   const queryClient = useQueryClient();
 
   const shareAccess = (data) => {
-    const sharedUsers = [...data.shared_users];
+    let sharedUsers = data.shared_users;
+    if (typeof data.shared_users === 'string') {
+      sharedUsers = [data.shared_users];
+    }
+
     return axios.post('/shared_accesses.json', { friendly_id: friendlyId, shared_users: sharedUsers });
   };
 

--- a/app/javascript/hooks/queries/shared_accesses/useShareableUsers.jsx
+++ b/app/javascript/hooks/queries/shared_accesses/useShareableUsers.jsx
@@ -1,13 +1,16 @@
 import { useQuery } from 'react-query';
 import axios from '../../../helpers/Axios';
 
-export default function useShareableUsers(friendlyId, input, setShareableUsers) {
+export default function useShareableUsers(friendlyId, input) {
   const params = {
     search: input,
   };
 
   return useQuery(
     ['getShareableUsers', input],
-    () => axios.get(`/shared_accesses/${friendlyId}/shareable_users.json`, { params }).then((resp) => setShareableUsers(resp.data.data)),
+    () => axios.get(`/shared_accesses/${friendlyId}/shareable_users.json`, { params }).then((resp) => resp.data.data),
+    {
+      keepPreviousData: true,
+    },
   );
 }

--- a/app/javascript/hooks/queries/shared_accesses/useSharedUsers.jsx
+++ b/app/javascript/hooks/queries/shared_accesses/useSharedUsers.jsx
@@ -1,12 +1,15 @@
 import { useQuery } from 'react-query';
 import axios from '../../../helpers/Axios';
 
-export default function useSharedUsers(friendlyId, input, setSharedUsers) {
+export default function useSharedUsers(friendlyId, input) {
   const params = {
     search: input,
   };
   return useQuery(
     ['getSharedUsers', input],
-    () => axios.get(`/shared_accesses/${friendlyId}.json`, { params }).then((resp) => setSharedUsers(resp.data.data)),
+    () => axios.get(`/shared_accesses/${friendlyId}.json`, { params }).then((resp) => resp.data.data),
+    {
+      keepPreviousData: true,
+    }
   );
 }

--- a/app/javascript/hooks/queries/shared_accesses/useSharedUsers.jsx
+++ b/app/javascript/hooks/queries/shared_accesses/useSharedUsers.jsx
@@ -10,6 +10,6 @@ export default function useSharedUsers(friendlyId, input) {
     () => axios.get(`/shared_accesses/${friendlyId}.json`, { params }).then((resp) => resp.data.data),
     {
       keepPreviousData: true,
-    }
+    },
   );
 }


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Fix the Share Access edge case error (backend solution).
- Change the SharableUsers and SharedUsers mutation hooks to use the new template.
- Add the keepPreviousData param to the SharedUsers and ShareableUsers query hooks.


**Problem:** 
If there is only one sharableUser left, the form data will return a single string instead of an array.`"user_id"`
It is a problem because our controller is expecting an array.
It is kind of an edge case because if you select/share with only one user, it will still return an array with a single string. `["user_id"]`.
The bug will happen only if there is _a single user left that is shareable_.
For example, if your local app has only two users (yourself and another one), the shared access feature will not work at all (as yourself is never included in shareable users).

**Solution:**
I went thru React Hook Form docs to see if we could format the form response, which would be the ideal solution, without success.
~The proposed solution is to add an _if checktype_.~
Put the params response inside the ruby Array() method in backend so the server always deals with an array.