### PR TITLE
Buttons overhaul

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -177,7 +177,7 @@ input.search-bar {
 }
 
 .btn-brand-backward {
-  border: 2px solid var(--brand-color);
+  border: 2px solid gainsboro;
   color: var(--brand-color);
   background-color: white;
   box-shadow: var(--brand-color-light);

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -164,12 +164,12 @@ input.search-bar {
 .btn-brand {
   background-color: var(--brand-color);
   border-color: var(--brand-color);
-  border: 2px solid var(--brand-color);
+  //border: 2px solid var(--brand-color);
   color: white;
 
   &:hover {
-    color: var(--brand-color);
-    background-color: white !important;
+    box-shadow: inset 0 0 200px 200px rgba(0, 0, 0, 0.1);
+    color: white;
   }
 
   &:focus {
@@ -179,13 +179,14 @@ input.search-bar {
 
 .btn-brand-backward {
   border: 2px solid gainsboro;
+  border-color: var(--brand-color);
   color: var(--brand-color);
   background-color: white;
   box-shadow: var(--brand-color-light);
 
   &:hover {
+    box-shadow: inset 0 0 200px 200px rgba(0, 0, 0, 0.05);
     color: var(--brand-color);
-    border-color: var(--brand-color);
   }
 
   &:focus {
@@ -195,15 +196,12 @@ input.search-bar {
 
 .btn-brand-light {
   background-color: var(--brand-color-light);
-  border-color: var(--brand-color-light);
   color: var(--brand-color);
   border: 2px solid var(--brand-color-light);
 
   &:hover {
-    background-color: white !important;
+    box-shadow: inset 0 0 200px 200px rgba(0, 0, 0, 0.05);
     color: var(--brand-color);
-    border-color: var(--brand-color-light);
-    border: 2px solid var(--brand-color-light);
   }
 
   &:focus {

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -164,7 +164,6 @@ input.search-bar {
 .btn-brand {
   background-color: var(--brand-color);
   border-color: var(--brand-color);
-  //border: 2px solid var(--brand-color);
   color: white;
 
   &:hover {
@@ -178,8 +177,7 @@ input.search-bar {
 }
 
 .btn-brand-backward {
-  border: 2px solid gainsboro;
-  border-color: var(--brand-color);
+  border: 2px solid var(--brand-color);
   color: var(--brand-color);
   background-color: white;
   box-shadow: var(--brand-color-light);

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -207,6 +207,36 @@ input.search-bar {
   }
 }
 
+.btn-delete {
+  border: 2px solid $danger;
+  color: $danger;
+  background-color: white;
+
+  &:hover {
+    box-shadow: inset 0 0 200px 200px rgba(0, 0, 0, 0.03);
+    color: $danger;
+  }
+
+  &:focus {
+    box-shadow: none;
+  }
+}
+
+.btn-neutral {
+  border: 2px solid gainsboro;
+  color: gray;
+  background-color: white;
+
+  &:hover {
+    box-shadow: inset 0 0 200px 200px rgba(0, 0, 0, 0.05);
+    color: gray;
+  }
+
+  &:focus {
+    box-shadow: none;
+  }
+}
+
 //Bootstrap overwrite
 .form-switch .form-check-input:focus {
   border-color: rgba(0, 0, 0, 0.25);

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -192,13 +192,29 @@ input.search-bar {
   }
 }
 
+.btn-brand-outline-color {
+  border: 2px solid var(--brand-color);
+  color: var(--brand-color);
+  background-color: white;
+  box-shadow: var(--brand-color-light);
+
+  &:hover {
+    box-shadow: inset 0 0 200px 200px rgba(0, 0, 0, 0.03);
+    color: var(--brand-color);
+  }
+
+  &:focus {
+    box-shadow: 0 0 0 0.25rem var(--brand-color-light);
+  }
+}
+
 .btn-brand-light {
   background-color: var(--brand-color-light);
   color: var(--brand-color);
   border: 2px solid var(--brand-color-light);
 
   &:hover {
-    box-shadow: inset 0 0 200px 200px rgba(0, 0, 0, 0.05);
+    box-shadow: inset 0 0 200px 200px rgba(0, 0, 0, 0.03);
     color: var(--brand-color);
   }
 
@@ -228,7 +244,7 @@ input.search-bar {
   background-color: white;
 
   &:hover {
-    box-shadow: inset 0 0 200px 200px rgba(0, 0, 0, 0.05);
+    box-shadow: inset 0 0 200px 200px rgba(0, 0, 0, 0.03);
     color: gray;
   }
 

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -176,14 +176,14 @@ input.search-bar {
   }
 }
 
-.btn-brand-backward {
+.btn-brand-outline {
   border: 2px solid gainsboro;
   color: var(--brand-color);
   background-color: white;
   box-shadow: var(--brand-color-light);
 
   &:hover {
-    box-shadow: inset 0 0 200px 200px rgba(0, 0, 0, 0.05);
+    border-color: var(--brand-color);
     color: var(--brand-color);
   }
 

--- a/app/javascript/components/admin/manage_users/forms/DeleteUserForm.jsx
+++ b/app/javascript/components/admin/manage_users/forms/DeleteUserForm.jsx
@@ -23,7 +23,7 @@ export default function DeleteUserForm({ user, handleClose }) {
       </p>
       <Form methods={methods} onSubmit={deleteUser.mutate}>
         <Stack direction="horizontal" gap={1} className="float-end">
-          <Button variant="brand-backward" onClick={handleClose}>
+          <Button variant="brand-outline" onClick={handleClose}>
             { t('close') }
           </Button>
           <Button variant="danger" type="submit" disabled={deleteUser.isLoading}>

--- a/app/javascript/components/admin/roles/forms/CreateRoleForm.jsx
+++ b/app/javascript/components/admin/roles/forms/CreateRoleForm.jsx
@@ -19,7 +19,7 @@ export default function CreateRoleForm({ handleClose }) {
     <Form methods={methods} onSubmit={createRole.mutate}>
       <FormControl field={fields.name} type="text" />
       <Stack className="mt-1" direction="horizontal" gap={1}>
-        <Button variant="brand-backward" className="ms-auto" onClick={handleClose}>
+        <Button variant="brand-outline" className="ms-auto" onClick={handleClose}>
           Close
         </Button>
         <Button variant="brand" type="submit" disabled={createRole.isLoading}>

--- a/app/javascript/components/admin/roles/forms/DeleteRoleForm.jsx
+++ b/app/javascript/components/admin/roles/forms/DeleteRoleForm.jsx
@@ -17,7 +17,7 @@ export default function DeleteRoleForm({ role, handleClose }) {
       <p className="text-center"> Are you sure you want to delete role <strong>{role.name}</strong>?</p>
       <Form methods={methods} onSubmit={deleteRoleAPI.mutate}>
         <Stack direction="horizontal" gap={1} className="float-end">
-          <Button variant="brand-backward" onClick={handleClose}>
+          <Button variant="brand-outline" onClick={handleClose}>
             Close
           </Button>
           <Button variant="danger" type="submit" disabled={deleteRoleAPI.isLoading}>

--- a/app/javascript/components/admin/roles/forms/EditRoleForm.jsx
+++ b/app/javascript/components/admin/roles/forms/EditRoleForm.jsx
@@ -108,7 +108,7 @@ export default function EditRoleForm({ role }) {
 
         <div>
           <Modal
-            modalButton={<Button variant="brand-backward" className="float-end"> Delete Role </Button>}
+            modalButton={<Button variant="brand-outline" className="float-end"> Delete Role </Button>}
             title="Delete Role"
             body={<DeleteRoleForm role={role} />}
           />

--- a/app/javascript/components/admin/server_recordings/ServerRecordings.jsx
+++ b/app/javascript/components/admin/server_recordings/ServerRecordings.jsx
@@ -40,7 +40,7 @@ export default function ServerRecordings() {
                     <Stack direction="horizontal" className="mb-4">
                       <SearchBarQuery setInput={setInput} />
                       <Button
-                        variant="brand-backward"
+                        variant="brand-outline"
                         className="ms-auto"
                         onClick={recordingsReSync.refetch}
                       > { t('admin.server_recordings.resync_recordings') }

--- a/app/javascript/components/admin/site_settings/appearance/BrandColorPopover.jsx
+++ b/app/javascript/components/admin/site_settings/appearance/BrandColorPopover.jsx
@@ -57,7 +57,7 @@ export default function BrandColorPopover({
               <div className="color-preview" style={{ background: initialColor }} />
               <div className="color-preview" style={{ background: color }} />
               <Stack direction="horizontal" className="mt-2 pb-2 float-end">
-                <Button variant="brand-outline" className="me-2" onClick={handleCancel}> { t('cancel') } </Button>
+                <Button variant="neutral" className="me-2" onClick={handleCancel}> { t('cancel') } </Button>
                 <Button variant="brand" onClick={handleSave}> { t('save') } </Button>
               </Stack>
             </div>

--- a/app/javascript/components/admin/site_settings/appearance/BrandColorPopover.jsx
+++ b/app/javascript/components/admin/site_settings/appearance/BrandColorPopover.jsx
@@ -57,7 +57,7 @@ export default function BrandColorPopover({
               <div className="color-preview" style={{ background: initialColor }} />
               <div className="color-preview" style={{ background: color }} />
               <Stack direction="horizontal" className="mt-2 pb-2 float-end">
-                <Button variant="brand-backward" className="me-2" onClick={handleCancel}> { t('cancel') } </Button>
+                <Button variant="brand-outline" className="me-2" onClick={handleCancel}> { t('cancel') } </Button>
                 <Button variant="brand" onClick={handleSave}> { t('save') } </Button>
               </Stack>
             </div>

--- a/app/javascript/components/home/HomePage.jsx
+++ b/app/javascript/components/home/HomePage.jsx
@@ -45,12 +45,12 @@ export default function HomePage() {
             env.OPENID_CONNECT ? (
               <Form action="/auth/openid_connect" method="POST" data-turbo="false">
                 <input type="hidden" name="authenticity_token" value={document.querySelector('meta[name="csrf-token"]').content} />
-                <Button variant="brand-outline" className="btn btn-xlg" type="submit">{t('authentication.sign_up')}</Button>
+                <Button variant="brand-outline-color" className="btn btn-xlg" type="submit">{t('authentication.sign_up')}</Button>
                 <Button variant="brand" className="btn btn-xlg ms-4" type="submit">{t('authentication.sign_in')}</Button>
               </Form>
             ) : (
               <>
-                <ButtonLink to="/signup" variant="brand-outline" className="btn btn-xlg">{t('authentication.sign_up')}</ButtonLink>
+                <ButtonLink to="/signup" variant="brand-outline-color" className="btn btn-xlg">{t('authentication.sign_up')}</ButtonLink>
                 <ButtonLink to="/signin" variant="brand" className="btn btn-xlg ms-4">{t('authentication.sign_in')}</ButtonLink>
               </>
             )

--- a/app/javascript/components/home/HomePage.jsx
+++ b/app/javascript/components/home/HomePage.jsx
@@ -45,12 +45,12 @@ export default function HomePage() {
             env.OPENID_CONNECT ? (
               <Form action="/auth/openid_connect" method="POST" data-turbo="false">
                 <input type="hidden" name="authenticity_token" value={document.querySelector('meta[name="csrf-token"]').content} />
-                <Button variant="brand-backward" className="btn btn-xlg" type="submit">{t('authentication.sign_up')}</Button>
+                <Button variant="brand-outline" className="btn btn-xlg" type="submit">{t('authentication.sign_up')}</Button>
                 <Button variant="brand" className="btn btn-xlg ms-4" type="submit">{t('authentication.sign_in')}</Button>
               </Form>
             ) : (
               <>
-                <ButtonLink to="/signup" variant="brand-backward" className="btn btn-xlg">{t('authentication.sign_up')}</ButtonLink>
+                <ButtonLink to="/signup" variant="brand-outline" className="btn btn-xlg">{t('authentication.sign_up')}</ButtonLink>
                 <ButtonLink to="/signin" variant="brand" className="btn btn-xlg ms-4">{t('authentication.sign_in')}</ButtonLink>
               </>
             )

--- a/app/javascript/components/recordings/forms/DeleteRecordingForm.jsx
+++ b/app/javascript/components/recordings/forms/DeleteRecordingForm.jsx
@@ -18,7 +18,7 @@ export default function DeleteRecordingForm({ mutation: useDeleteAPI, recordId, 
       <p className="text-center"> { t('recording.are_you_sure_delete_recording') }</p>
       <Form methods={methods} onSubmit={deleteAPI.mutate}>
         <Stack direction="horizontal" gap={1} className="float-end">
-          <Button variant="brand-backward" onClick={handleClose}>
+          <Button variant="brand-outline" onClick={handleClose}>
             { t('close') }
           </Button>
           <Button variant="danger" type="submit" disabled={deleteAPI.isLoading}>

--- a/app/javascript/components/rooms/RoomCard.jsx
+++ b/app/javascript/components/rooms/RoomCard.jsx
@@ -46,7 +46,7 @@ export default function RoomCard({ room }) {
         >
           <DuplicateIcon className="hi-m text-brand mt-1" />
         </Button>
-        <Button variant="brand-backward" className="btn btn-md float-end" onClick={startMeeting.mutate} disabled={startMeeting.isLoading}>
+        <Button variant="brand-outline" className="btn btn-md float-end" onClick={startMeeting.mutate} disabled={startMeeting.isLoading}>
           { t('start') }
           {startMeeting.isLoading && <Spinner />}
         </Button>

--- a/app/javascript/components/rooms/room/Room.jsx
+++ b/app/javascript/components/rooms/room/Room.jsx
@@ -40,7 +40,7 @@ export default function Room() {
             { t('room.meeting.start_meeting') }
             {startMeeting.isLoading && <Spinner />}
           </Button>
-          <Button variant="brand-backward" className="mt-1 mx-2 float-end" onClick={copyInvite}>
+          <Button variant="brand-outline" className="mt-1 mx-2 float-end" onClick={copyInvite}>
             <DuplicateIcon className="hi-xs" />
             { t('copy') }
           </Button>

--- a/app/javascript/components/rooms/room/forms/CreateRoomForm.jsx
+++ b/app/javascript/components/rooms/room/forms/CreateRoomForm.jsx
@@ -23,7 +23,7 @@ export default function CreateRoomForm({ mutation: useCreateRoomAPI, userId, han
     <Form methods={methods} onSubmit={createRoomAPI.mutate}>
       <FormControl field={name} type="text" />
       <Stack className="mt-1" direction="horizontal" gap={1}>
-        <Button variant="brand-outline" className="ms-auto" onClick={handleClose}>
+        <Button variant="neutral" className="ms-auto" onClick={handleClose}>
           { t('close') }
         </Button>
         <Button variant="brand" type="submit" disabled={createRoomAPI.isLoading}>

--- a/app/javascript/components/rooms/room/forms/CreateRoomForm.jsx
+++ b/app/javascript/components/rooms/room/forms/CreateRoomForm.jsx
@@ -23,7 +23,7 @@ export default function CreateRoomForm({ mutation: useCreateRoomAPI, userId, han
     <Form methods={methods} onSubmit={createRoomAPI.mutate}>
       <FormControl field={name} type="text" />
       <Stack className="mt-1" direction="horizontal" gap={1}>
-        <Button variant="brand-backward" className="ms-auto" onClick={handleClose}>
+        <Button variant="brand-outline" className="ms-auto" onClick={handleClose}>
           { t('close') }
         </Button>
         <Button variant="brand" type="submit" disabled={createRoomAPI.isLoading}>

--- a/app/javascript/components/rooms/room/forms/DeleteRoomForm.jsx
+++ b/app/javascript/components/rooms/room/forms/DeleteRoomForm.jsx
@@ -18,7 +18,7 @@ export default function DeleteRoomForm({ mutation: useDeleteRoomAPI, handleClose
       <p className="text-center"> Are you sure you want to delete this room?</p>
       <Form methods={methods} onSubmit={deleteRoomAPI.mutate}>
         <Stack direction="horizontal" gap={1} className="float-end">
-          <Button variant="brand-backward" onClick={handleClose}>
+          <Button variant="brand-outline" onClick={handleClose}>
             { t('close') }
           </Button>
           <Button variant="danger" type="submit" disabled={deleteRoomAPI.isLoading}>

--- a/app/javascript/components/rooms/room/forms/DeleteRoomForm.jsx
+++ b/app/javascript/components/rooms/room/forms/DeleteRoomForm.jsx
@@ -18,7 +18,7 @@ export default function DeleteRoomForm({ mutation: useDeleteRoomAPI, handleClose
       <p className="text-center"> Are you sure you want to delete this room?</p>
       <Form methods={methods} onSubmit={deleteRoomAPI.mutate}>
         <Stack direction="horizontal" gap={1} className="float-end">
-          <Button variant="brand-outline" onClick={handleClose}>
+          <Button variant="neutral" onClick={handleClose}>
             { t('close') }
           </Button>
           <Button variant="danger" type="submit" disabled={deleteRoomAPI.isLoading}>

--- a/app/javascript/components/rooms/room/presentation/forms/DeletePresentationForm.jsx
+++ b/app/javascript/components/rooms/room/presentation/forms/DeletePresentationForm.jsx
@@ -20,7 +20,7 @@ export default function DeletePresentationForm({ handleClose }) {
       <p className="text-center"> { t('room.presentation.are_you_sure_delete_presentation') }</p>
       <Form methods={methods} onSubmit={deletePresentation.mutate}>
         <Stack direction="horizontal" gap={1} className="float-end">
-          <Button variant="brand-backward" onClick={handleClose}>
+          <Button variant="brand-outline" onClick={handleClose}>
             { t('close') }
           </Button>
           <Button variant="danger" type="submit" disabled={deletePresentation.isLoading}>

--- a/app/javascript/components/rooms/room/room_settings/AccessCodeRow.jsx
+++ b/app/javascript/components/rooms/room/room_settings/AccessCodeRow.jsx
@@ -60,7 +60,7 @@ export default function AccessCodeRow({
           : (
             <div>
               <Button
-                variant="brand-backward"
+                variant="brand-outline"
                 onClick={handleGenerateCode}
               >
                 { t('room.settings.generate') }

--- a/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
+++ b/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
@@ -99,7 +99,7 @@ export default function RoomSettings() {
           </Row>
           <Row className="float-end">
             <Modal
-              modalButton={<Button variant="brand-backward" className="mt-1 mx-2 float-end">{ t('room.delete_room') }</Button>}
+              modalButton={<Button variant="brand-outline" className="mt-1 mx-2 float-end">{ t('room.delete_room') }</Button>}
               title={t('room.delete_room')}
               body={<DeleteRoomForm mutation={deleteMutationWrapper} />}
             />

--- a/app/javascript/components/rooms/room/shared_access/SharedAccess.jsx
+++ b/app/javascript/components/rooms/room/shared_access/SharedAccess.jsx
@@ -29,7 +29,7 @@ export default function SharedAccess() {
             <SearchBarQuery setInput={setInput} />
           </div>
           <Modal
-            modalButton={<Button variant="brand-backward" className="ms-auto">{ t('room.shared_access.new_share_access')}</Button>}
+            modalButton={<Button variant="brand-outline" className="ms-auto">{ t('room.shared_access.new_share_access')}</Button>}
             title={t('room.shared_access.share_room_access')}
             body={<SharedAccessForm />}
             size="lg"

--- a/app/javascript/components/rooms/room/shared_access/SharedAccessEmpty.jsx
+++ b/app/javascript/components/rooms/room/shared_access/SharedAccessEmpty.jsx
@@ -20,7 +20,7 @@ export default function SharedAccessEmpty() {
             { t('room.shared_access.add_some_users_description') }
           </Card.Text>
           <Modal
-            modalButton={<Button variant="brand-backward">{ t('room.shared_access.add_share_access') }</Button>}
+            modalButton={<Button variant="brand-outline">{ t('room.shared_access.add_share_access') }</Button>}
             title={t('room.shared_access.share_room_access')}
             body={<SharedAccessForm />}
             size="lg"

--- a/app/javascript/components/rooms/room/shared_access/SharedAccessList.jsx
+++ b/app/javascript/components/rooms/room/shared_access/SharedAccessList.jsx
@@ -28,7 +28,7 @@ export default function SharedAccessList({ users, isLoading }) {
           <SearchBar setSearch={setSearch} className="w-100" />
         </div>
         <Modal
-          modalButton={<Button variant="brand-backward" className="ms-auto">{ t('room.shared_access.add_share_access') }</Button>}
+          modalButton={<Button variant="brand-outline" className="ms-auto">{ t('room.shared_access.add_share_access') }</Button>}
           title={t('room.shared_access.share_room_access')}
           body={<SharedAccessForm />}
           size="lg"

--- a/app/javascript/components/rooms/room/shared_access/forms/SharedAccessForm.jsx
+++ b/app/javascript/components/rooms/room/shared_access/forms/SharedAccessForm.jsx
@@ -63,7 +63,7 @@ export default function SharedAccessForm({ handleClose }) {
           </tbody>
         </Table>
         <Stack className="mt-3" direction="horizontal" gap={1}>
-          <Button variant="brand-backward" className="ms-auto" onClick={handleClose}>
+          <Button variant="brand-outline" className="ms-auto" onClick={handleClose}>
             { t('close') }
           </Button>
           <Button variant="brand" type="submit">

--- a/app/javascript/components/rooms/room/shared_access/forms/SharedAccessForm.jsx
+++ b/app/javascript/components/rooms/room/shared_access/forms/SharedAccessForm.jsx
@@ -63,7 +63,7 @@ export default function SharedAccessForm({ handleClose }) {
           </tbody>
         </Table>
         <Stack className="mt-3" direction="horizontal" gap={1}>
-          <Button variant="brand-outline" className="ms-auto" onClick={handleClose}>
+          <Button variant="neutral" className="ms-auto" onClick={handleClose}>
             { t('close') }
           </Button>
           <Button variant="brand" type="submit">

--- a/app/javascript/components/shared_components/PaginationPrevButton.jsx
+++ b/app/javascript/components/shared_components/PaginationPrevButton.jsx
@@ -10,7 +10,7 @@ export default function PaginationButton({ direction }) {
 
   if (direction === 'Previous') {
     return (
-      <Button variant="brand-backward">
+      <Button variant="brand-outline">
         <ArrowLeftIcon className="me-3 hi-s text-brand" />
         { t('previous') }
       </Button>
@@ -19,7 +19,7 @@ export default function PaginationButton({ direction }) {
 
   if (direction === 'Next') {
     return (
-      <Button variant="brand-backward">
+      <Button variant="brand-outline">
         { t('next') }
         <ArrowRightIcon className="ms-3 hi-s text-brand" />
       </Button>

--- a/app/javascript/components/users/user/DeleteAccount.jsx
+++ b/app/javascript/components/users/user/DeleteAccount.jsx
@@ -14,7 +14,7 @@ export default function DeleteAccount() {
         { t('user.account.delete_account_description') }
       </p>
       <Modal
-        modalButton={<Button variant="danger">{ t('user.account.delete_account_confirmation') }</Button>}
+        modalButton={<Button variant="delete">{ t('user.account.delete_account_confirmation') }</Button>}
         title={t('are_you_sure')}
         body={<DeleteUserForm />}
       />

--- a/app/javascript/components/users/user/SetAvatar.jsx
+++ b/app/javascript/components/users/user/SetAvatar.jsx
@@ -89,7 +89,7 @@ export default function SetAvatar({ user }) {
           </div>
         </Modal.Body>
         <Modal.Footer>
-          <Button variant="brand-backward" onClick={handleClose}>
+          <Button variant="brand-outline" onClick={handleClose}>
             { t('close') }
           </Button>
           <Button variant="brand" onClick={handleSave}>

--- a/app/javascript/components/users/user/forms/DeleteUserForm.jsx
+++ b/app/javascript/components/users/user/forms/DeleteUserForm.jsx
@@ -21,7 +21,7 @@ export default function DeleteUserForm({ handleClose }) {
       <p className="text-center"> { t('user.account.are_you_sure_delete_account') }</p>
       <Form methods={methods} onSubmit={deleteUserAPI.mutate}>
         <Stack direction="horizontal" gap={1} className="float-end">
-          <Button variant="brand-outline" onClick={handleClose}>
+          <Button variant="neutral" onClick={handleClose}>
             { t('close') }
           </Button>
           <Button variant="danger" type="submit" disabled={deleteUserAPI.isLoading}>

--- a/app/javascript/components/users/user/forms/DeleteUserForm.jsx
+++ b/app/javascript/components/users/user/forms/DeleteUserForm.jsx
@@ -21,7 +21,7 @@ export default function DeleteUserForm({ handleClose }) {
       <p className="text-center"> { t('user.account.are_you_sure_delete_account') }</p>
       <Form methods={methods} onSubmit={deleteUserAPI.mutate}>
         <Stack direction="horizontal" gap={1} className="float-end">
-          <Button variant="brand-backward" onClick={handleClose}>
+          <Button variant="brand-outline" onClick={handleClose}>
             { t('close') }
           </Button>
           <Button variant="danger" type="submit" disabled={deleteUserAPI.isLoading}>

--- a/app/javascript/components/users/user/forms/UpdateUserForm.jsx
+++ b/app/javascript/components/users/user/forms/UpdateUserForm.jsx
@@ -62,7 +62,7 @@ export default function UpdateUserForm({ user }) {
 
       <Stack direction="horizontal" gap={2} className="float-end">
         <Button
-          variant="brand-backward"
+          variant="brand-outline"
           onClick={() => methods.reset({
             name: user.name,
             email: user.email,

--- a/app/javascript/components/users/user/forms/UpdateUserForm.jsx
+++ b/app/javascript/components/users/user/forms/UpdateUserForm.jsx
@@ -62,7 +62,7 @@ export default function UpdateUserForm({ user }) {
 
       <Stack direction="horizontal" gap={2} className="float-end">
         <Button
-          variant="brand-outline"
+          variant="neutral"
           onClick={() => methods.reset({
             name: user.name,
             email: user.email,


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Change brand button styling (as per requested by Tyler)

Remove the "inside-out" effect on brand button, it is now grayed-out on hover instead.
Rename btn-brand-backward to btn-brand-outline.

![image](https://user-images.githubusercontent.com/43917914/192051409-24e1d1e8-3e1c-4e8f-9b0b-c308ffdbacc3.png)

- Add three new buttons variants (delete, neutral and brand-outline-color)

The neutral is really needed for the cancel/close buttons.
It makes no sense to have, for example, a cancel/close button with a bright green color (if green is the brand color).
![image](https://user-images.githubusercontent.com/43917914/192050133-b3848016-e9a7-4614-8542-f8166633aa7d.png)

The delete variant is as per the mock-ups.
![image](https://user-images.githubusercontent.com/43917914/192050171-83acc438-9248-423b-aa52-ed6d0c0ddb0f.png)

The brand-outline-color is used specifically on the Homepage right now.
![image](https://user-images.githubusercontent.com/43917914/192057148-9513ff81-1ab9-495c-b8d8-3b2755f9de28.png)



