### PR TITLE
Online Feedback - create online column in Room

### DIFF
--- a/app/assets/stylesheets/helpers.scss
+++ b/app/assets/stylesheets/helpers.scss
@@ -8,7 +8,7 @@
   margin: 0 -600rem;
   padding: 0.25rem 600rem;
   //TODO - samuel: need to find a solution for this
-  height: 317px;
+  height: 302px;
 }
 
 .wide-background-rooms {

--- a/app/assets/stylesheets/rooms.scss
+++ b/app/assets/stylesheets/rooms.scss
@@ -9,6 +9,10 @@
       cursor: pointer;
     }
   }
+  .room-card-badges {
+    margin-bottom: auto;
+    margin-left: auto;
+  }
 }
 
 .tab-content {

--- a/app/controllers/api/v1/admin/server_rooms_controller.rb
+++ b/app/controllers/api/v1/admin/server_rooms_controller.rb
@@ -14,9 +14,19 @@ module Api
 
           pagy, rooms = pagy(rooms)
 
-          rooms = RunningMeetingChecker.new(rooms:).call
+          active_rooms = BigBlueButtonApi.new.active_meetings
+          active_rooms_hash = {}
 
-          render_data data: rooms, meta: pagy_metadata(pagy), serializer: ServerRoomSerializer, status: :ok
+          active_rooms.each do |active_room|
+            active_rooms_hash[active_room[:meetingID]] = active_room[:participantCount]
+          end
+
+          @rooms.each do |room|
+            room.active = active_rooms_hash.key?(room.meeting_id)
+            room.participants = active_rooms_hash[room.meeting_id]
+          end
+
+          render_data data: @rooms, meta: pagy_metadata(pagy), serializer: ServerRoomSerializer, status: :ok
         end
       end
     end

--- a/app/controllers/api/v1/admin/server_rooms_controller.rb
+++ b/app/controllers/api/v1/admin/server_rooms_controller.rb
@@ -21,12 +21,12 @@ module Api
             active_rooms_hash[active_room[:meetingID]] = active_room[:participantCount]
           end
 
-          @rooms.each do |room|
+          rooms.each do |room|
             room.active = active_rooms_hash.key?(room.meeting_id)
             room.participants = active_rooms_hash[room.meeting_id]
           end
 
-          render_data data: @rooms, meta: pagy_metadata(pagy), serializer: ServerRoomSerializer, status: :ok
+          render_data data: rooms, meta: pagy_metadata(pagy), serializer: ServerRoomSerializer, status: :ok
         end
       end
     end

--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -23,7 +23,6 @@ module Api
             current_user:,
             provider: current_provider
           ).call
-          @room.update(online: true)
         rescue BigBlueButton::BigBlueButtonException => e
           return render_error status: :bad_request unless e.key == 'idNotUnique'
         end
@@ -67,7 +66,6 @@ module Api
               current_user:,
               provider: current_provider
             ).call
-            @room.update(online: true)
           rescue BigBlueButton::BigBlueButtonException => e
             return render_error status: :bad_request unless e.key == 'idNotUnique'
           end

--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -23,6 +23,7 @@ module Api
             current_user:,
             provider: current_provider
           ).call
+          @room.update(online: true)
         rescue BigBlueButton::BigBlueButtonException => e
           return render_error status: :bad_request unless e.key == 'idNotUnique'
         end
@@ -66,6 +67,7 @@ module Api
               current_user:,
               provider: current_provider
             ).call
+            @room.update(online: true)
           rescue BigBlueButton::BigBlueButtonException => e
             return render_error status: :bad_request unless e.key == 'idNotUnique'
           end
@@ -81,6 +83,7 @@ module Api
             role: bbb_role
           )
         end
+
         render_data data:, status: :ok
       end
 

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -27,9 +27,8 @@ module Api
         end
 
         rooms = user_rooms + shared_rooms
-        online_rooms = rooms.select { |room| room.online == true }
 
-        RunningMeetingChecker.new(rooms: online_rooms).call
+        RunningMeetingChecker.new(rooms:).call
 
         render_data data: rooms, status: :ok
       end

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -26,13 +26,18 @@ module Api
           room
         end
 
-        rooms = RunningMeetingChecker.new(rooms: user_rooms + shared_rooms).call
+        rooms = user_rooms + shared_rooms
+        online_rooms = rooms.select { |room| room.online == true }
+
+        RunningMeetingChecker.new(rooms: online_rooms).call
 
         render_data data: rooms, status: :ok
       end
 
       # GET /api/v1/rooms/:friendly_id.json
       def show
+        RunningMeetingChecker.new(rooms: @room).call if @room.online
+
         render_data data: @room, serializer: CurrentRoomSerializer, options: { include_owner: params[:include_owner] == 'true' }, status: :ok
       end
 

--- a/app/controllers/external_controller.rb
+++ b/app/controllers/external_controller.rb
@@ -44,7 +44,7 @@ class ExternalController < ApplicationController
     return render json: {} unless params[:recordingmarks] == 'true'
 
     @room = Room.find_by(meeting_id: params[:meetingID])
-    @room.update(recordings_processing: @room.recordings_processing + 1)
+    @room.update(recordings_processing: @room.recordings_processing + 1, online: false)
 
     render json: {}, status: :ok
   end

--- a/app/javascript/components/rooms/MeetingBadges.jsx
+++ b/app/javascript/components/rooms/MeetingBadges.jsx
@@ -4,11 +4,10 @@ import PropTypes from 'prop-types';
 import MeetingStatusBadge from './MeetingStatusBadge';
 import MeetingParticipantsBadge from './MeetingParticipantsBadge';
 
-export default function MeetingBadges({ active, count }) {
+export default function MeetingBadges({ count }) {
   return (
     <Stack direction="horizontal" gap={0} className="room-card-badges">
-      { active
-        && <MeetingStatusBadge />}
+      <MeetingStatusBadge />
       { count >= 1
         && <MeetingParticipantsBadge count={count} />}
     </Stack>
@@ -16,6 +15,5 @@ export default function MeetingBadges({ active, count }) {
 }
 
 MeetingBadges.propTypes = {
-  active: PropTypes.bool.isRequired,
   count: PropTypes.number.isRequired,
 };

--- a/app/javascript/components/rooms/MeetingBadges.jsx
+++ b/app/javascript/components/rooms/MeetingBadges.jsx
@@ -6,7 +6,7 @@ import MeetingParticipantsBadge from './MeetingParticipantsBadge';
 
 export default function MeetingBadges({ active, count }) {
   return (
-    <Stack direction="horizontal" gap={0} className="room-card-badges ms-auto mb-auto">
+    <Stack direction="horizontal" gap={0} className="room-card-badges">
       { active
         && <MeetingStatusBadge />}
       { count >= 1

--- a/app/javascript/components/rooms/RoomCard.jsx
+++ b/app/javascript/components/rooms/RoomCard.jsx
@@ -32,7 +32,7 @@ export default function RoomCard({ room }) {
             )}
           </div>
           { room.online
-            && <MeetingBadges active={room.active} count={room.participants} />}
+            && <MeetingBadges active={room.online} count={room.participants} />}
         </Stack>
 
         <Stack className="my-4">

--- a/app/javascript/components/rooms/RoomCard.jsx
+++ b/app/javascript/components/rooms/RoomCard.jsx
@@ -31,7 +31,8 @@ export default function RoomCard({ room }) {
               <UserIcon className="hi-m text-brand pt-4 d-block mx-auto" />
             )}
           </div>
-          <MeetingBadges active={room.active} count={room.participants} />
+          { room.active
+            && <MeetingBadges active={room.active} count={room.participants} />}
         </Stack>
 
         <Stack className="my-4">

--- a/app/javascript/components/rooms/RoomCard.jsx
+++ b/app/javascript/components/rooms/RoomCard.jsx
@@ -31,7 +31,7 @@ export default function RoomCard({ room }) {
               <UserIcon className="hi-m text-brand pt-4 d-block mx-auto" />
             )}
           </div>
-          { room.active
+          { room.online
             && <MeetingBadges active={room.active} count={room.participants} />}
         </Stack>
 
@@ -55,7 +55,7 @@ export default function RoomCard({ room }) {
           <DocumentDuplicateIcon className="hi-m text-brand mt-1" />
         </Button>
         <Button variant="brand-outline" className="btn btn-md float-end" onClick={startMeeting.mutate} disabled={startMeeting.isLoading}>
-          { room.active ? (
+          { room.online ? (
             t('join')
           ) : (
             t('start')
@@ -80,7 +80,7 @@ RoomCard.propTypes = {
     name: PropTypes.string.isRequired,
     last_session: PropTypes.string,
     shared_owner: PropTypes.string,
-    active: PropTypes.bool,
+    online: PropTypes.bool,
     participants: PropTypes.number,
   }).isRequired,
 };

--- a/app/javascript/components/rooms/RoomsList.jsx
+++ b/app/javascript/components/rooms/RoomsList.jsx
@@ -36,7 +36,7 @@ export default function RoomsList() {
       </Stack>
       <Row md={4} className="g-4 pb-4 mt-4">
         {
-          rooms.sort((a, b) => b.active - a.active).filter((room) => {
+          rooms.sort((a, b) => b.online - a.online).filter((room) => {
             if (room.name.toLowerCase().includes(search.toLowerCase())) {
               return room;
             }

--- a/app/javascript/components/rooms/room/Room.jsx
+++ b/app/javascript/components/rooms/room/Room.jsx
@@ -51,7 +51,7 @@ export default function Room() {
         </Col>
         <Col>
           <Button variant="brand" className="mt-1 mx-2 float-end" onClick={startMeeting.mutate} disabled={startMeeting.isLoading}>
-            { room.active ? (
+            { room.online ? (
               t('room.meeting.join_meeting')
             ) : (
               t('room.meeting.start_meeting')

--- a/app/javascript/components/rooms/room/Room.jsx
+++ b/app/javascript/components/rooms/room/Room.jsx
@@ -38,9 +38,9 @@ export default function Room() {
         <Col className="col-xxl-8">
           <Stack direction="horizontal" gap={2}>
             <h1>{room.name}</h1>
-            <div className="mb-2">
-              { room.active
-                && <MeetingBadges active={room.active} count={room.participants} />}
+            <div className="mb-1">
+              { room.online
+                && <MeetingBadges active={room.online} count={room.participants} />}
             </div>
           </Stack>
           { room.last_session ? (

--- a/app/javascript/components/rooms/room/Room.jsx
+++ b/app/javascript/components/rooms/room/Room.jsx
@@ -41,10 +41,12 @@ export default function Room() {
         <Col className="col-xxl-8">
           <Stack direction="horizontal" gap={2}>
             <h1>{room.name}</h1>
-            { isRunning
-              && (
-                <MeetingBadges active={room.active} count={room.participants} />
-              )}
+            <div className="mb-2">
+              { isRunning
+                && (
+                  <MeetingBadges active={room.active} count={room.participants} />
+                )}
+            </div>
           </Stack>
           { room.last_session ? (
             <span className="text-muted"> { t('room.last_session', { room }) }  </span>

--- a/app/javascript/components/rooms/room/Room.jsx
+++ b/app/javascript/components/rooms/room/Room.jsx
@@ -10,7 +10,6 @@ import FeatureTabs from './FeatureTabs';
 import Spinner from '../../shared_components/utilities/Spinner';
 import useRoom from '../../../hooks/queries/rooms/useRoom';
 import useStartMeeting from '../../../hooks/mutations/rooms/useStartMeeting';
-import useMeetingRunning from '../../../hooks/queries/rooms/useMeetingRunning';
 import MeetingBadges from '../MeetingBadges';
 
 function copyInvite() {
@@ -23,9 +22,7 @@ export default function Room() {
   const { friendlyId } = useParams();
   const { isLoading: isLoadingRoom, data: room } = useRoom(friendlyId);
   const startMeeting = useStartMeeting(friendlyId);
-  const { isLoading: isLoadingRunning, data: isRunning } = useMeetingRunning(friendlyId);
 
-  if (isLoadingRunning) return <Spinner />; // Todo: amir - Revisit this.
   if (isLoadingRoom) return <Spinner />; // Todo: amir - Revisit this.
 
   return (
@@ -42,10 +39,8 @@ export default function Room() {
           <Stack direction="horizontal" gap={2}>
             <h1>{room.name}</h1>
             <div className="mb-2">
-              { isRunning
-                && (
-                  <MeetingBadges active={room.active} count={room.participants} />
-                )}
+              { room.active
+                && <MeetingBadges active={room.active} count={room.participants} />}
             </div>
           </Stack>
           { room.last_session ? (
@@ -56,7 +51,7 @@ export default function Room() {
         </Col>
         <Col>
           <Button variant="brand" className="mt-1 mx-2 float-end" onClick={startMeeting.mutate} disabled={startMeeting.isLoading}>
-            { isRunning ? (
+            { room.active ? (
               t('room.meeting.join_meeting')
             ) : (
               t('room.meeting.start_meeting')

--- a/app/serializers/current_room_serializer.rb
+++ b/app/serializers/current_room_serializer.rb
@@ -4,7 +4,7 @@ class CurrentRoomSerializer < ApplicationSerializer
   include Presentable
   include Avatarable
 
-  attributes :id, :name, :presentation_name, :thumbnail
+  attributes :id, :name, :presentation_name, :thumbnail, :online, :participants
 
   attribute :owner_name, if: -> { @instance_options[:options][:include_owner] }
   attribute :owner_avatar, if: -> { @instance_options[:options][:include_owner] }

--- a/app/serializers/room_serializer.rb
+++ b/app/serializers/room_serializer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class RoomSerializer < ApplicationSerializer
-  attributes :id, :name, :friendly_id, :active, :participants
+  attributes :id, :name, :friendly_id, :online, :participants
+
   attribute :shared_owner, if: -> { object.shared }
   attribute :last_session, if: -> { object.last_session }
 

--- a/app/services/big_blue_button_api.rb
+++ b/app/services/big_blue_button_api.rb
@@ -44,6 +44,10 @@ class BigBlueButtonApi
     bbb_server.get_meetings[:meetings]
   end
 
+  def get_meeting_info(meeting_id:)
+    bbb_server.get_meeting_info(meeting_id, nil)
+  end
+
   # Retrieve the recordings that belong to room with given record_id
   def get_recording(record_id:)
     bbb_server.get_recordings(recordID: record_id)[:recordings][0]

--- a/app/services/meeting_starter.rb
+++ b/app/services/meeting_starter.rb
@@ -21,7 +21,7 @@ class MeetingStarter
     begin
       meeting = BigBlueButtonApi.new.start_meeting room: @room, options: options, presentation_url: @presentation_url
 
-      @room.update!(last_session: DateTime.strptime(meeting[:createTime].to_s, '%Q', online: true))
+      @room.update!(online: true, last_session: DateTime.strptime(meeting[:createTime].to_s, '%Q'))
 
       ActionCable.server.broadcast "#{@room.friendly_id}_rooms_channel", 'started'
     rescue BigBlueButton::BigBlueButtonException => e

--- a/app/services/meeting_starter.rb
+++ b/app/services/meeting_starter.rb
@@ -21,7 +21,7 @@ class MeetingStarter
     begin
       meeting = BigBlueButtonApi.new.start_meeting room: @room, options: options, presentation_url: @presentation_url
 
-      @room.update!(last_session: DateTime.strptime(meeting[:createTime].to_s, '%Q'))
+      @room.update!(last_session: DateTime.strptime(meeting[:createTime].to_s, '%Q', online: true))
 
       ActionCable.server.broadcast "#{@room.friendly_id}_rooms_channel", 'started'
     rescue BigBlueButton::BigBlueButtonException => e

--- a/app/services/running_meeting_checker.rb
+++ b/app/services/running_meeting_checker.rb
@@ -7,7 +7,9 @@ class RunningMeetingChecker
   end
 
   def call
-    Array(@rooms).each do |online_room|
+    online_rooms = Array(@rooms).select { |room| room.online == true }
+
+    online_rooms.each do |online_room|
       bbb_meeting = BigBlueButtonApi.new.get_meeting_info(meeting_id: online_room.meeting_id)
       online_room.participants = bbb_meeting[:participantCount]
     rescue BigBlueButton::BigBlueButtonException

--- a/db/migrate/20220928193827_add_online_to_room.rb
+++ b/db/migrate/20220928193827_add_online_to_room.rb
@@ -1,0 +1,5 @@
+class AddOnlineToRoom < ActiveRecord::Migration[7.0]
+  def change
+    add_column :rooms, :online, :boolean
+  end
+end

--- a/db/migrate/20220928193827_add_online_to_room.rb
+++ b/db/migrate/20220928193827_add_online_to_room.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddOnlineToRoom < ActiveRecord::Migration[7.0]
   def change
     add_column :rooms, :online, :boolean

--- a/db/migrate/20220928193827_add_online_to_room.rb
+++ b/db/migrate/20220928193827_add_online_to_room.rb
@@ -2,6 +2,6 @@
 
 class AddOnlineToRoom < ActiveRecord::Migration[7.0]
   def change
-    add_column :rooms, :online, :boolean
+    add_column :rooms, :online, :boolean, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_14_190934) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_28_193827) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -119,6 +119,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_190934) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "recordings_processing", default: 0
+    t.boolean "online"
     t.index ["friendly_id"], name: "index_rooms_on_friendly_id", unique: true
     t.index ["meeting_id"], name: "index_rooms_on_meeting_id", unique: true
     t.index ["user_id"], name: "index_rooms_on_user_id"


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add online boolean column to Room.
When a meeting is started, `room.online = true`.
When a meeting is closed, `room.online = false` via the callback endpoint in ExternalController.

You can pass a Room or a bunch of Rooms to RunningMeetingChecker and it will confirm if a meeting is truly online by running `get_meeting_info` on the provided rooms.




## TODO
<!--- Please describe in detail how to test your changes. -->

- Add RunningMeetingChecker specs
- Run benchmark on ServerRooms? `active_meetings` vs running the RunningMeeting service?

![image](https://user-images.githubusercontent.com/43917914/192634492-c797c11d-14fe-4fc7-b490-4c6542a724e5.png)
![image](https://user-images.githubusercontent.com/43917914/192634534-6f149add-5146-4bbd-85e3-21fbe63001ee.png)

