### PR TITLE
Added ResyncOnLogin Site Setting

### DIFF
--- a/app/javascript/components/admin/site_settings/SettingsRow.jsx
+++ b/app/javascript/components/admin/site_settings/SettingsRow.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Stack } from 'react-bootstrap';
-import useUpdateSiteSetting from '../../../../hooks/mutations/admin/site_settings/useUpdateSiteSetting';
+import useUpdateSiteSetting from '../../../hooks/mutations/admin/site_settings/useUpdateSiteSetting';
 
 export default function SettingsRow({
   name, title, description, value,

--- a/app/javascript/components/admin/site_settings/registration/Registration.jsx
+++ b/app/javascript/components/admin/site_settings/registration/Registration.jsx
@@ -5,22 +5,42 @@ import useUpdateSiteSetting from '../../../../hooks/mutations/admin/site_setting
 import RegistrationForm from './forms/RegistrationForm';
 import useSiteSettings from '../../../../hooks/queries/admin/site_settings/useSiteSettings';
 import Spinner from '../../../shared_components/utilities/Spinner';
+import SettingsRow from '../SettingsRow';
+import useEnv from '../../../../hooks/queries/env/useEnv';
 
 export default function Registration() {
   const { t } = useTranslation();
 
-  const { isLoading, data: registration } = useSiteSettings(['RoleMapping']);
+  const { isLoading, data: registration } = useSiteSettings(['RoleMapping', 'ResyncOnLogin']);
+  const { isLoadingEnv, data: env } = useEnv();
 
-  if (isLoading) return <Spinner />;
+  if (isLoading || isLoadingEnv) return <Spinner />;
 
   return (
-    <Row className="mb-3">
-      <h6> { t('admin.site_settings.registration.role_mapping_by_email') } </h6>
-      <p className="text-muted"> { t('admin.site_settings.registration.role_mapping_by_email_description') } </p>
-      <RegistrationForm
-        mutation={() => useUpdateSiteSetting('RoleMapping')}
-        value={registration.RoleMapping}
-      />
-    </Row>
+    <>
+      { env.OPENID_CONNECT && (
+        <Row className="mb-3">
+          <SettingsRow
+            name="ResyncOnLogin"
+            title={t('admin.site_settings.registration.resync_on_login')}
+            description={(
+              <p className="text-muted">
+                { t('admin.site_settings.registration.resync_on_login_description') }
+              </p>
+            )}
+            value={registration.ResyncOnLogin}
+          />
+        </Row>
+      )}
+
+      <Row className="mb-3">
+        <h6> { t('admin.site_settings.registration.role_mapping_by_email') } </h6>
+        <p className="text-muted"> { t('admin.site_settings.registration.role_mapping_by_email_description') } </p>
+        <RegistrationForm
+          mutation={() => useUpdateSiteSetting('RoleMapping')}
+          value={registration.RoleMapping}
+        />
+      </Row>
+    </>
   );
 }

--- a/app/javascript/components/admin/site_settings/settings/Settings.jsx
+++ b/app/javascript/components/admin/site_settings/settings/Settings.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import useSiteSettings from '../../../../hooks/queries/admin/site_settings/useSiteSettings';
 import Spinner from '../../../shared_components/utilities/Spinner';
-import SettingsRow from './SettingsRow';
+import SettingsRow from '../SettingsRow';
 
 export default function Settings() {
   const { t } = useTranslation();

--- a/db/data/20220929144051_add_resync_on_login_to_settings.rb
+++ b/db/data/20220929144051_add_resync_on_login_to_settings.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddResyncOnLoginToSettings < ActiveRecord::Migration[7.0]
+  def up
+    setting = Setting.create!(name: 'ResyncOnLogin')
+    SiteSetting.create!(setting:, value: 'true', provider: 'greenlight')
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -222,7 +222,9 @@
         "registration": "Registration",
         "role_mapping_by_email": "Role Mapping By Email",
         "role_mapping_by_email_description": "Map the user to a role using their email. Must be in the format: role1=email1, role2=email2",
-        "enter_role_mapping_rule": "Enter a role mapping rule"
+        "enter_role_mapping_rule": "Enter a role mapping rule",
+        "resync_on_login": "Resync User Data On Every Sign In",
+        "resync_on_login_description": "Resync a user's information every time they sign in, making the external authentication provider always match the information in Greenlight"
       }
     },
     "room_configuration": {

--- a/spec/controllers/external_controller_spec.rb
+++ b/spec/controllers/external_controller_spec.rb
@@ -74,6 +74,18 @@ RSpec.describe ExternalController, type: :controller do
         expect(user.name).to eq('Example Name')
         expect(user.email).to eq('email@example.com')
       end
+
+      it 'does not overwrite the role even if true' do
+        allow_any_instance_of(SettingGetter).to receive(:call).and_return(true)
+        request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
+
+        new_role = create(:role)
+        user.update(role: new_role)
+
+        get :create_user, params: { provider: 'openid_connect' }
+
+        expect(user.reload.role).to eq(new_role)
+      end
     end
   end
 

--- a/spec/controllers/external_controller_spec.rb
+++ b/spec/controllers/external_controller_spec.rb
@@ -42,6 +42,39 @@ RSpec.describe ExternalController, type: :controller do
 
       expect(User.find_by(email: OmniAuth.config.mock_auth[:openid_connect][:info][:email]).role).to eq(role)
     end
+
+    context 'ResyncOnLogin' do
+      let!(:user) do
+        create(:user,
+               external_id: OmniAuth.config.mock_auth[:openid_connect]['uid'],
+               name: 'Example Name',
+               email: 'email@example.com')
+      end
+
+      it 'overwrites the saved values with the values from the authentication provider if true' do
+        allow_any_instance_of(SettingGetter).to receive(:call).and_return(true)
+
+        request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
+
+        get :create_user, params: { provider: 'openid_connect' }
+
+        user.reload
+        expect(user.name).to eq(OmniAuth.config.mock_auth[:openid_connect]['info']['name'])
+        expect(user.email).to eq(OmniAuth.config.mock_auth[:openid_connect]['info']['email'])
+      end
+
+      it 'does not overwrite the saved values with the values from the authentication provider if false' do
+        allow_any_instance_of(SettingGetter).to receive(:call).and_return(false)
+
+        request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
+
+        get :create_user, params: { provider: 'openid_connect' }
+
+        user.reload
+        expect(user.name).to eq('Example Name')
+        expect(user.email).to eq('email@example.com')
+      end
+    end
   end
 
   describe '#recording_ready' do


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Added a new site setting that will only appear if using an external authentication provider. This site setting will determine what is the source of truth - Greenlight or the Authentication provider.

If Greenlight is the source of truth, the user's information (name, email, picture, .. ) will never change even if they change in the authentication provider. 

If the authentication provider is the source of truth, the information in greenlight (name, email, picture) will always match whatever is in the authentication provider

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
