### PR TITLE
Add Admin/ServerRooms sorting

### DIFF
--- a/app/javascript/components/admin/server_rooms/ServerRoomRow.jsx
+++ b/app/javascript/components/admin/server_rooms/ServerRoomRow.jsx
@@ -38,9 +38,9 @@ export default function ServerRoomRow({ room }) {
 
   const meetingRunning = () => {
     if (online) {
-      return <td className="border-0 text-success"> { t('admin.server_rooms.running') } </td>
+      return <td className="border-0 text-success"> { t('admin.server_rooms.running') } </td>;
     }
-    return <td className="border-0"> { t('admin.server_rooms.not_running') } </td>
+    return <td className="border-0"> { t('admin.server_rooms.not_running') } </td>;
   };
 
   return (

--- a/app/javascript/components/admin/server_rooms/ServerRoomRow.jsx
+++ b/app/javascript/components/admin/server_rooms/ServerRoomRow.jsx
@@ -36,6 +36,13 @@ export default function ServerRoomRow({ room }) {
     return t('admin.server_rooms.last_session', { lastSession });
   };
 
+  const meetingRunning = () => {
+    if (online) {
+      return <td className="border-0 text-success"> { t('admin.server_rooms.running') } </td>
+    }
+    return <td className="border-0"> { t('admin.server_rooms.not_running') } </td>
+  };
+
   return (
     <tr className="align-middle text-muted border border-2">
       <td className="border-end-0">
@@ -47,7 +54,7 @@ export default function ServerRoomRow({ room }) {
       <td className="border-0"> {owner}</td>
       <td className="border-0"> {friendlyId} </td>
       <td className="border-0"> {participants || '-'} </td>
-      <td className="border-0"> {online ? t('admin.server_rooms.running') : t('admin.server_rooms.not_running')} </td>
+      { meetingRunning() }
       <td className="border-start-0">
         <Dropdown className="float-end cursor-pointer">
           <Dropdown.Toggle className="hi-s" as={EllipsisVerticalIcon} />

--- a/app/javascript/components/admin/server_rooms/ServerRoomRow.jsx
+++ b/app/javascript/components/admin/server_rooms/ServerRoomRow.jsx
@@ -15,7 +15,7 @@ import { useAuth } from '../../../contexts/auth/AuthProvider';
 
 export default function ServerRoomRow({ room }) {
   const {
-    friendly_id: friendlyId, name, owner, last_session: lastSession, active, participants,
+    friendly_id: friendlyId, name, owner, last_session: lastSession, online, participants,
   } = room;
   const { t } = useTranslation();
   const mutationWrapper = (args) => useDeleteServerRoom({ friendlyId, ...args });
@@ -30,7 +30,7 @@ export default function ServerRoomRow({ room }) {
     if (lastSession == null) {
       return t('admin.server_rooms.no_meeting_yet');
     }
-    if (active) {
+    if (online) {
       return t('admin.server_rooms.current_session', { lastSession });
     }
     return t('admin.server_rooms.last_session', { lastSession });
@@ -47,12 +47,12 @@ export default function ServerRoomRow({ room }) {
       <td className="border-0"> {owner}</td>
       <td className="border-0"> {friendlyId} </td>
       <td className="border-0"> {participants || '-'} </td>
-      <td className="border-0"> {active ? t('admin.server_rooms.active') : t('admin.server_rooms.not_running')} </td>
+      <td className="border-0"> {online ? t('admin.server_rooms.running') : t('admin.server_rooms.not_running')} </td>
       <td className="border-start-0">
         <Dropdown className="float-end cursor-pointer">
           <Dropdown.Toggle className="hi-s" as={EllipsisVerticalIcon} />
           <Dropdown.Menu>
-            { room.active
+            { room.online
               ? (
                 <Dropdown.Item className="text-muted" onClick={handleJoin}>
                   <ArrowTopRightOnSquareIcon className="hi-s pb-1 me-1" /> { t('join') }
@@ -67,7 +67,7 @@ export default function ServerRoomRow({ room }) {
               <EyeIcon className="hi-s pb-1 me-1" /> { t('view') }
             </Dropdown.Item>
             <Modal
-              modalButton={<Dropdown.Item className="text-muted"><TrashIcon className="hi-s pb-1 me-1" /> Delete</Dropdown.Item>}
+              modalButton={<Dropdown.Item className="text-muted"><TrashIcon className="hi-s pb-1 me-1" /> { t('delete') }</Dropdown.Item>}
               title={t('admin.server_rooms.delete_server_rooms')}
               body={<DeleteRoomForm mutation={mutationWrapper} />}
             />
@@ -83,7 +83,7 @@ ServerRoomRow.propTypes = {
     name: PropTypes.string.isRequired,
     owner: PropTypes.string.isRequired,
     friendly_id: PropTypes.string.isRequired,
-    active: PropTypes.bool.isRequired,
+    online: PropTypes.bool.isRequired,
     last_session: PropTypes.string,
     participants: PropTypes.number,
   }).isRequired,

--- a/app/javascript/components/admin/server_rooms/ServerRooms.jsx
+++ b/app/javascript/components/admin/server_rooms/ServerRooms.jsx
@@ -9,6 +9,7 @@ import ServerRoomRow from './ServerRoomRow';
 import SearchBarQuery from '../../shared_components/search/SearchBarQuery';
 import AdminNavSideBar from '../AdminNavSideBar';
 import Pagination from '../../shared_components/Pagination';
+import SortBy from '../../shared_components/search/SortBy';
 
 export default function ServerRooms() {
   const { t } = useTranslation();
@@ -38,8 +39,8 @@ export default function ServerRooms() {
                     <Table className="table-bordered border border-2 mt-4 mb-0" hover>
                       <thead>
                         <tr className="text-muted small">
-                          <th className="fw-normal border-end-0">{ t('admin.server_rooms.name') }</th>
-                          <th className="fw-normal border-0">{ t('admin.server_rooms.owner') }</th>
+                          <th className="fw-normal border-end-0">{ t('admin.server_rooms.name') }<SortBy fieldName="name" /></th>
+                          <th className="fw-normal border-0">{ t('admin.server_rooms.owner') }<SortBy fieldName="user.name" /></th>
                           <th className="fw-normal border-0">{ t('admin.server_rooms.room_id') }</th>
                           <th className="fw-normal border-0">{ t('admin.server_rooms.participants') }</th>
                           <th className="fw-normal border-0">{ t('admin.server_rooms.status') }</th>

--- a/app/javascript/hooks/queries/admin/server_rooms/useActiveServerRooms.jsx
+++ b/app/javascript/hooks/queries/admin/server_rooms/useActiveServerRooms.jsx
@@ -1,9 +1,0 @@
-import { useQuery } from 'react-query';
-import axios from '../../../../helpers/Axios';
-
-export default function useActiveServerRooms() {
-  return useQuery(
-    'getServerRooms',
-    () => axios.get('/admin/server_rooms/active_server_rooms.json').then((resp) => resp.data.data),
-  );
-}

--- a/app/javascript/hooks/queries/admin/server_rooms/useServerRooms.jsx
+++ b/app/javascript/hooks/queries/admin/server_rooms/useServerRooms.jsx
@@ -1,8 +1,13 @@
 import { useQuery } from 'react-query';
+import { useSearchParams } from 'react-router-dom';
 import axios from '../../../../helpers/Axios';
 
 export default function useServerRooms(input, page) {
+  const [searchParams] = useSearchParams();
+
   const params = {
+    'sort[column]': searchParams.get('sort[column]'),
+    'sort[direction]': searchParams.get('sort[direction]'),
     search: input,
     page,
   };

--- a/app/serializers/server_room_serializer.rb
+++ b/app/serializers/server_room_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ServerRoomSerializer < RoomSerializer
-  attributes :owner, :active, :participants, :last_session
+  attributes :owner, :online, :participants, :last_session
 
   def owner
     object.user.name

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -175,6 +175,7 @@
       "room_id": "Room ID",
       "participants": "Participants",
       "status": "Status",
+      "running": "Running",
       "not_running": "Not Running",
       "active": "Active",
       "current_session": "Current Session: {{lastSession}}",

--- a/spec/controllers/admin/server_rooms_controller_spec.rb
+++ b/spec/controllers/admin/server_rooms_controller_spec.rb
@@ -25,16 +25,16 @@ RSpec.describe Api::V1::Admin::ServerRoomsController, type: :controller do
         .to match_array(Room.all.pluck(:friendly_id))
     end
 
-    it 'returns the server room status as active if the meeting has started' do
+    it 'returns the server room status as online if the meeting has started' do
       active_server_room = create(:room)
       active_server_room.update(meeting_id: 'hulsdzwvitlk1dbekzxdprshsxmvycvar0jeaszc')
 
       allow_any_instance_of(BigBlueButtonApi).to receive(:active_meetings).and_return(bbb_meetings)
       get :index
-      expect(JSON.parse(response.body)['data'][0]['active']).to be(true)
+      expect(JSON.parse(response.body)['data'][0]['online']).to be(true)
     end
 
-    it 'returns the number of participants in an active server room' do
+    it 'returns the number of participants in an online server room' do
       active_server_room = create(:room)
       active_server_room.update(meeting_id: 'hulsdzwvitlk1dbekzxdprshsxmvycvar0jeaszc')
 
@@ -43,12 +43,12 @@ RSpec.describe Api::V1::Admin::ServerRoomsController, type: :controller do
       expect(JSON.parse(response.body)['data'][0]['participants']).to be(1)
     end
 
-    it 'returns the server status as not running if BBB server does not return any active meetings' do
+    it 'returns the server status as not running if BBB server does not return any online meetings' do
       create(:room)
 
       allow_any_instance_of(BigBlueButtonApi).to receive(:active_meetings).and_return([])
       get :index
-      expect(JSON.parse(response.body)['data'][0]['active']).to be(false)
+      expect(JSON.parse(response.body)['data'][0]['online']).to be(false)
     end
 
     it 'excludes rooms whose owners have a different provider' do


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Add sorting to admin/server rooms table.
- Rename server rooms attributes from "active" to "online"
- Improve UI - "running" meeting status is now green.
- Clean up ServerRooms#index method.

![image](https://user-images.githubusercontent.com/43917914/193344440-082f320d-1847-41f4-b4e4-1dfb1d0d2d12.png)

