### PR TITLE
Recordings re-sync: Migrated `Admin::ServerRecordingsController#resync` API to `Admin::ServerRoomsController#resync`.

### DIFF
--- a/app/controllers/api/v1/admin/server_recordings_controller.rb
+++ b/app/controllers/api/v1/admin/server_recordings_controller.rb
@@ -25,12 +25,6 @@ module Api
 
           render_data data: recordings, meta: pagy_metadata(pagy), status: :ok
         end
-
-        def resync
-          RecordingsSync.new(user: current_user).call
-
-          render_data status: :ok
-        end
       end
     end
   end

--- a/app/services/recordings_sync.rb
+++ b/app/services/recordings_sync.rb
@@ -1,19 +1,14 @@
 # frozen_string_literal: true
 
 class RecordingsSync
-  def initialize(params)
-    @user = params[:user]
+  def initialize(room:)
+    @room = room
   end
 
   def call
-    rooms = @user.rooms
+    @room.recordings.destroy_all
 
-    # Get the meeting_id of all the current user's rooms
-    meeting_ids = rooms.map(&:meeting_id)
-
-    Recording.destroy_by(room_id: rooms.map(&:id))
-
-    recordings = BigBlueButtonApi.new.get_recordings(meeting_ids:)
+    recordings = BigBlueButtonApi.new.get_recordings(meeting_ids: @room.meeting_id)
     recordings[:recordings].each do |recording|
       RecordingCreator.new(recording:).call
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,10 +69,10 @@ Rails.application.routes.draw do
             post '/:user_id/create_server_room', to: 'users#create_server_room'
           end
         end
-        resources :server_recordings, only: %i[index] do
-          get '/resync', to: 'server_recordings#resync', on: :collection
+        resources :server_recordings, only: %i[index]
+        resources :server_rooms, only: %i[index destroy], param: :friendly_id do
+          get '/resync', to: 'server_rooms#resync', on: :member
         end
-        resources :server_rooms, only: %i[index destroy], param: :friendly_id
         resources :site_settings, only: %i[index update], param: :name
         resources :rooms_configurations, only: :update, param: :name
         resources :roles

--- a/spec/controllers/admin/server_recordings_controller_spec.rb
+++ b/spec/controllers/admin/server_recordings_controller_spec.rb
@@ -82,32 +82,4 @@ RSpec.describe Api::V1::Admin::ServerRecordingsController, type: :controller do
       end
     end
   end
-
-  describe '#resync' do
-    let(:fake_recording_sync) { instance_double(RecordingsSync) }
-
-    before do
-      allow(RecordingsSync).to receive(:new).and_return(fake_recording_sync)
-      allow(fake_recording_sync).to receive(:call).and_return({ 'recordings' => 'values' })
-    end
-
-    # TODO: - samuel current_user is user_with_manage.. I think we should keep a regular user as default even in admin specs
-    it 'calls the RecordingsSync service with correct params' do
-      expect(RecordingsSync).to receive(:new).with(user: user_with_manage_recordings_permission)
-      expect(fake_recording_sync).to receive(:call)
-      get :resync
-      expect(response).to have_http_status(:ok)
-    end
-
-    context 'user without ManageRecordings permission' do
-      before do
-        sign_in_user(user)
-      end
-
-      it 'call the RecordingsSync service' do
-        get :resync
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
-  end
 end

--- a/spec/controllers/admin/server_rooms_controller_spec.rb
+++ b/spec/controllers/admin/server_rooms_controller_spec.rb
@@ -83,6 +83,36 @@ RSpec.describe Api::V1::Admin::ServerRoomsController, type: :controller do
     end
   end
 
+  describe '#resync' do
+    let(:fake_recording_sync) { instance_double(RecordingsSync) }
+    let(:room) { create(:room) }
+
+    before do
+      allow(RecordingsSync).to receive(:new).and_return(fake_recording_sync)
+      allow(fake_recording_sync).to receive(:call).and_return({ 'recordings' => 'values' })
+    end
+
+    # TODO: - samuel current_user is user_with_manage.. I think we should keep a regular user as default even in admin specs
+    it 'calls the RecordingsSync service with correct params' do
+      expect(RecordingsSync).to receive(:new).with(room:)
+      expect(fake_recording_sync).to receive(:call)
+      get :resync, params: { friendly_id: room.friendly_id }
+      expect(response).to have_http_status(:ok)
+    end
+
+    context 'user without ManageRooms permission' do
+      before do
+        sign_in_user(user)
+      end
+
+      it 'call the RecordingsSync service' do
+        expect(RecordingsSync).not_to receive(:new).with(room:)
+        get :resync, params: { friendly_id: room.friendly_id }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
   private
 
   def bbb_meetings


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Scoping the recordings resync feature to individual rooms,

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
