### PR TITLE
Add DefaultRole SiteSetting

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -97,7 +97,7 @@ module Api
       private
 
       def user_params
-        params.require(:user).permit(:name, :email, :password, :avatar, :language, :role_id)
+        params.require(:user).permit(:name, :email, :password, :password_confirmation, :avatar, :language, :role_id)
       end
 
       def change_password_params

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -97,7 +97,7 @@ module Api
       private
 
       def user_params
-        params.require(:user).permit(:name, :email, :password, :password_confirmation, :avatar, :language, :role_id)
+        params.require(:user).permit(:name, :email, :password, :avatar, :language, :role_id)
       end
 
       def change_password_params

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -26,7 +26,7 @@ module Api
         # TODO: amir - ensure accessibility for unauthenticated requests only.
         params[:user][:language] = I18n.default_locale if params[:user][:language].blank?
 
-        user = UserCreator.new(user_params:, provider: current_provider).call
+        user = UserCreator.new(user_params:, provider: current_provider, default_role:).call
 
         # TODO: Add proper error logging for non-verified token hcaptcha
         return render_error errors: user.errors.to_a if hcaptcha_enabled? && !verify_hcaptcha(response: params[:token])

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -26,7 +26,7 @@ module Api
         # TODO: amir - ensure accessibility for unauthenticated requests only.
         params[:user][:language] = I18n.default_locale if params[:user][:language].blank?
 
-        user = UserCreator.new(user_params:, provider: current_provider, default_role:).call
+        user = UserCreator.new(user_params:, provider: current_provider, role: default_role).call
 
         # TODO: Add proper error logging for non-verified token hcaptcha
         return render_error errors: user.errors.to_a if hcaptcha_enabled? && !verify_hcaptcha(response: params[:token])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,7 @@ class ApplicationController < ActionController::Base
   # Returns the default role
   def default_role
     default_role_setting = SettingGetter.new(setting_name: 'DefaultRole', provider: current_provider).call
-    @default_role = Role.find_by(name: default_role_setting, provider: current_provider)
+    @default_role = Role.find_by(name: default_role_setting, provider: current_provider) || Role.find_by(name: 'User', provider: current_provider)
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,7 @@ class ApplicationController < ActionController::Base
     @current_user ||= user
   end
 
+
   # Returns whether hcaptcha is enabled by checking if ENV variables are set
   def hcaptcha_enabled?
     (ENV['HCAPTCHA_SITE_KEY'].present? && ENV['HCAPTCHA_SECRET_KEY'].present?)
@@ -32,6 +33,13 @@ class ApplicationController < ActionController::Base
                             'greenlight'
                           end
   end
+
+  # Returns the default role
+  def default_role
+    default_role_setting = SettingGetter.new(setting_name: 'DefaultRole', provider: current_provider).call
+    @default_role = Role.find_by(name: default_role_setting)
+  end
+
 
   private
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,7 @@ class ApplicationController < ActionController::Base
   # Returns the default role
   def default_role
     default_role_setting = SettingGetter.new(setting_name: 'DefaultRole', provider: current_provider).call
-    @default_role = Role.find_by(name: default_role_setting)
+    @default_role = Role.find_by(name: default_role_setting, provider: current_provider)
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,6 @@ class ApplicationController < ActionController::Base
     @current_user ||= user
   end
 
-
   # Returns whether hcaptcha is enabled by checking if ENV variables are set
   def hcaptcha_enabled?
     (ENV['HCAPTCHA_SITE_KEY'].present? && ENV['HCAPTCHA_SECRET_KEY'].present?)
@@ -39,7 +38,6 @@ class ApplicationController < ActionController::Base
     default_role_setting = SettingGetter.new(setting_name: 'DefaultRole', provider: current_provider).call
     @default_role = Role.find_by(name: default_role_setting)
   end
-
 
   private
 

--- a/app/controllers/external_controller.rb
+++ b/app/controllers/external_controller.rb
@@ -15,7 +15,7 @@ class ExternalController < ApplicationController
     }
 
     user = User.find_or_create_by!(external_id: credentials['uid'], provider:) do |u|
-      user_info[:role] = Role.find_by(name: 'User')
+      user_info[:role] = default_role
       u.assign_attributes(user_info)
     end
 

--- a/app/javascript/components/admin/site_settings/registration/Registration.jsx
+++ b/app/javascript/components/admin/site_settings/registration/Registration.jsx
@@ -7,12 +7,13 @@ import useSiteSettings from '../../../../hooks/queries/admin/site_settings/useSi
 import Spinner from '../../../shared_components/utilities/Spinner';
 import SettingsRow from '../SettingsRow';
 import useEnv from '../../../../hooks/queries/env/useEnv';
+import SettingSelect from '../settings/SettingSelect';
 
 export default function Registration() {
   const { t } = useTranslation();
-
-  const { isLoading, data: registration } = useSiteSettings(['RoleMapping', 'ResyncOnLogin']);
   const { isLoadingEnv, data: env } = useEnv();
+  const { isLoading, data: siteSettings } = useSiteSettings(['RoleMapping', 'DefaultRole', 'ResyncOnLogin']);
+
 
   if (isLoading || isLoadingEnv) return <Spinner />;
 
@@ -28,17 +29,24 @@ export default function Registration() {
                 { t('admin.site_settings.registration.resync_on_login_description') }
               </p>
             )}
-            value={registration.ResyncOnLogin}
+            value={siteSettings.ResyncOnLogin}
           />
         </Row>
       )}
+
+      <SettingSelect
+        settingName="DefaultRole"
+        defaultValue={siteSettings.DefaultRole}
+        title={t('admin.site_settings.settings.default_role')}
+        description={t('admin.site_settings.settings.default_role_description')}
+      />
 
       <Row className="mb-3">
         <h6> { t('admin.site_settings.registration.role_mapping_by_email') } </h6>
         <p className="text-muted"> { t('admin.site_settings.registration.role_mapping_by_email_description') } </p>
         <RegistrationForm
           mutation={() => useUpdateSiteSetting('RoleMapping')}
-          value={registration.RoleMapping}
+          value={siteSettings.RoleMapping}
         />
       </Row>
     </>

--- a/app/javascript/components/admin/site_settings/registration/Registration.jsx
+++ b/app/javascript/components/admin/site_settings/registration/Registration.jsx
@@ -14,7 +14,6 @@ export default function Registration() {
   const { isLoadingEnv, data: env } = useEnv();
   const { isLoading, data: siteSettings } = useSiteSettings(['RoleMapping', 'DefaultRole', 'ResyncOnLogin']);
 
-
   if (isLoading || isLoadingEnv) return <Spinner />;
 
   return (

--- a/app/javascript/components/admin/site_settings/settings/SettingSelect.jsx
+++ b/app/javascript/components/admin/site_settings/settings/SettingSelect.jsx
@@ -1,0 +1,41 @@
+import { Form, Stack } from 'react-bootstrap';
+import React from 'react';
+import PropTypes from 'prop-types';
+import useRoles from '../../../../hooks/queries/admin/roles/useRoles';
+import useUpdateSiteSetting from '../../../../hooks/mutations/admin/site_settings/useUpdateSiteSetting';
+
+export default function SettingSelect({
+  settingName, defaultValue, title, description,
+}) {
+  const { data: roles } = useRoles();
+  const updateSiteSetting = useUpdateSiteSetting(settingName);
+
+  return (
+    <Stack direction="horizontal" className="mb-3">
+      <Stack>
+        <strong> { title } </strong>
+        <div className="text-muted">{ description }</div>
+      </Stack>
+      <div>
+        <Form.Select
+          aria-label="Default Role Select"
+          value={defaultValue}
+          onChange={(event) => {
+            updateSiteSetting.mutate({ value: event.target.value });
+          }}
+        >
+          {roles?.map((role) => (
+            <option key={role.id} value={role.name}> {role.name} </option>
+          ))}
+        </Form.Select>
+      </div>
+    </Stack>
+  );
+}
+
+SettingSelect.propTypes = {
+  settingName: PropTypes.string.isRequired,
+  defaultValue: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+};

--- a/app/services/user_creator.rb
+++ b/app/services/user_creator.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class UserCreator
-  def initialize(user_params:, provider:, default_role:)
+  def initialize(user_params:, provider:, role:)
     @user_params = user_params
     @provider = provider
-    @default_role = default_role
+    @role = role
     @roles_mappers = SettingGetter.new(setting_name: 'RoleMapping', provider:).call
   end
 
@@ -13,7 +13,7 @@ class UserCreator
 
     User.new({
       provider: @provider,
-      role: email_role || @default_role
+      role: email_role || @role
     }.merge(@user_params))
   end
 

--- a/app/services/user_creator.rb
+++ b/app/services/user_creator.rb
@@ -9,7 +9,6 @@ class UserCreator
 
   def call
     default_role_name = SettingGetter.new(setting_name: 'DefaultRole', provider: @provider).call
-    # TODO - could we save this query by storing the activerecord directly in the db? SiteSetting: value -> <Role>
     default_role = Role.find_by(name: default_role_name)
     role = infer_role_from_email(@user_params[:email])
 

--- a/app/services/user_creator.rb
+++ b/app/services/user_creator.rb
@@ -26,6 +26,6 @@ class UserCreator
                      rules.find { |rule| email.ends_with? rule.second if rule.second }
                    end
 
-    Role.find_by(name: matched_rule&.first)
+    Role.find_by(name: matched_rule&.first, provider: @provider)
   end
 end

--- a/app/services/user_creator.rb
+++ b/app/services/user_creator.rb
@@ -1,20 +1,19 @@
 # frozen_string_literal: true
 
 class UserCreator
-  def initialize(user_params:, provider:)
+  def initialize(user_params:, provider:, default_role:)
     @user_params = user_params
     @provider = provider
+    @default_role = default_role
     @roles_mappers = SettingGetter.new(setting_name: 'RoleMapping', provider:).call
   end
 
   def call
-    default_role_name = SettingGetter.new(setting_name: 'DefaultRole', provider: @provider).call
-    default_role = Role.find_by(name: default_role_name)
-    role = infer_role_from_email(@user_params[:email])
+    email_role = infer_role_from_email(@user_params[:email])
 
     User.new({
       provider: @provider,
-      role: role || default_role
+      role: email_role || @default_role
     }.merge(@user_params))
   end
 

--- a/app/services/user_creator.rb
+++ b/app/services/user_creator.rb
@@ -8,11 +8,14 @@ class UserCreator
   end
 
   def call
+    default_role_name = SettingGetter.new(setting_name: 'DefaultRole', provider: @provider).call
+    # TODO - could we save this query by storing the activerecord directly in the db? SiteSetting: value -> <Role>
+    default_role = Role.find_by(name: default_role_name)
     role = infer_role_from_email(@user_params[:email])
 
     User.new({
       provider: @provider,
-      role:
+      role: role || default_role
     }.merge(@user_params))
   end
 
@@ -25,6 +28,6 @@ class UserCreator
                      rules.find { |rule| email.ends_with? rule.second if rule.second }
                    end
 
-    Role.find_by(name: matched_rule&.first) || Role.find_by(name: 'User')
+    Role.find_by(name: matched_rule&.first)
   end
 end

--- a/db/data/20221003201116_populate_default_role_settings.rb
+++ b/db/data/20221003201116_populate_default_role_settings.rb
@@ -12,7 +12,7 @@ class PopulateDefaultRoleSettings < ActiveRecord::Migration[7.0]
   end
 
   def down
-    Setting.find_by(name: 'DefaultRole').delete
     SiteSetting.find_by(setting: Setting.find_by(name: 'DefaultRole').delete)
+    Setting.find_by(name: 'DefaultRole').delete
   end
 end

--- a/db/data/20221003201116_populate_default_role_settings.rb
+++ b/db/data/20221003201116_populate_default_role_settings.rb
@@ -1,0 +1,16 @@
+class PopulateDefaultRoleSettings < ActiveRecord::Migration[7.0]
+  def up
+    Setting.create! [
+      { name: 'DefaultRole' }
+    ]
+
+    SiteSetting.create! [
+      { setting: Setting.find_by(name: 'DefaultRole'), provider: 'greenlight', value: 'User' }
+    ]
+  end
+
+  def down
+    Setting.find_by(name: 'DefaultRole').delete
+    SiteSetting.find_by(setting: Setting.find_by(name: 'DefaultRole').delete)
+  end
+end

--- a/db/data/20221003201116_populate_default_role_settings.rb
+++ b/db/data/20221003201116_populate_default_role_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PopulateDefaultRoleSettings < ActiveRecord::Migration[7.0]
   def up
     Setting.create! [

--- a/db/data/20221003201116_populate_default_role_settings.rb
+++ b/db/data/20221003201116_populate_default_role_settings.rb
@@ -12,7 +12,8 @@ class PopulateDefaultRoleSettings < ActiveRecord::Migration[7.0]
   end
 
   def down
-    SiteSetting.find_by(setting: Setting.find_by(name: 'DefaultRole').delete)
-    Setting.find_by(name: 'DefaultRole').delete
+    setting = Setting.find_by(name: 'DefaultRole')
+    SiteSetting.where(setting:).destroy_all
+    setting.destroy!
   end
 end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20221003201116)
+DataMigrate::Data.define(version: 20220930022007)

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20220930022007)
+DataMigrate::Data.define(version: 20221003201116)

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -218,7 +218,9 @@
         "allow_users_to_share_rooms": "Allow Users to Share Rooms",
         "allow_users_to_share_rooms_description": "Setting to disabled will remove the button from the room options dropdown, preventing users from sharing rooms",
         "allow_users_to_preupload_presentation": "Allow Users to Preupload Presentations",
-        "allow_users_to_preupload_presentation_description": "Users can preupload a presentation to be used as the default presentation for that specific room"
+        "allow_users_to_preupload_presentation_description": "Users can preupload a presentation to be used as the default presentation for that specific room",
+        "default_role": "Default Role",
+        "default_role_description": "The default role to be assigned to newly created users"
       },
       "registration": {
         "registration": "Registration",

--- a/spec/controllers/external_controller_spec.rb
+++ b/spec/controllers/external_controller_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe ExternalController, type: :controller do
+  let(:fake_setting_getter) { instance_double(SettingGetter) }
+
   describe '#create_user' do
     before do
       OmniAuth.config.test_mode = true
@@ -14,6 +16,10 @@ RSpec.describe ExternalController, type: :controller do
           name: Faker::Name.name
         }
       )
+
+      allow(SettingGetter).to receive(:new).and_call_original
+      allow(SettingGetter).to receive(:new).with(setting_name: 'DefaultRole', provider: 'greenlight').and_return(fake_setting_getter)
+      allow(fake_setting_getter).to receive(:call).and_return('User')
     end
 
     let!(:role) { create(:role, name: 'User') }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::UsersController, type: :controller do
   let(:user) { create(:user) }
   let(:user_with_manage_users_permission) { create(:user, :with_manage_users_permission) }
+  let(:fake_setting_getter) { instance_double(SettingGetter) }
 
   before do
     request.headers['ACCEPT'] = 'application/json'
@@ -26,6 +27,9 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     before do
       create(:role, name: 'User') # Needed for admin#create
       clear_enqueued_jobs
+      allow(SettingGetter).to receive(:new).and_call_original
+      allow(SettingGetter).to receive(:new).with(setting_name: 'DefaultRole', provider: 'greenlight').and_return(fake_setting_getter)
+      allow(fake_setting_getter).to receive(:call).and_return('User')
     end
 
     context 'when user is saved' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         expect(session[:session_token]).not_to eql(user.session_token)
       end
 
-      context 'from antoher user' do
+      context 'from another user' do
         it 'sends activation email to but does NOT signin the created user' do
           expect { post :create, params: user_params }.to change(User, :count).by(1)
           expect(ActionMailer::MailDeliveryJob).to have_been_enqueued.at(:no_wait).exactly(:once).with('UserMailer', 'activate_account_email',

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -13,13 +13,19 @@ RSpec.describe Api::V1::UsersController, type: :request do
       }
     }
   end
-  # TODO: Migrate this to controllers spec and refactor it for consistency.
+  let!(:role) { create(:role, name: 'User') }
+  let(:fake_setting_getter) { instance_double(SettingGetter) }
+
+  before do
+    allow(SettingGetter).to receive(:new).and_call_original
+    allow(SettingGetter).to receive(:new).with(setting_name: 'DefaultRole', provider: 'greenlight').and_return(fake_setting_getter)
+    allow(fake_setting_getter).to receive(:call).and_return('User')
+  end
 
   describe 'Signup' do
     let(:headers) { { 'ACCEPT' => 'application/json' } }
 
     context 'valid user params' do
-      let!(:role) { create(:role, name: 'User') }
 
       it 'creates a user account for valid params' do
         expect { post api_v1_users_path, params: valid_user_params, headers: }.to change(User, :count).from(0).to(1)

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe Api::V1::UsersController, type: :request do
     let(:headers) { { 'ACCEPT' => 'application/json' } }
 
     context 'valid user params' do
-
       it 'creates a user account for valid params' do
         expect { post api_v1_users_path, params: valid_user_params, headers: }.to change(User, :count).from(0).to(1)
         expect(response.content_type).to eq('application/json; charset=utf-8')

--- a/spec/services/user_creator_spec.rb
+++ b/spec/services/user_creator_spec.rb
@@ -4,48 +4,27 @@ require 'rails_helper'
 
 describe UserCreator, type: :service do
   describe '#call' do
-    let!(:users) { create(:role, name: 'User') }
+    let(:users) { create(:role, name: 'User') }
+    let(:teachers) { create(:role, name: 'Teachers') }
     let(:fake_setting_getter) { instance_double(SettingGetter) }
 
     before do
       setting = create(:setting, name: 'RoleMapping')
       create(:site_setting, setting:, provider: 'greenlight', value: 'Decepticons=@decepticons.cybertron,Autobots=autobots.cybertron')
-      allow(SettingGetter).to receive(:new).and_call_original
-      allow(SettingGetter).to receive(:new).with(setting_name: 'DefaultRole', provider: 'greenlight').and_return(fake_setting_getter)
-      allow(fake_setting_getter).to receive(:call).and_return('User')
     end
 
-    it 'creates a user with the default User role' do
+    it 'creates a user with the default role' do
       user_params = {
         name: 'Lorem',
         email: 'lorem@ipsum.com',
         password: 'Password1+',
         language: 'eng'
       }
-      res = described_class.new(user_params:, provider: 'greenlight').call
-      expect(res.role).to eq(users)
+      res = described_class.new(user_params:, provider: 'greenlight', default_role: teachers).call
+      expect(res.role).to eq(teachers)
     end
 
-    context 'default role is not User' do
-      let!(:teachers) { create(:role, name: 'Teacher') }
-
-      before do
-        allow(fake_setting_getter).to receive(:call).and_return('Teacher')
-      end
-
-      it 'creates a user with the default Teacher role' do
-        user_params = {
-          name: 'Lorem',
-          email: 'lorem@ipsum.com',
-          password: 'Password1+',
-          language: 'eng'
-        }
-        res = described_class.new(user_params:, provider: 'greenlight').call
-        expect(res.role).to eq(teachers)
-      end
-    end
-
-    it 'creates a user with the role matching a rule if role found' do
+    it 'creates a user with the role matching a rule instead of the default role if email role is found' do
       decepticons = create(:role, name: 'Decepticons')
       user_params = {
         name: 'Megatron',
@@ -53,7 +32,7 @@ describe UserCreator, type: :service do
         password: 'Decepticons',
         language: 'teletraan'
       }
-      res = described_class.new(user_params:, provider: 'greenlight').call
+      res = described_class.new(user_params:, provider: 'greenlight', default_role: users).call
 
       expect(res).to be_instance_of(User)
       expect(res).not_to be_persisted
@@ -71,7 +50,7 @@ describe UserCreator, type: :service do
         password: 'Cybertron',
         language: 'teletraan'
       }
-      res = described_class.new(user_params:, provider: 'greenlight').call
+      res = described_class.new(user_params:, provider: 'greenlight', default_role: users).call
 
       expect(res).to be_instance_of(User)
       expect(res).not_to be_persisted
@@ -89,7 +68,7 @@ describe UserCreator, type: :service do
         password: 'Autobots',
         language: 'teletraan'
       }
-      res = described_class.new(user_params:, provider: 'greenlight').call
+      res = described_class.new(user_params:, provider: 'greenlight', default_role: users).call
 
       expect(res).to be_instance_of(User)
       expect(res).not_to be_persisted

--- a/spec/services/user_creator_spec.rb
+++ b/spec/services/user_creator_spec.rb
@@ -20,7 +20,7 @@ describe UserCreator, type: :service do
         password: 'Password1+',
         language: 'eng'
       }
-      res = described_class.new(user_params:, provider: 'greenlight', default_role: teachers).call
+      res = described_class.new(user_params:, provider: 'greenlight', role: teachers).call
       expect(res.role).to eq(teachers)
     end
 
@@ -32,7 +32,7 @@ describe UserCreator, type: :service do
         password: 'Decepticons',
         language: 'teletraan'
       }
-      res = described_class.new(user_params:, provider: 'greenlight', default_role: users).call
+      res = described_class.new(user_params:, provider: 'greenlight', role: users).call
 
       expect(res).to be_instance_of(User)
       expect(res).not_to be_persisted
@@ -50,7 +50,7 @@ describe UserCreator, type: :service do
         password: 'Cybertron',
         language: 'teletraan'
       }
-      res = described_class.new(user_params:, provider: 'greenlight', default_role: users).call
+      res = described_class.new(user_params:, provider: 'greenlight', role: users).call
 
       expect(res).to be_instance_of(User)
       expect(res).not_to be_persisted
@@ -68,7 +68,7 @@ describe UserCreator, type: :service do
         password: 'Autobots',
         language: 'teletraan'
       }
-      res = described_class.new(user_params:, provider: 'greenlight', default_role: users).call
+      res = described_class.new(user_params:, provider: 'greenlight', role: users).call
 
       expect(res).to be_instance_of(User)
       expect(res).not_to be_persisted

--- a/spec/services/user_creator_spec.rb
+++ b/spec/services/user_creator_spec.rb
@@ -6,7 +6,6 @@ describe UserCreator, type: :service do
   describe '#call' do
     let(:users) { create(:role, name: 'User') }
     let(:teachers) { create(:role, name: 'Teachers') }
-    let(:fake_setting_getter) { instance_double(SettingGetter) }
 
     before do
       setting = create(:setting, name: 'RoleMapping')

--- a/spec/services/user_creator_spec.rb
+++ b/spec/services/user_creator_spec.rb
@@ -5,22 +5,10 @@ require 'rails_helper'
 describe UserCreator, type: :service do
   describe '#call' do
     let(:users) { create(:role, name: 'User') }
-    let(:teachers) { create(:role, name: 'Teachers') }
 
     before do
       setting = create(:setting, name: 'RoleMapping')
       create(:site_setting, setting:, provider: 'greenlight', value: 'Decepticons=@decepticons.cybertron,Autobots=autobots.cybertron')
-    end
-
-    it 'creates a user with the default role' do
-      user_params = {
-        name: 'Lorem',
-        email: 'lorem@ipsum.com',
-        password: 'Password1+',
-        language: 'eng'
-      }
-      res = described_class.new(user_params:, provider: 'greenlight', role: teachers).call
-      expect(res.role).to eq(teachers)
     end
 
     it 'creates a user with the role matching a rule instead of the default role if email role is found' do

--- a/spec/services/user_creator_spec.rb
+++ b/spec/services/user_creator_spec.rb
@@ -5,11 +5,46 @@ require 'rails_helper'
 describe UserCreator, type: :service do
   describe '#call' do
     let!(:users) { create(:role, name: 'User') }
+    let(:fake_setting_getter) { instance_double(SettingGetter) }
 
     before do
       setting = create(:setting, name: 'RoleMapping')
       create(:site_setting, setting:, provider: 'greenlight', value: 'Decepticons=@decepticons.cybertron,Autobots=autobots.cybertron')
+      allow(SettingGetter).to receive(:new).and_call_original
+      allow(SettingGetter).to receive(:new).with(setting_name: 'DefaultRole', provider: 'greenlight').and_return(fake_setting_getter)
+      allow(fake_setting_getter).to receive(:call).and_return('User')
     end
+
+    it 'creates a user with the default User role' do
+      user_params = {
+        name: 'Lorem',
+        email: 'lorem@ipsum.com',
+        password: 'Password1+',
+        language: 'eng'
+      }
+      res = described_class.new(user_params:, provider: 'greenlight').call
+      expect(res.role).to eq(users)
+    end
+
+    context 'default role is not User' do
+      let!(:teachers) { create(:role, name: 'Teacher') }
+
+      before do
+        allow(fake_setting_getter).to receive(:call).and_return('Teacher')
+      end
+
+      it 'creates a user with the default Teacher role' do
+        user_params = {
+          name: 'Lorem',
+          email: 'lorem@ipsum.com',
+          password: 'Password1+',
+          language: 'eng'
+        }
+        res = described_class.new(user_params:, provider: 'greenlight').call
+        expect(res.role).to eq(teachers)
+      end
+    end
+
 
     it 'creates a user with the role matching a rule if role found' do
       decepticons = create(:role, name: 'Decepticons')

--- a/spec/services/user_creator_spec.rb
+++ b/spec/services/user_creator_spec.rb
@@ -45,7 +45,6 @@ describe UserCreator, type: :service do
       end
     end
 
-
     it 'creates a user with the role matching a rule if role found' do
       decepticons = create(:role, name: 'Decepticons')
       user_params = {


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add DefaultRole site setting.
Admin can now set a default role upon user creation.
Create "default_role" method in Application controller as "default_role" is needed in both local and external account creation.
Setting is accessible in Admin/SiteSettings/Registration.


## TODO
Upcoming PR: Make default roles (User, Admin, Guest) undeletable.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
Create a new role.
Select the new role in SiteSettings/Registration.
Create a new user and verify it has the selected default role.

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/43917914/194396704-3569523e-c818-4314-b2d3-0789ed1c24f6.png)
