### PR TITLE
Query cache: Minor fix to `useRoom` & `useRoomRecordings` queries.

### DIFF
--- a/app/javascript/hooks/mutations/recordings/useDeleteRecording.jsx
+++ b/app/javascript/hooks/mutations/recordings/useDeleteRecording.jsx
@@ -12,7 +12,7 @@ export default function useDeleteRecording({ recordId, onSettled }) {
     {
       onSuccess: () => {
         queryClient.invalidateQueries('getRecordings');
-        queryClient.invalidateQueries('getRoomRecordings');
+        queryClient.invalidateQueries(['getRoomRecordings']);
         queryClient.invalidateQueries('getServerRecordings');
         toast.success(t('toast.success.recording.recording_deleted'));
       },

--- a/app/javascript/hooks/mutations/rooms/useDeletePresentation.jsx
+++ b/app/javascript/hooks/mutations/rooms/useDeletePresentation.jsx
@@ -11,7 +11,7 @@ export default function useDeletePresentation(friendlyId) {
     () => axios.delete(`/rooms/${friendlyId}/purge_presentation.json`),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries('getRoom');
+        queryClient.invalidateQueries(['getRoom', { friendlyId }]);
         toast.success(t('toast.success.presentation_deleted'));
       },
       onError: () => {

--- a/app/javascript/hooks/mutations/rooms/useUpdateRoom.jsx
+++ b/app/javascript/hooks/mutations/rooms/useUpdateRoom.jsx
@@ -11,7 +11,7 @@ export default function useUpdateRoom({ friendlyId }) {
     (data) => axios.patch(`/rooms/${friendlyId}.json`, data),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries('getRoom');
+        queryClient.invalidateQueries(['getRoom', { friendlyId }]);
         toast.success(t('toast.success.room.room_updated'));
       },
       onError: () => {

--- a/app/javascript/hooks/mutations/rooms/useUploadPresentation.jsx
+++ b/app/javascript/hooks/mutations/rooms/useUploadPresentation.jsx
@@ -15,7 +15,7 @@ export default function useUploadPresentation(friendlyId) {
 
   const mutation = useMutation(uploadPresentation, {
     onSuccess: () => {
-      queryClient.invalidateQueries('getRoom');
+      queryClient.invalidateQueries(['getRoom', { friendlyId }]);
       toast.success(t('toast.success.presentation_updated'));
     },
     onError: () => {

--- a/app/javascript/hooks/queries/recordings/useRoomRecordings.jsx
+++ b/app/javascript/hooks/queries/recordings/useRoomRecordings.jsx
@@ -7,7 +7,7 @@ export default function useRoomRecordings(friendlyId, input, page) {
     page,
   };
   return useQuery(
-    ['getRoomRecordings', { ...params }],
+    ['getRoomRecordings', { ...params, friendlyId }],
     () => axios.get(`/rooms/${friendlyId}/recordings.json`, { params }).then((resp) => resp.data),
     {
       keepPreviousData: true,

--- a/app/javascript/hooks/queries/rooms/useRoom.jsx
+++ b/app/javascript/hooks/queries/rooms/useRoom.jsx
@@ -6,7 +6,7 @@ export default function useRoom(friendlyId, includeOwner = false) {
     include_owner: includeOwner,
   };
   return useQuery(
-    'getRoom',
+    ['getRoom', { friendlyId }],
     () => axios.get(`/rooms/${friendlyId}.json`, { params }).then((resp) => resp.data.data),
   );
 }


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Minor fix to `useRoom` and `useRoomRecordings` queries to effectively store cache per room.
This :
- Has rectified caching and therefore improved the overall application performance in the rooms area.
- Will fix the inconsistent UI caused by fetching irrelevant cached data (e.g when jumping from a room to another you will first see the old room page and recordings before react query fetches the new room data and update the cache).

Both points leads to a better UX.
## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
