### PR TITLE
Change Shared By layout (small design fix)

### DIFF
--- a/app/javascript/components/rooms/RoomCard.jsx
+++ b/app/javascript/components/rooms/RoomCard.jsx
@@ -38,7 +38,7 @@ export default function RoomCard({ room }) {
         <Stack className="my-4">
           <Card.Title className="mb-0"> { room.name } </Card.Title>
           { room.shared_owner && (
-            <span className="text-muted">{ t('room.shared_by', { room }) } </span>
+            <span className="text-muted">{ t('room.shared_by') } <strong>{ room.shared_owner }</strong></span>
           )}
           { room.last_session ? (
             <span className="text-muted"> { t('room.last_session', { room }) } </span>

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -85,7 +85,7 @@
     "delete_room": "Delete Room",
     "create_new_room": "Create New Room",
     "enter_room_name": "Enter the room name",
-    "shared_by": "Shared by: {{room.shared_owner}}",
+    "shared_by": "shared by ",
     "last_session": "Last Session: {{ room.last_session }}",
     "no_last_session": "No previous session created",
     "no_rooms_found": "No rooms found",


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change "Shared by:" to "shared by" which looks nicer IMO. 
Idea is to continue the Room name basically with the shared by Owner.
Before:
![image](https://user-images.githubusercontent.com/43917914/194601767-3ee02dcd-d13d-4143-89c3-48ca589fa4c1.png)
After:
![image](https://user-images.githubusercontent.com/43917914/194601691-51b5a9ad-bb9c-4199-9d51-30a44ca0e334.png)

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
