### PR TITLE
Fix User join his own room as a moderator

### DIFF
--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -90,7 +90,8 @@ module Api
       def authorized_as_moderator?(access_code:)
         (params[:access_code].present? && access_code == params[:access_code]) ||
           @room.anyone_joins_as_moderator? ||
-          current_user&.shared_rooms&.include?(@room)
+          current_user&.shared_rooms&.include?(@room) ||
+          current_user&.rooms&.include?(@room)
       end
 
       def infer_bbb_role(mod_code:, viewer_code:)

--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -91,7 +91,7 @@ module Api
         (params[:access_code].present? && access_code == params[:access_code]) ||
           @room.anyone_joins_as_moderator? ||
           current_user&.shared_rooms&.include?(@room) ||
-          current_user&.rooms&.include?(@room)
+          @room.user_id == current_user&.id
       end
 
       def infer_bbb_role(mod_code:, viewer_code:)

--- a/spec/controllers/meetings_controller_spec.rb
+++ b/spec/controllers/meetings_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::MeetingsController, type: :controller do
   let(:user) { create(:user) }
   let(:room) { create(:room, user:) }
-  let(:test_user) { create(:user)}
+  let(:test_user) { create(:user) }
   let(:test_room) { create(:room, user: test_user) }
   let(:user_with_manage_rooms_permission) { create(:user, :with_manage_rooms_permission) }
 

--- a/spec/controllers/meetings_controller_spec.rb
+++ b/spec/controllers/meetings_controller_spec.rb
@@ -127,9 +127,9 @@ RSpec.describe Api::V1::MeetingsController, type: :controller do
   describe '#status' do
     it 'gets the joinUrl if the meeting is running' do
       allow_any_instance_of(BigBlueButtonApi).to receive(:meeting_running?).and_return(true)
-      expect_any_instance_of(BigBlueButtonApi).to receive(:join_meeting).with(room:, name: user.name, avatar_url: nil, role: 'Moderator')
+      expect_any_instance_of(BigBlueButtonApi).to receive(:join_meeting).with(room: test_room, name: user.name, avatar_url: nil, role: 'Viewer')
 
-      post :status, params: { friendly_id: room.friendly_id, name: user.name }
+      post :status, params: { friendly_id: test_room.friendly_id, name: user.name }
       expect(response).to have_http_status(:ok)
       expect(JSON.parse(response.body)['data']).to eq({ 'joinUrl' => 'JOIN_URL', 'status' => true })
     end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
You would join your own meeting as a regular viewer if the meeting was started by a shared user.
Now you will join all your meetings as an admin.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

1. Create a room with user1
2. Share the room with user2
3. Go on incognito and log in user2
4. Start the shared room with user2
5. Join the meeting with user1
6. You should be logged in as a moderator
