### PR TITLE
Fix Rooms sorting (NULLS FIRST is the default for DESC)

### DIFF
--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -24,7 +24,8 @@ module Api
         shared_rooms = SharedAccess.where(user_id: current_user.id).select(:room_id)
         rooms = Room.where(user_id: current_user.id)
                     .or(Room.where(id: shared_rooms))
-                    .order(Room.arel_table[:online].desc, Room.arel_table[:last_session].desc.nulls_last)
+                    .order(online: :desc)
+                    .order(Room.arel_table[:last_session].desc.nulls_last)
                     .search(params[:search])
 
         rooms.map do |room|

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -24,7 +24,7 @@ module Api
         shared_rooms = SharedAccess.where(user_id: current_user.id).select(:room_id)
         rooms = Room.where(user_id: current_user.id)
                     .or(Room.where(id: shared_rooms))
-                    .order(online: :desc, last_session: :desc)
+                    .order(Room.arel_table[:online].desc, Room.arel_table[:last_session].desc.nulls_last)
                     .search(params[:search])
 
         rooms.map do |room|

--- a/app/javascript/components/rooms/RoomsList.jsx
+++ b/app/javascript/components/rooms/RoomsList.jsx
@@ -19,8 +19,6 @@ export default function RoomsList() {
   const currentUser = useAuth();
   const mutationWrapper = (args) => useCreateRoom({ userId: currentUser.id, ...args });
 
-  console.log(rooms)
-
   return (
     <>
       <Stack direction="horizontal" className="w-100 mt-5">

--- a/app/javascript/components/rooms/RoomsList.jsx
+++ b/app/javascript/components/rooms/RoomsList.jsx
@@ -19,6 +19,8 @@ export default function RoomsList() {
   const currentUser = useAuth();
   const mutationWrapper = (args) => useCreateRoom({ userId: currentUser.id, ...args });
 
+  console.log(rooms)
+
   return (
     <>
       <Stack direction="horizontal" className="w-100 mt-5">

--- a/app/serializers/room_serializer.rb
+++ b/app/serializers/room_serializer.rb
@@ -4,7 +4,6 @@ class RoomSerializer < ApplicationSerializer
   attributes :id, :name, :friendly_id, :online, :participants, :last_session
 
   attribute :shared_owner, if: -> { object.shared }
-  # attribute :last_session, if: -> { object.last_session }
 
   def shared_owner
     object.user.name

--- a/app/serializers/room_serializer.rb
+++ b/app/serializers/room_serializer.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 class RoomSerializer < ApplicationSerializer
-  attributes :id, :name, :friendly_id, :online, :participants
+  attributes :id, :name, :friendly_id, :online, :participants, :last_session
 
   attribute :shared_owner, if: -> { object.shared }
-  attribute :last_session, if: -> { object.last_session }
+  # attribute :last_session, if: -> { object.last_session }
 
   def shared_owner
     object.user.name
   end
 
   def last_session
-    object.last_session.strftime('%B %e, %Y %l:%M%P')
+    object.last_session&.strftime('%B %e, %Y %l:%M%P')
   end
 end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix small issue with Rooms sorting where a room with last_session: null would appear at the top of the list.
NULLS FIRST is the default for DESC in PG.
I think we would rather have those at the bottom of the rooms list and have most recently used rooms at the top of the list.

![image](https://user-images.githubusercontent.com/43917914/195942145-3b87ec19-d449-4bfb-9892-820f260326f9.png)

