### PR TITLE
Add Recordings count badge

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -487,4 +487,3 @@ input[type="range"]:focus::-moz-range-thumb {
   0% { transform: rotate(0deg) }
   to { transform: rotate(359deg) }
 }
-

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -446,6 +446,8 @@ input[type="range"]:focus::-moz-range-thumb {
   }
 
   .nav-link {
+    padding-left: 8px !important;
+    padding-right: 8px !important;
     &:hover {
       border-bottom: 2px solid var(--brand-color) !important;
     }
@@ -485,3 +487,4 @@ input[type="range"]:focus::-moz-range-thumb {
   0% { transform: rotate(0deg) }
   to { transform: rotate(359deg) }
 }
+

--- a/app/assets/stylesheets/recordings.scss
+++ b/app/assets/stylesheets/recordings.scss
@@ -35,3 +35,7 @@
   cursor: pointer;
 }
 
+.recordings-count-badge {
+  background-color: whitesmoke !important;
+}
+

--- a/app/controllers/api/v1/recordings_controller.rb
+++ b/app/controllers/api/v1/recordings_controller.rb
@@ -70,6 +70,11 @@ module Api
         render_data status: :ok
       end
 
+      def recordings_count
+        count = current_user.recordings.count
+        render_data data: count, status: :ok
+      end
+
       private
 
       def recording_params

--- a/app/javascript/components/recordings/RecordingsCountTab.jsx
+++ b/app/javascript/components/recordings/RecordingsCountTab.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Badge, Stack } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+
+export default function RecordingsCountTab({ count }) {
+  return (
+    <Stack direction="horizontal" gap={0}>
+      <span> Recordings </span>
+      { count > 0
+        && (
+          <Badge className="rounded-pill recordings-count-badge fw-normal ms-2 text-brand">
+            { count }
+          </Badge>
+        )}
+    </Stack>
+  );
+}
+
+RecordingsCountTab.propTypes = {
+  count: PropTypes.number,
+};
+
+RecordingsCountTab.defaultProps = {
+  count: 0,
+};

--- a/app/javascript/components/recordings/RecordingsCountTab.jsx
+++ b/app/javascript/components/recordings/RecordingsCountTab.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { Badge, Stack } from 'react-bootstrap';
 import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
 
 export default function RecordingsCountTab({ count }) {
+  const { t } = useTranslation();
+
   return (
     <Stack direction="horizontal" gap={0}>
-      <span> Recordings </span>
+      <span> { t('recording.recordings') } </span>
       { count > 0
         && (
           <Badge className="rounded-pill recordings-count-badge fw-normal ms-2 text-brand">

--- a/app/javascript/components/rooms/Rooms.jsx
+++ b/app/javascript/components/rooms/Rooms.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
-import { Row, Tab, Tabs } from 'react-bootstrap';
+import { Row, Spinner, Tab, Tabs } from 'react-bootstrap';
 import RoomsList from './RoomsList';
 import Recordings from '../recordings/Recordings';
+import RecordingsCountTab from '../recordings/RecordingsCountTab';
+import useRecordingsCount from '../../hooks/queries/recordings/useRecordingsCount';
 
 export default function Rooms() {
+  const { isLoading, data: recordingsCount } = useRecordingsCount();
+
+  if (isLoading) return <Spinner />;
+
   return (
     <Row className="pt-5 wide-background-rooms">
       <Tabs defaultActiveKey="rooms" unmountOnExit>
@@ -11,7 +17,7 @@ export default function Rooms() {
           <RoomsList />
         </Tab>
         {/* TODO: May need to change this to it's own component depending on how RecordingsTable will work */}
-        <Tab eventKey="recordings" title="Recordings">
+        <Tab eventKey="recordings" title={<RecordingsCountTab count={recordingsCount} />}>
           <Recordings />
         </Tab>
       </Tabs>

--- a/app/javascript/components/rooms/Rooms.jsx
+++ b/app/javascript/components/rooms/Rooms.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Row, Spinner, Tab, Tabs } from 'react-bootstrap';
+import {
+  Row, Spinner, Tab, Tabs,
+} from 'react-bootstrap';
 import RoomsList from './RoomsList';
 import Recordings from '../recordings/Recordings';
 import RecordingsCountTab from '../recordings/RecordingsCountTab';

--- a/app/javascript/hooks/mutations/recordings/useDeleteRecording.jsx
+++ b/app/javascript/hooks/mutations/recordings/useDeleteRecording.jsx
@@ -12,6 +12,7 @@ export default function useDeleteRecording({ recordId, onSettled }) {
     {
       onSuccess: () => {
         queryClient.invalidateQueries('getRecordings');
+        queryClient.invalidateQueries('getRecordingsCount');
         queryClient.invalidateQueries(['getRoomRecordings']);
         queryClient.invalidateQueries('getServerRecordings');
         toast.success(t('toast.success.recording.recording_deleted'));

--- a/app/javascript/hooks/queries/recordings/useRecordingsCount.jsx
+++ b/app/javascript/hooks/queries/recordings/useRecordingsCount.jsx
@@ -3,7 +3,7 @@ import axios from '../../../helpers/Axios';
 
 export default function useRecordingsCount() {
   return useQuery(
-    'getRecordings',
+    'getRecordingsCount',
     () => axios.get('/recordings/recordings_count.json').then((resp) => resp.data.data),
     {
       keepPreviousData: true,

--- a/app/javascript/hooks/queries/recordings/useRecordingsCount.jsx
+++ b/app/javascript/hooks/queries/recordings/useRecordingsCount.jsx
@@ -1,0 +1,12 @@
+import { useQuery } from 'react-query';
+import axios from '../../../helpers/Axios';
+
+export default function useRecordingsCount() {
+  return useQuery(
+    'getRecordings',
+    () => axios.get('/recordings/recordings_count.json').then((resp) => resp.data.data),
+    {
+      keepPreviousData: true,
+    },
+  );
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
       resources :recordings, only: %i[index update destroy] do
         collection do
           post '/update_visibility', to: 'recordings#update_visibility'
+          get '/recordings_count', to: 'recordings#recordings_count'
         end
       end
       resources :shared_accesses, only: %i[create show destroy], param: :friendly_id do
@@ -77,7 +78,7 @@ Rails.application.routes.draw do
         resources :rooms_configurations, only: :update, param: :name
         resources :roles
         # TODO: Review update route
-        resources :role_permissions, only: [:index] do 
+        resources :role_permissions, only: [:index] do
           collection do
             post '/', to: 'role_permissions#update'
           end

--- a/spec/controllers/recordings_controller_spec.rb
+++ b/spec/controllers/recordings_controller_spec.rb
@@ -208,6 +208,16 @@ RSpec.describe Api::V1::RecordingsController, type: :controller do
 
     # TODO: samuel - add tests for user_with_manage_recordings_permission
   end
+
+  describe '#recordings_count' do
+    it 'returns the total count of recordings of a user' do
+      recordings = create_list(:recording, 5)
+      create_list(:room, 5, user:, recordings:)
+
+      get :recordings_count
+      expect(JSON.parse(response.body)['data']).to be(5)
+    end
+  end
 end
 
 def http_ok_response


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add Recording Count badge as per mock-up.

I figured it was more convenient to add an endpoint for the recordings count, instead of doing an expensive query for the whole Recordings#index in Rooms for (potentially) no reason.

Can do the same thing in Room/Recording if you guys like this solution ie create a room_recording_count endpoint in rooms.

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/43917914/196291108-8abb2e42-c78a-4ea6-b54c-d872c880f243.png)
