### PR TITLE
Admin Panel fixes

### DIFF
--- a/app/assets/stylesheets/admin_panel.scss
+++ b/app/assets/stylesheets/admin_panel.scss
@@ -1,3 +1,5 @@
+$admin-card-height: 969px;
+
 #admin-panel {
   padding-bottom: $header-height;
 
@@ -5,6 +7,11 @@
     height: 100%;
     border-right: 2px solid whitesmoke;
     padding: 1rem;
+    min-height: $admin-card-height;
+  }
+
+  .admin-panel-card {
+    min-height: $admin-card-height;
   }
 
   .tab-content {

--- a/app/assets/stylesheets/admin_panel.scss
+++ b/app/assets/stylesheets/admin_panel.scss
@@ -1,4 +1,4 @@
-$admin-card-height: 811px;
+$admin-card-height: 700px;
 
 #admin-panel {
   padding-bottom: $header-height;

--- a/app/assets/stylesheets/admin_panel.scss
+++ b/app/assets/stylesheets/admin_panel.scss
@@ -1,4 +1,4 @@
-$admin-card-height: 969px;
+$admin-card-height: 811px;
 
 #admin-panel {
   padding-bottom: $header-height;

--- a/app/javascript/components/admin/site_settings/SiteSettings.jsx
+++ b/app/javascript/components/admin/site_settings/SiteSettings.jsx
@@ -3,6 +3,7 @@ import Card from 'react-bootstrap/Card';
 import {
   Row, Col, Tab, Tabs, Container,
 } from 'react-bootstrap';
+import { useTranslation } from 'react-i18next';
 import AdminNavSideBar from '../AdminNavSideBar';
 import Appearance from './appearance/Appearance';
 import Administration from './administration/Administration';
@@ -10,9 +11,10 @@ import Settings from './settings/Settings';
 import Registration from './registration/Registration';
 
 export default function SiteSettings() {
+  const { t } = useTranslation();
   return (
     <div id="admin-panel">
-      <h3 className="py-5"> Administrator Panel </h3>
+      <h3 className="py-5">{ t('admin.admin_panel') }</h3>
       <Card className="border-0 shadow-sm">
         <Tab.Container activeKey="site-settings">
           <Row>
@@ -25,9 +27,9 @@ export default function SiteSettings() {
               <Tab.Content className="p-0">
                 <Container className="admin-table p-0">
                   <div className="ps-4 pe-4 pt-4">
-                    <h3> Customize Greenlight </h3>
+                    <h3>{ t('admin.site_settings.customize_greenlight') }</h3>
                   </div>
-                  <Tabs className="border-bottom ps-3" defaultActiveKey="appearance" unmountOnExit>
+                  <Tabs className="border-bottom ps-3" defaultActiveKey="appearance">
                     <Tab className="p-4" eventKey="appearance" title="Appearance">
                       <Appearance />
                     </Tab>

--- a/app/javascript/components/recordings/RecordingRow.jsx
+++ b/app/javascript/components/recordings/RecordingRow.jsx
@@ -33,7 +33,7 @@ export default function RecordingRow({
   const [isUpdating, setIsUpdating] = useState(false);
 
   return (
-    <tr key={recording.id} className="align-middle">
+    <tr key={recording.id} className="align-middle border-bottom-0">
       <td className="border-end-0 text-dark">
         <Stack direction="horizontal" className="py-2">
           <div className="recording-icon-circle rounded-circle me-3 d-flex align-items-center justify-content-center">

--- a/app/javascript/components/recordings/RecordingRow.jsx
+++ b/app/javascript/components/recordings/RecordingRow.jsx
@@ -33,7 +33,7 @@ export default function RecordingRow({
   const [isUpdating, setIsUpdating] = useState(false);
 
   return (
-    <tr key={recording.id} className="align-middle border-bottom-0">
+    <tr key={recording.id} className="align-middle">
       <td className="border-end-0 text-dark">
         <Stack direction="horizontal" className="py-2">
           <div className="recording-icon-circle rounded-circle me-3 d-flex align-items-center justify-content-center">

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -12,7 +12,7 @@
 # Instance variables
 # See https://ddnexus.github.io/pagy/api/pagy#instance-variables
 # Pagy::DEFAULT[:page]   = 1                                  # default
-Pagy::DEFAULT[:items] = 5 # default
+Pagy::DEFAULT[:items] = 10 # default
 # Pagy::DEFAULT[:outset] = 0                                  # default
 
 # Other Variables

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -12,7 +12,7 @@
 # Instance variables
 # See https://ddnexus.github.io/pagy/api/pagy#instance-variables
 # Pagy::DEFAULT[:page]   = 1                                  # default
-Pagy::DEFAULT[:items] = 10 # default
+Pagy::DEFAULT[:items] = 8 # default
 # Pagy::DEFAULT[:outset] = 0                                  # default
 
 # Other Variables

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -12,7 +12,7 @@
 # Instance variables
 # See https://ddnexus.github.io/pagy/api/pagy#instance-variables
 # Pagy::DEFAULT[:page]   = 1                                  # default
-Pagy::DEFAULT[:items] = 8 # default
+Pagy::DEFAULT[:items] = 10 # default
 # Pagy::DEFAULT[:outset] = 0                                  # default
 
 # Other Variables


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Add a (kind of cheap) fix to limit Admin tabs "jumping".

    Set an arbitrary min-height to the admin panel.
    RoomConfigs is pretty tall as well so we can't use pagination to size down the tabs.
    There might a better solution than that - I don't really like setting "random" pixel height but that does it for now.

- Set Pagy to return 10 elements instead of 5.
- Fix the "jumping" in Admin/SiteSettings tabs also.
- This PR does not include the fixes to the different styling of the tables in admin panels

