### PR TITLE
V2 Resources Migration: Fixed `Migrations::ExternalController#create_user`to generate password only for local users.

### DIFF
--- a/app/controllers/api/v1/migrations/external_controller.rb
+++ b/app/controllers/api/v1/migrations/external_controller.rb
@@ -38,17 +38,17 @@ module Api
         # Does: Creates a user.
 
         def create_user
-          language = if user_params[:language].blank? || user_params[:language] == 'default'
-                       I18n.default_locale
-                     else
-                       user_params[:language]
-                     end
+          user_hash = user_params.to_h
 
-          role = Role.find_by(name: user_params[:role], provider: 'greenlight')
+          user_hash[:language] = I18n.default_locale if user_hash[:language].blank? || user_hash[:language] == 'default'
+
+          role = Role.find_by(name: user_hash[:role], provider: 'greenlight')
 
           return render_error status: :bad_request unless role
 
-          user = User.new(user_params.merge(provider: 'greenlight', password: generate_secure_pwd, language:, role:))
+          user_hash[:password] = generate_secure_pwd if user_hash[:external_id].blank?
+
+          user = User.new(user_hash.merge(provider: 'greenlight', role:))
           return render_error status: :bad_request unless user.save
 
           return render_data status: :created if user.external_id?

--- a/spec/controllers/migrations/external_controller_spec.rb
+++ b/spec/controllers/migrations/external_controller_spec.rb
@@ -133,10 +133,10 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
         context 'when external_id is present' do
           before { valid_user_params[:external_id] = 'EXTERNAL' }
 
-          it 'returns :created, creates a user but does not send a reset email' do
+          it 'returns :created, creates a user but does not generate a pwd nor send a reset email' do
             encrypted_params = encrypt_params({ user: valid_user_params }, expires_in: 10.seconds)
 
-            expect_any_instance_of(described_class).to receive(:generate_secure_pwd).and_call_original
+            expect_any_instance_of(described_class).not_to receive(:generate_secure_pwd).and_call_original
             expect { post :create_user, params: { v2: { encrypted_params: } } }.to change(User, :count).from(0).to(1)
             expect(ActionMailer::MailDeliveryJob).not_to have_been_enqueued
 
@@ -148,7 +148,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
             expect(user.session_token).to be_present
             expect(user.provider).to eq('greenlight')
             expect(response).to have_http_status(:created)
-            expect(user.password_digest).to be_present
+            expect(user.password_digest).to be_blank
             expect(user.reset_digest).to be_blank
           end
         end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed `Migrations::ExternalController#create_user`to generate password only for local users.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext .jsx,.js`
> 6. Run `./bin/dev` to run the assets builders processes and the Puma server all at once.

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
