### PR TITLE
Add AdminPanel component to redirect to proper AdminPanel tab

### DIFF
--- a/app/javascript/components/admin/AdminNavSideBar.jsx
+++ b/app/javascript/components/admin/AdminNavSideBar.jsx
@@ -23,7 +23,7 @@ export default function AdminNavSideBar() {
       )}
       {(currentUser.permissions.ManageRooms === 'true') && (
         <Nav.Item>
-          <Nav.Link className="cursor-pointer text-muted" as={Link} to="/admin/server-rooms" eventKey="server-rooms">
+          <Nav.Link className="cursor-pointer text-muted" as={Link} to="/admin/server_rooms" eventKey="server_rooms">
             <ServerStackIcon className="hi-s me-3" />
             { t('admin.server_rooms.server_rooms') }
           </Nav.Link>
@@ -31,7 +31,7 @@ export default function AdminNavSideBar() {
       )}
       {(currentUser.permissions.ManageRecordings === 'true') && (
         <Nav.Item>
-          <Nav.Link className="cursor-pointer text-muted" as={Link} to="/admin/server-recordings" eventKey="server-recordings">
+          <Nav.Link className="cursor-pointer text-muted" as={Link} to="/admin/server_recordings" eventKey="server_recordings">
             <VideoCameraIcon className="hi-s me-3" />
             { t('admin.server_recordings.server_recordings') }
           </Nav.Link>
@@ -40,13 +40,13 @@ export default function AdminNavSideBar() {
       {(currentUser.permissions.ManageSiteSettings === 'true') && (
         <>
           <Nav.Item>
-            <Nav.Link className="cursor-pointer text-muted" as={Link} to="/admin/site-settings" eventKey="site-settings">
+            <Nav.Link className="cursor-pointer text-muted" as={Link} to="/admin/site_settings" eventKey="site_settings">
               <Cog8ToothIcon className="hi-s me-3" />
               { t('admin.site_settings.site_settings') }
             </Nav.Link>
           </Nav.Item>
           <Nav.Item>
-            <Nav.Link className="cursor-pointer text-muted" as={Link} to="/admin/room-configuration" eventKey="room-configuration">
+            <Nav.Link className="cursor-pointer text-muted" as={Link} to="/admin/room_configuration" eventKey="room_configuration">
               <AdjustmentsVerticalIcon className="hi-s me-3" />
               { t('admin.room_configuration.room_configuration') }
             </Nav.Link>

--- a/app/javascript/components/admin/AdminPanel.jsx
+++ b/app/javascript/components/admin/AdminPanel.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/auth/AuthProvider';
+
+export default function AdminPanel() {
+  const currentUser = useAuth();
+
+  const navigateTo = () => {
+    const { permissions } = currentUser;
+    const {
+      ManageUsers, ManageRooms, ManageRecordings, ManageSiteSettings, ManageRoles,
+    } = permissions;
+
+    if (ManageUsers === 'true') {
+      return '/admin/users';
+    }
+
+    if (ManageRooms === 'true') {
+      return '/admin/server_rooms';
+    }
+
+    if (ManageRecordings === 'true') {
+      return '/admin/server_recordings';
+    }
+
+    if (ManageSiteSettings === 'true') {
+      return '/admin/site_settings';
+    }
+
+    if (ManageRoles === 'true') {
+      return '/admin/roles';
+    }
+
+    return '/';
+  };
+
+  return (
+    <Navigate to={navigateTo()} replace />
+  );
+}

--- a/app/javascript/components/admin/room_configuration/RoomConfig.jsx
+++ b/app/javascript/components/admin/room_configuration/RoomConfig.jsx
@@ -18,7 +18,7 @@ export default function RoomConfig() {
     <div id="admin-panel">
       <h3 className="py-5"> { t('admin.admin_panel') } </h3>
       <Card className="border-0 shadow-sm">
-        <Tab.Container activeKey="room-configuration">
+        <Tab.Container activeKey="room_configuration">
           <Row>
             <Col className="pe-0" sm={3}>
               <div id="admin-sidebar">

--- a/app/javascript/components/admin/server_recordings/ServerRecordings.jsx
+++ b/app/javascript/components/admin/server_recordings/ServerRecordings.jsx
@@ -21,7 +21,7 @@ export default function ServerRecordings() {
     <div id="admin-panel">
       <h3 className="py-5"> {t('admin.admin_panel')} </h3>
       <Card className="border-0 shadow-sm">
-        <Tab.Container activeKey="server-recordings">
+        <Tab.Container activeKey="server_recordings">
           <Row>
             <Col className="pe-0" sm={3}>
               <div id="admin-sidebar">

--- a/app/javascript/components/admin/server_rooms/ServerRooms.jsx
+++ b/app/javascript/components/admin/server_rooms/ServerRooms.jsx
@@ -21,7 +21,7 @@ export default function ServerRooms() {
     <div id="admin-panel">
       <h3 className="py-5"> { t('admin.admin_panel') } </h3>
       <Card className="border-0 shadow-sm">
-        <Tab.Container activeKey="server-rooms">
+        <Tab.Container activeKey="server_rooms">
           <Row>
             <Col className="pe-0" sm={3}>
               <div id="admin-sidebar">

--- a/app/javascript/components/admin/site_settings/SiteSettings.jsx
+++ b/app/javascript/components/admin/site_settings/SiteSettings.jsx
@@ -16,7 +16,7 @@ export default function SiteSettings() {
     <div id="admin-panel">
       <h3 className="py-5">{ t('admin.admin_panel') }</h3>
       <Card className="border-0 shadow-sm">
-        <Tab.Container activeKey="site-settings">
+        <Tab.Container activeKey="site_settings">
           <Row>
             <Col className="pe-0" sm={3}>
               <div id="admin-sidebar">

--- a/app/javascript/main.jsx
+++ b/app/javascript/main.jsx
@@ -32,6 +32,7 @@ import ErrorBoundary from './components/shared_components/ErrorBoundary';
 import DefaultErrorPage from './components/errors/DefaultErrorPage';
 import NotFoundPage from './components/errors/NotFoundPage';
 import VerifyAccount from './components/users/account_activation/VerifyAccount';
+import AdminPanel from './components/admin/AdminPanel';
 
 const queryClient = new QueryClient();
 
@@ -51,13 +52,13 @@ const root = (
                 <Route path="/activate_account/:token" element={<ActivateAccount />} />
                 <Route path="/verify_account" element={<VerifyAccount />} />
                 <Route path="/profile" element={<Profile />} />
-                <Route path="/admin" element={<Navigate to="/admin/users" replace />} />
+                <Route path="/admin" element={<AdminPanel />} />
                 <Route path="/admin/users" element={<ManageUsers />} />
                 <Route path="/admin/edit_user/:userId" element={<EditUser />} />
-                <Route path="/admin/server-recordings" element={<ServerRecordings />} />
-                <Route path="/admin/server-rooms" element={<ServerRooms />} />
-                <Route path="/admin/room-configuration" element={<RoomConfig />} />
-                <Route path="/admin/site-settings" element={<SiteSettings />} />
+                <Route path="/admin/server_recordings" element={<ServerRecordings />} />
+                <Route path="/admin/server_rooms" element={<ServerRooms />} />
+                <Route path="/admin/room_configuration" element={<RoomConfig />} />
+                <Route path="/admin/site_settings" element={<SiteSettings />} />
                 <Route path="/admin/roles" element={<Roles />} />
                 <Route path="/admin/roles/edit/:roleId" element={<EditRole />} />
                 <Route path="/rooms" element={<Rooms />} />


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Problem: AdminPanel would always redirect to AdminPanel/ManageUsers. It is a problem because you can have a certain permission without having the ManageUser permission.
Solution: Create new AdminPanel component that will redirect to the proper AdminPanel tab depending on the User's permissions.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
Add/Remove certain permissions, and go to the AdminPanel.
