### PR TITLE
Allow ManageRooms to view other rooms

### DIFF
--- a/app/controllers/api/v1/rooms_configurations_controller.rb
+++ b/app/controllers/api/v1/rooms_configurations_controller.rb
@@ -3,6 +3,7 @@
 module Api
   module V1
     class RoomsConfigurationsController < ApiController
+      # TODO: samuel - Review this, RoomsConfig#index is needed when user with ManageRooms what to access another users room
       before_action only: %i[index] do
         ensure_authorized(%w[CreateRoom ManageSiteSettings ManageRoles], friendly_id: params[:friendly_id])
       end

--- a/app/controllers/api/v1/rooms_configurations_controller.rb
+++ b/app/controllers/api/v1/rooms_configurations_controller.rb
@@ -3,9 +3,8 @@
 module Api
   module V1
     class RoomsConfigurationsController < ApiController
-      # TODO: samuel - Review this, RoomsConfig#index is needed when user with ManageRooms what to access another users room
       before_action only: %i[index] do
-        ensure_authorized(%w[CreateRoom ManageSiteSettings ManageRoles], friendly_id: params[:friendly_id])
+        ensure_authorized(%w[CreateRoom ManageSiteSettings ManageRoles ManageRooms], friendly_id: params[:friendly_id])
       end
 
       # GET /api/v1/rooms_configurations.json

--- a/app/javascript/components/rooms/room/FeatureTabs.jsx
+++ b/app/javascript/components/rooms/room/FeatureTabs.jsx
@@ -17,9 +17,6 @@ export default function FeatureTabs({ shared }) {
   const { isLoading: isLoadingShare, data: shareRoomEnabled } = useSiteSetting('ShareRooms');
 
   const currentUser = useAuth();
-  const { permissions } = currentUser;
-
-  console.log(currentUser)
 
   if (isLoadingPreup || isLoadingShare) {
     return (

--- a/app/javascript/components/rooms/room/FeatureTabs.jsx
+++ b/app/javascript/components/rooms/room/FeatureTabs.jsx
@@ -9,11 +9,17 @@ import Presentation from './presentation/Presentation';
 import RoomSettings from './room_settings/RoomSettings';
 import useSiteSetting from '../../../hooks/queries/site_settings/useSiteSetting';
 import SharedAccess from './shared_access/SharedAccess';
+import { useAuth } from '../../../contexts/auth/AuthProvider';
 
 export default function FeatureTabs({ shared }) {
   const { t } = useTranslation();
   const { isLoading: isLoadingPreup, data: preuploadEnabled } = useSiteSetting('PreuploadPresentation');
   const { isLoading: isLoadingShare, data: shareRoomEnabled } = useSiteSetting('ShareRooms');
+
+  const currentUser = useAuth();
+  const { permissions } = currentUser;
+
+  console.log(currentUser)
 
   if (isLoadingPreup || isLoadingShare) {
     return (
@@ -28,8 +34,8 @@ export default function FeatureTabs({ shared }) {
     );
   }
 
-  // Returns only the Recording tab if the room is a Shared Room
-  if (shared) {
+  // Returns only the Recording tab if the room is a Shared Room and the User does not have the ManageRoom permission
+  if (shared && !currentUser?.permissions?.ManageRooms) {
     return (
       <Row className="pt-4 mx-0">
         <Tabs defaultActiveKey="recordings" unmountOnExit>


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Problem: User with ManageRoom permissions can't access Presentation, Shared and Settings tabs other users Rooms because it is not shared.
Solution: Add a permission checker to Room view. If user has ManageRoom permission, tabs should appear.


## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
