### PR TITLE
Add disabled to Pagination button

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -217,6 +217,12 @@ input.search-bar {
   &:focus {
     box-shadow: 0 0 0 0.25rem var(--brand-color-light);
   }
+
+  &:disabled {
+    color: gray !important;
+    pointer-events: none !important;
+    cursor: not-allowed !important;
+  }
 }
 
 .btn-brand-outline-color {

--- a/app/javascript/components/shared_components/Pagination.jsx
+++ b/app/javascript/components/shared_components/Pagination.jsx
@@ -8,6 +8,20 @@ export default function Pagination({
 }) {
   const handlePage = (e, { activePage }) => setPage(activePage);
 
+  const disabledPrevious = () => {
+    if (page === 1) {
+      return true;
+    }
+    return false;
+  };
+
+  const disabledNext = () => {
+    if (page === totalPages) {
+      return true;
+    }
+    return false;
+  }
+
   if (totalPages > 1) {
     return (
       <div className="semantic-ui-pagination pagination-wrapper">
@@ -18,12 +32,16 @@ export default function Pagination({
           onPageChange={handlePage}
           firstItem={null}
           lastItem={null}
-          prevItem={{
-            content: <PaginationButton direction="Previous" />,
+          prevItem={
+          {
+            disabled: disabledPrevious(),
+            content: <PaginationButton page={page} totalPages={totalPages} direction="Previous" />,
             icon: true,
-          }}
+          }
+        }
           nextItem={{
-            content: <PaginationButton direction="Next" />,
+            disabled: disabledNext(),
+            content: <PaginationButton page={page} totalPages={totalPages} direction="Next" />,
             icon: true,
           }}
         />

--- a/app/javascript/components/shared_components/Pagination.jsx
+++ b/app/javascript/components/shared_components/Pagination.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Pagination as PaginationSemanticUi } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
-import PaginationButton from './PaginationPrevButton';
+import PaginationButton from './PaginationButton';
 
 export default function Pagination({
   page, totalPages, setPage,
@@ -20,7 +20,7 @@ export default function Pagination({
       return true;
     }
     return false;
-  }
+  };
 
   if (totalPages > 1) {
     return (

--- a/app/javascript/components/shared_components/Pagination.jsx
+++ b/app/javascript/components/shared_components/Pagination.jsx
@@ -8,19 +8,9 @@ export default function Pagination({
 }) {
   const handlePage = (e, { activePage }) => setPage(activePage);
 
-  const disabledPrevious = () => {
-    if (page === 1) {
-      return true;
-    }
-    return false;
-  };
+  const disabledPrevious = () => (page === 1);
 
-  const disabledNext = () => {
-    if (page === totalPages) {
-      return true;
-    }
-    return false;
-  };
+  const disabledNext = () => (page === totalPages);
 
   if (totalPages > 1) {
     return (

--- a/app/javascript/components/shared_components/PaginationButton.jsx
+++ b/app/javascript/components/shared_components/PaginationButton.jsx
@@ -4,10 +4,19 @@ import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 
-export default function PaginationButton({ direction }) {
+export default function PaginationButton({ direction, page, totalPages }) {
   const { t } = useTranslation();
 
   if (direction === 'Previous') {
+    if (page === 1) {
+      return (
+        <Button variant="brand-outline" disabled>
+          <ArrowLeftIcon className="me-3 hi-s" />
+          { t('previous') }
+        </Button>
+      );
+    }
+
     return (
       <Button variant="brand-outline">
         <ArrowLeftIcon className="me-3 hi-s text-brand" />
@@ -17,6 +26,15 @@ export default function PaginationButton({ direction }) {
   }
 
   if (direction === 'Next') {
+    if (page === totalPages) {
+      return (
+        <Button variant="brand-outline" disabled>
+          { t('next') }
+          <ArrowRightIcon className="ms-3 hi-s" />
+        </Button>
+      );
+    }
+
     return (
       <Button variant="brand-outline">
         { t('next') }
@@ -28,4 +46,6 @@ export default function PaginationButton({ direction }) {
 
 PaginationButton.propTypes = {
   direction: PropTypes.string.isRequired,
+  page: PropTypes.number.isRequired,
+  totalPages: PropTypes.number.isRequired,
 };


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A bit of an annoying fix:

1. Semantic-ui pagination buttons are a button inside of an anchor. So we need to disable the anchor with `aria-disabled=true` in the Pagination component. 
![image](https://user-images.githubusercontent.com/43917914/200943451-8d530a29-e830-4f6e-8887-5266b4ebfab6.png)

2. We need to disable the button itself in PaginationButton component.
3. We need to overwrite the custom button in app.scss

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/43917914/200942903-0b1c071c-75f0-4afd-a71f-29849bc1e37b.png)
