### PR TITLE
Select API: Removed dependency cycles between <Select/> and <Option/>.

### DIFF
--- a/app/javascript/components/shared_components/constants/SelectConstants.js
+++ b/app/javascript/components/shared_components/constants/SelectConstants.js
@@ -1,0 +1,5 @@
+export const ACTIONS = {
+  SELECT: 'SELECT',
+};
+
+export default {};

--- a/app/javascript/components/shared_components/contexts/SelectContext.js
+++ b/app/javascript/components/shared_components/contexts/SelectContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const SelectContext = React.createContext(null);
+
+export default SelectContext;

--- a/app/javascript/components/shared_components/utilities/Option.jsx
+++ b/app/javascript/components/shared_components/utilities/Option.jsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Dropdown } from 'react-bootstrap';
-import { ACTIONS, SelectContext } from './Select';
+import SelectContext from '../contexts/SelectContext';
+import { ACTIONS } from '../constants/SelectConstants';
 
 export default function Option({ children: title, value }) {
   const { selected, dispatch } = useContext(SelectContext);

--- a/app/javascript/components/shared_components/utilities/Select.jsx
+++ b/app/javascript/components/shared_components/utilities/Select.jsx
@@ -3,12 +3,8 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { Dropdown } from 'react-bootstrap';
-
-export const SelectContext = React.createContext(null);
-
-export const ACTIONS = {
-  SELECT: 'SELECT',
-};
+import SelectContext from '../contexts/SelectContext';
+import { ACTIONS } from '../constants/SelectConstants';
 
 const reducer = (state, action) => {
   switch (action.type) {


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR makes a small refactoring to the **Select** API to remove the room for cyclic dependencies between **Select** and **Option** components.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext 

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
