### PR TITLE
Select API: Added `createOptionsFromChildren` function to the `Select` component.

### DIFF
--- a/app/javascript/components/shared_components/utilities/Select.jsx
+++ b/app/javascript/components/shared_components/utilities/Select.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { Dropdown } from 'react-bootstrap';
 import SelectContext from '../contexts/SelectContext';
 import { ACTIONS } from '../constants/SelectConstants';
+import Option from './Option';
 
 const reducer = (state, action) => {
   switch (action.type) {
@@ -13,6 +14,38 @@ const reducer = (state, action) => {
     default:
       return state;
   }
+};
+
+const createOptionsFromChildren = (children) => {
+  const options = {};
+
+  React.Children.forEach(children, (elem) => {
+    if (!elem) { return; }
+
+    if (!React.isValidElement(elem)) {
+      throw new Error('Only react elements are allowed inside of <Select> component.');
+    }
+
+    if (elem.type !== Option) { return; }
+
+    const { children: title, value } = elem.props;
+
+    if (!title || typeof title !== 'string') {
+      throw new Error('An <Option> component was caught with an invalid title. All nested <Option> components must have a string children title.');
+    }
+
+    if (value === undefined || value === null || value === '') {
+      throw new Error('An <Option> component was caught with no value prop. All nested <Option> components must have a value prop.');
+    }
+
+    if (options[value]) {
+      throw new Error('An <Option> component was caught with a duplicated value. All nested <Option> components must have a unique value.');
+    }
+
+    options[value] = title;
+  });
+
+  return options;
 };
 
 export default function Select({


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds `createOptionsFromChildren` function to the `Select` component.
This function is inspired from `createRoutesFromChildren` function that empowers `react-router` **Routes** component [HERE](https://github.com/remix-run/react-router/blob/v6.2.2/packages/react-router/index.tsx#L760).
Like  `createRoutesFromChildren` is used to enable the react-router to map the routes list while preserving a declarative approach and hiding complexities, the `createOptionsFromChildren` will enable the **Select** component to seamlessly map the options list while preserving the declarative design of react and therefore the API itself.

`createOptionsFromChildren` shares the same objectives and philosophy with `createRoutesFromChildren` but not the requirements and criteria.
 createOptionsFromChildren empowers the API with:
1. The ability to dynamically map and create a an object (unlike react-router that uses an array) of `optionValue => optionTitle`.
2. **Ensures and not assumes** that the children list is formed of valid react elements **only**.
3. **Ensures and not assumes** that if a child react element is an `Option` component:
    1. It **must** have a none empty string value as a children that will be considered as the option title.
    2. It **must** have a none empty **value** prop.
4. **Ensures and not assumes** that all `Option` components in a `Select` will have **unique values**.
5. Any child valid react element or falsy value that isn't an `Option` component will be ignored when encountered.

With those points `createOptionsFromChildren` will map the declarative list of options to a plain old javascript object that is optimized for lookups.
With this in place the **Select** component can make sense of its list of options and therefore have a clean state and become controllable.

Like the native DOM select API that can be controlled by the `select.value` property the **Select** component can now be controlled by a `value` prop.


## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext 


## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
