### PR TITLE
Select API: Added custom form control component `FormSelect`.

### DIFF
--- a/app/javascript/components/shared_components/forms/controls/FormSelect.jsx
+++ b/app/javascript/components/shared_components/forms/controls/FormSelect.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Form as BootStrapForm } from 'react-bootstrap';
+import { useController } from 'react-hook-form';
+import Select from '../../utilities/Select';
+
+export default function FormSelect({
+  children, variant, field,
+}) {
+  const { hookForm: { id: name, validations: rules } } = field;
+
+  const {
+    field: { onChange, onBlur, value },
+    fieldState: { invalid, error },
+  } = useController({
+    name,
+    rules,
+  });
+
+  return (
+    <BootStrapForm.Group className="mb-2" controlId={field.controlId}>
+      <BootStrapForm.Label className="small mb-0">
+        {field.label}
+      </BootStrapForm.Label>
+      <Select
+        id={field.controlId}
+        onChange={onChange}
+        onBlur={onBlur}
+        value={value}
+        variant={variant}
+        isValid={!invalid}
+      >
+        { children }
+      </Select>
+      {
+        error
+        && (
+          (error.types
+            && Object.keys(error.types).map(
+              (key) => (
+                error.types[key] && <BootStrapForm.Control.Feedback key={key} type="invalid">{error.types[key]}</BootStrapForm.Control.Feedback>
+              ),
+            )
+          )
+          || (error.message && <BootStrapForm.Control.Feedback type="invalid">{error.message}</BootStrapForm.Control.Feedback>)
+        )
+
+      }
+    </BootStrapForm.Group>
+  );
+}
+
+FormSelect.defaultProps = {
+  variant: undefined,
+};
+
+FormSelect.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.element).isRequired,
+  variant: PropTypes.string,
+  field: PropTypes.shape(
+    {
+      label: PropTypes.string,
+      placeHolder: PropTypes.string,
+      controlId: PropTypes.string.isRequired,
+      hookForm: PropTypes.shape(
+        {
+          id: PropTypes.string.isRequired,
+          validations: PropTypes.shape({
+            deps: PropTypes.arrayOf(PropTypes.string),
+          }),
+        },
+      ).isRequired,
+    },
+  ).isRequired,
+};


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the custom form control `FormSelect`.
**FormSelect** is a wrapping component around the **Select** UI component that will integrate and register it seamlessly with the closest react-hook form.
**FormSelect** will provide a simplified declarative experience compared to interacting directly with the **Select** API and hook-forms.

 **FormSelect** is a form control component and therefore it is a case of the regular **FormControl** that uses its same structure and design (a future refactoring can reduce duplication between both components).

## Usage:
Example of using the current `FormSelect` API:
```
 <Form methods={methods} onSubmit={updateUser.mutate}>
      <FormControl field={fields.name} type="text" />
      <FormSelect field={fields.language} variant='primary'>
        {
          Object.keys(LOCALES).map((code) => <Option key={code} value={code}>{LOCALES[code]}</Option>)
        }
      </FormSelect>
 </Form>
```

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
> 1. Pull the code.
> 2. Install the dependencies `bundle install && npm|yarn install`.
> 3. Clean the previous assets build by running `rm app/assets/builds/*` (This won't remove .keep since it's hidden).
> 4. Clean the database and tmp files for a better isolation by running `rails tmp:clear && rails db:schema:cache:clear && rails db:drop && rails db:create && rails db:migrate:with_data`
> 5. Run the linter and specs `bundle exec rubocop --parallel && bundle exec rspec && npx eslint app/javascript/* --ext 

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
