### PR TITLE
Fix Admin Toggles

### DIFF
--- a/app/javascript/components/admin/room_configuration/RoomConfig.jsx
+++ b/app/javascript/components/admin/room_configuration/RoomConfig.jsx
@@ -13,12 +13,14 @@ import { useAuth } from '../../../contexts/auth/AuthProvider';
 
 export default function RoomConfig() {
   const { t } = useTranslation();
-  const { data: roomConfigs } = useRoomConfigs();
+  const { data: roomConfigs, isLoading } = useRoomConfigs();
   const currentUser = useAuth();
 
   if (currentUser.permissions?.ManageSiteSettings !== 'true') {
     return <Navigate to="/404" />;
   }
+
+  if (isLoading) return null;
 
   return (
     <div id="admin-panel" className="pb-3">

--- a/app/javascript/components/admin/site_settings/settings/Settings.jsx
+++ b/app/javascript/components/admin/site_settings/settings/Settings.jsx
@@ -5,7 +5,9 @@ import SettingsRow from '../SettingsRow';
 
 export default function Settings() {
   const { t } = useTranslation();
-  const { data: siteSettings } = useSiteSettings(['ShareRooms', 'PreuploadPresentation']);
+  const { data: siteSettings, isLoading } = useSiteSettings(['ShareRooms', 'PreuploadPresentation']);
+
+  if (isLoading) return null;
 
   return (
     <>


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Problem: The toggle buttons in Admin Settings and RoomConfig would not appear with the proper values - they are all toggled off. 
Solution: Add isLoading back so the toggling value is loaded before the page gets rendered.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
