### PR TITLE
Fix Access Code edgecases

### DIFF
--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -101,7 +101,7 @@ module Api
         @room.user_id == current_user&.id ||
           current_user&.shared_rooms&.include?(@room) ||
           access_code_validator(access_code: mod_code) ||
-          (anyone_join_as_mod && mod_code.blank? && viewer_code.blank?) ||
+          (anyone_join_as_mod && viewer_code.blank? && mod_code.blank?) ||
           (anyone_join_as_mod && (access_code_validator(access_code: mod_code) || access_code_validator(access_code: viewer_code)))
       end
 
@@ -112,7 +112,7 @@ module Api
       def infer_bbb_role(mod_code:, viewer_code:, anyone_join_as_mod:)
         if authorized_as_moderator?(mod_code:, viewer_code:, anyone_join_as_mod:)
           'Moderator'
-        elsif authorized_as_viewer?(viewer_code:)
+        elsif authorized_as_viewer?(viewer_code:) && !anyone_join_as_mod
           'Viewer'
         end
       end

--- a/app/javascript/components/rooms/room/join/RoomJoin.jsx
+++ b/app/javascript/components/rooms/room/join/RoomJoin.jsx
@@ -40,8 +40,6 @@ export default function RoomJoin() {
   const location = useLocation();
   const path = encodeURIComponent(location.pathname);
 
-  console.log(publicRoom?.data);
-
   useEffect(() => { // set cookie to return to if needed
     document.cookie = `location=${path};path=/;`;
 

--- a/app/javascript/components/rooms/room/join/RoomJoin.jsx
+++ b/app/javascript/components/rooms/room/join/RoomJoin.jsx
@@ -40,6 +40,8 @@ export default function RoomJoin() {
   const location = useLocation();
   const path = encodeURIComponent(location.pathname);
 
+  console.log(publicRoom?.data);
+
   useEffect(() => { // set cookie to return to if needed
     document.cookie = `location=${path};path=/;`;
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -40,10 +40,6 @@ class Room < ApplicationRecord
     all
   end
 
-  def anyone_joins_as_moderator?
-    MeetingOption.get_setting_value(name: 'glAnyoneJoinAsModerator', room_id: id)&.value == 'true'
-  end
-
   def get_setting(name:)
     room_meeting_options.joins(:meeting_option)
                         .find_by(meeting_option: { name: })

--- a/spec/controllers/meetings_controller_spec.rb
+++ b/spec/controllers/meetings_controller_spec.rb
@@ -314,7 +314,6 @@ RSpec.describe Api::V1::MeetingsController, type: :controller do
       end
     end
 
-
     context 'glAnyoneCanStart' do
       let(:fake_room_settings_getter) { instance_double(RoomSettingsGetter) }
 

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -120,31 +120,6 @@ RSpec.describe Room, type: :model do
   end
 
   context 'instance methods' do
-    describe '#anyone_joins_as_moderator?' do
-      let!(:room) { create(:room) }
-
-      it 'calls MeetingOption::get_setting_value and returns true if "glAnyoneJoinAsModerator" is set to "true"' do
-        allow(MeetingOption).to receive(:get_setting_value).and_return(instance_double(RoomMeetingOption, value: 'true'))
-        expect(MeetingOption).to receive(:get_setting_value).with(name: 'glAnyoneJoinAsModerator', room_id: room.id)
-
-        expect(room).to be_anyone_joins_as_moderator
-      end
-
-      it 'calls MeetingOption::get_setting_value and returns false if "glAnyoneJoinAsModerator" is NOT set to "true"' do
-        allow(MeetingOption).to receive(:get_setting_value).and_return(instance_double(RoomMeetingOption, value: 'false'))
-        expect(MeetingOption).to receive(:get_setting_value).with(name: 'glAnyoneJoinAsModerator', room_id: room.id)
-
-        expect(room).not_to be_anyone_joins_as_moderator
-      end
-
-      it 'calls MeetingOption::get_setting_value and returns false if "glAnyoneJoinAsModerator" is NOT set' do
-        allow(MeetingOption).to receive(:get_setting_value).and_return(nil)
-        expect(MeetingOption).to receive(:get_setting_value).with(name: 'glAnyoneJoinAsModerator', room_id: room.id)
-
-        expect(room).not_to be_anyone_joins_as_moderator
-      end
-    end
-
     describe '#get_setting' do
       it 'fetches a room setting by :name' do
         room = create(:room)


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR aims to review/fix the Access Code process.

**Moderator Code is enabled**
When a Moderator Code is enable, the input bar will be visible to anyone on the RoomJoin page. 
Right now, if you enter an input,  if the input correspond to the Moderator Access Code, you will join in as a Moderator.
If the input does not correspond, you will join in as a Viewer.
Following this PR, if a user enters an input that does not correspond to the Moderator Access Code, it will be denied the access to the room. 
So, the input field needs to be let blank if you want to join as a Viewer.

**Anyone Join As Moderator**
When AnyoneJoinAsModerator is enabled, the Room owner can still enable the Viewer and Moderator Access code.
Before this PR, enabling AnyoneJoinAsModerator would bypass the Access Code checkup.
Following this PR, entering an Access Code that corresponds to either the Moderator or the Viewer Access Code will let the user in as a Moderator.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
- Toggle the RoomSettings, especially AnyoneJoinAsModerator
- Toggle the Mod/Viewer Access Code
- Open an incognito browser and try to join in the Room with different scenarios
