### PR TITLE
Solved Critical Issue Allowing Users to Change their Role 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,3 +431,4 @@ DEPENDENCIES
   web-console
   webdrivers
   webmock
+  

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,3 +431,9 @@ DEPENDENCIES
   web-console
   webdrivers
   webmock
+
+RUBY VERSION
+   ruby 3.1.0p0
+
+BUNDLED WITH
+   2.3.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,9 +431,3 @@ DEPENDENCIES
   web-console
   webdrivers
   webmock
-
-RUBY VERSION
-   ruby 3.1.0p0
-
-BUNDLED WITH
-   2.3.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,4 +431,3 @@ DEPENDENCIES
   web-console
   webdrivers
   webmock
-  

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -70,6 +70,12 @@ module Api
 
       def update
         user = User.find(params[:id])
+        # user is updating themselves
+
+        if current_user.id == params[:id] && !PermissionsChecker.new(permission_names: 'ManageUsers', current_user:, user_id: nil, record_id: nil,
+                                                                     friendly_id: nil).call
+          params[:user].delete(:role_id)
+        end
 
         if user.update(user_params)
           create_default_room(user)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -71,8 +71,7 @@ module Api
       def update
         user = User.find(params[:id])
         # user is updating themselves
-        if current_user.id == params[:id] && !PermissionsChecker.new(permission_names: 'ManageUsers', current_user:, user_id: nil, record_id: nil,
-                                                                     friendly_id: nil).call
+        if current_user.id == params[:id] && !PermissionsChecker.new(permission_names: 'ManageUsers', current_user:, current_provider:).call
           params[:user].delete(:role_id)
         end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -71,7 +71,6 @@ module Api
       def update
         user = User.find(params[:id])
         # user is updating themselves
-
         if current_user.id == params[:id] && !PermissionsChecker.new(permission_names: 'ManageUsers', current_user:, user_id: nil, record_id: nil,
                                                                      friendly_id: nil).call
           params[:user].delete(:role_id)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       updated_params = {
         name: 'New Name',
         email: 'newemail@gmail.com',
-        language: 'gl',
+        language: 'gl'
       }
       patch :update, params: { id: user.id, user: updated_params }
       expect(response).to have_http_status(:ok)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       expect(user.role_id).not_to eq(updated_params[:role_id])
     end
 
-    it 'allows an admin to edit themself' do
+    it 'allows a user with ManageUser permissions to edit their own role' do
       sign_in_user(user_with_manage_users_permission)
       updated_params = {
         role_id: create(:role, name: 'New Role').id
@@ -289,7 +289,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       expect(user_with_manage_users_permission.role_id).to eq(updated_params[:role_id])
     end
 
-    it 'allows an admin to edit someone else' do
+    it 'allows a user with ManageUser permissions to edit their own role' do
       sign_in_user(user_with_manage_users_permission)
 
       updated_params = {

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       expect(user_with_manage_users_permission.role_id).to eq(updated_params[:role_id])
     end
 
-    it 'allows a user with ManageUser permissions to edit their own role' do
+    it 'allows a user with ManageUser permissions to edit another users role' do
       sign_in_user(user_with_manage_users_permission)
 
       updated_params = {


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a Shared Access Serializer to prevent exposing the role id that was being exposed prior to this change. 
Updated the users controller to account to check if a user is editing themselves or tying to edit another user; same check goes for an admin as well.
Added corresponding rspec tests to test for these changes

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
Added 3 tests to check for 3 different conditions:
- Does not allow the user to change their own role 
    - sign in with user
    - pass in updated parameters including the role id in a PUT request 
    - expect the user id to  **not** be equal to the updated role id 
- An admin trying to edit themselves
    - sign in with admin
    - pass in updated parameters including the role id in a PUT request
    - expect the admin user's id to be equal to the updated role id
- An admin trying to edit another user
     - sign in with admin
     - pass in updated parameters including the role id in a PUT request
     - expect the changed user's id to be equal to the updated role id
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
