### PR TITLE
Migration upgrade (V3): addition of RolePermissions, RoomSettings, SharedAccess, SiteSettings, RoomConfiguration data

### DIFF
--- a/app/controllers/api/v1/migrations/external_controller.rb
+++ b/app/controllers/api/v1/migrations/external_controller.rb
@@ -148,7 +148,8 @@ module Api
 
           # Finds all the RoomsConfiguration that need to be updated
           room_configurations_temp = RoomsConfiguration.joins(:meeting_option)
-                                                       .where('meeting_options.name': settings_hash[:room_configurations].keys, provider: 'greenlight')
+                                                       .where('meeting_options.name': settings_hash[:room_configurations].keys,
+                                                              provider: 'greenlight')
                                                        .pluck(:id, :'meeting_options.name')
                                                        .to_h
           # Re-structure the data so it is in the format: { <rooms_configuration_id>: { value: <rooms_configuration_new_value> } }

--- a/app/controllers/api/v1/migrations/external_controller.rb
+++ b/app/controllers/api/v1/migrations/external_controller.rb
@@ -94,36 +94,37 @@ module Api
         end
 
         def create_room_meeting_option
-          room_meeting_option = room_meeting_option_params.to_h
+          room_meeting_option_hash = room_meeting_option_params.to_h
 
-          room = Room.find_by(friendly_id: room_meeting_option[:friendly_id])
+          room = Room.find_by(friendly_id: room_meeting_option_hash[:friendly_id])
 
           return render_error status: :bad_request unless room
 
-          meeting_options = room_meeting_option[:room_settings]
+          # Returns all RoomMeetingOptions for a room
+          room_meeting_options = RoomMeetingOption.where(room:)
 
-          meeting_options.each do |name, value|
+          room_meeting_option_hash.each do |name, value|
             meeting_option = MeetingOption.find_by(name:)
             return render_error status: :bad_request unless meeting_option
 
-            room_meeting_option = RoomMeetingOption.find_by(room:, meeting_option:)
+            room_meeting_option = room_meeting_options.find_by(room:, meeting_option:)
             return render_error status: :bad_request unless room_meeting_option
 
-            room_meeting_option.update(value:)
+            room_meeting_option.update!(value:) if room_meeting_option.value != value
           end
 
           render_data status: :created
         end
 
-        def create_settings
-          settings = settings_params.to_h
+        def create_site_settings
+          settings = site_settings_params.to_h
 
           settings.each do |name, value|
             site_setting = SiteSetting.find_by(name:, provider: 'greenlight')
 
             return render_error status: :bad_request unless site_setting
 
-            site_setting.update(value:)
+            site_setting.update!(value:)
           end
 
           render_data status: :created
@@ -147,7 +148,7 @@ module Api
           decrypted_params.require(:room).permit(:friendly_id, :room_settings)
         end
 
-        def settings_params
+        def site_settings_params
           decrypted_params.require(:settings).permit(:PrimaryColor, :PrimaryColorLight, :PrimaryColorDark, :RegistrationMethod, :ShareRooms, :PreuploadPresentation)
         end
 

--- a/app/controllers/api/v1/migrations/external_controller.rb
+++ b/app/controllers/api/v1/migrations/external_controller.rb
@@ -90,10 +90,6 @@ module Api
         def create_room
           room_hash = room_params.to_h
 
-
-          binding.break
-
-
           return render_data status: :created if Room.exists? friendly_id: room_hash[:friendly_id]
 
           user = User.find_by(email: room_hash[:owner_email], provider: 'greenlight')
@@ -141,10 +137,10 @@ module Api
         #                          :glAnyoneJoinAsModerator, :glRequireAuthentication } } }
         # Returns: { data: Array[serializable objects] , errors: Array[String] }
         # Does: Creates a SiteSettings or a RoomsConfiguration.
-        def create_site_settings
-          settings_hash = site_settings_params.to_h
+        def create_settings
+          settings_hash = settings_params.to_h
 
-          render_data status: :created unless settings.any?
+          render_data status: :created unless settings_hash.any?
 
           settings_hash[:site_settings].any? && settings_hash[:site_settings].each do |name, value|
             site_setting = SiteSetting.joins(:setting).find_by('settings.name': name, provider: 'greenlight')
@@ -180,7 +176,7 @@ module Api
                                                                                                                 shared_users_emails: [])
         end
 
-        def site_settings_params
+        def settings_params
           decrypted_params.require(:settings).permit(site_settings: {}, room_configurations: {})
         end
 

--- a/app/controllers/api/v1/migrations/external_controller.rb
+++ b/app/controllers/api/v1/migrations/external_controller.rb
@@ -143,7 +143,8 @@ module Api
         end
 
         def site_settings_params
-          decrypted_params.require(:settings).permit(:PrimaryColor, :PrimaryColorLight, :PrimaryColorDark, :RegistrationMethod, :ShareRooms, :PreuploadPresentation)
+          decrypted_params.require(:settings).permit(:PrimaryColor, :PrimaryColorLight, :PrimaryColorDark, :RegistrationMethod, :ShareRooms,
+                                                     :PreuploadPresentation)
         end
 
         def decrypted_params

--- a/app/controllers/api/v1/migrations/external_controller.rb
+++ b/app/controllers/api/v1/migrations/external_controller.rb
@@ -93,6 +93,42 @@ module Api
           render_data status: :created
         end
 
+        def create_room_meeting_option
+          room_meeting_option = room_meeting_option_params.to_h
+
+          room = Room.find_by(friendly_id: room_meeting_option[:friendly_id])
+
+          return render_error status: :bad_request unless room
+
+          meeting_options = room_meeting_option[:room_settings]
+
+          meeting_options.each do |name, value|
+            meeting_option = MeetingOption.find_by(name:)
+            return render_error status: :bad_request unless meeting_option
+
+            room_meeting_option = RoomMeetingOption.find_by(room:, meeting_option:)
+            return render_error status: :bad_request unless room_meeting_option
+
+            room_meeting_option.update(value:)
+          end
+
+          render_data status: :created
+        end
+
+        def create_settings
+          settings = settings_params.to_h
+
+          settings.each do |name, value|
+            site_setting = SiteSetting.find_by(name:, provider: 'greenlight')
+
+            return render_error status: :bad_request unless site_setting
+
+            site_setting.update(value:)
+          end
+
+          render_data status: :created
+        end
+
         private
 
         def role_params
@@ -105,6 +141,14 @@ module Api
 
         def room_params
           decrypted_params.require(:room).permit(:name, :friendly_id, :meeting_id, :last_session, :owner_email)
+        end
+
+        def room_meeting_option_params
+          decrypted_params.require(:room).permit(:friendly_id, :room_settings)
+        end
+
+        def settings_params
+          decrypted_params.require(:settings).permit(:PrimaryColor, :PrimaryColorLight, :PrimaryColorDark, :RegistrationMethod, :ShareRooms, :PreuploadPresentation)
         end
 
         def decrypted_params

--- a/app/controllers/api/v1/migrations/external_controller.rb
+++ b/app/controllers/api/v1/migrations/external_controller.rb
@@ -97,7 +97,6 @@ module Api
           room_meeting_option_hash = room_meeting_option_params.to_h
 
           room = Room.find_by(friendly_id: room_meeting_option_hash[:friendly_id])
-
           return render_error status: :bad_request unless room
 
           # Returns all RoomMeetingOptions for a room
@@ -111,6 +110,7 @@ module Api
             return render_error status: :bad_request unless room_meeting_option
 
             room_meeting_option.update!(value:) if room_meeting_option.value != value
+            return render_error status: :bad_request unless room_meeting_option.save
           end
 
           render_data status: :created
@@ -121,10 +121,10 @@ module Api
 
           settings.each do |name, value|
             site_setting = SiteSetting.find_by(name:, provider: 'greenlight')
-
             return render_error status: :bad_request unless site_setting
 
             site_setting.update!(value:)
+            return render_error status: :bad_request unless site_setting.save
           end
 
           render_data status: :created

--- a/app/controllers/api/v1/migrations/external_controller.rb
+++ b/app/controllers/api/v1/migrations/external_controller.rb
@@ -42,7 +42,7 @@ module Api
           role_permissions = RolePermission.where(role_id: role.id).includes(:permission)
           # The role_permissions hash contains only the permissions with value that differs from V3 default values
           role_hash[:role_permissions].any? && role_hash[:role_permissions].each do |name, value|
-            role_permission = role_permissions.find_by(permission: { 'permissions.name': name })
+            role_permission = role_permissions.find_by('permissions.name': name)
             return render_error status: :bad_request unless role_permission
 
             role_permission.update!(value:)

--- a/app/controllers/api/v1/migrations/external_controller.rb
+++ b/app/controllers/api/v1/migrations/external_controller.rb
@@ -36,7 +36,7 @@ module Api
           return render_error status: :bad_request unless role.save
 
           # Returns unless the Role has a RolePermission that differs from V3 default RolePermissions values
-          render_data status: :created unless role_hash[:role_permissions].any?
+          return render_data status: :created unless role_hash[:role_permissions].any?
 
           # Finds & Updates the associated RolePermissions associated with the Role
           role_permissions = RolePermission.where(role_id: role.id).includes(:permission)

--- a/app/controllers/api/v1/migrations/external_controller.rb
+++ b/app/controllers/api/v1/migrations/external_controller.rb
@@ -90,6 +90,10 @@ module Api
         def create_room
           room_hash = room_params.to_h
 
+
+          binding.break
+
+
           return render_data status: :created if Room.exists? friendly_id: room_hash[:friendly_id]
 
           user = User.find_by(email: room_hash[:owner_email], provider: 'greenlight')
@@ -107,9 +111,12 @@ module Api
           return render_error status: :bad_request unless room.save
 
           # Creates the RoomMeetingOptions associated with the Room
+          room_meeting_options = RoomMeetingOption.where(room:).includes(:meeting_option) # TODO - samuel: look at comment below
           # The room_settings hash contains only the MeetingOption with value that differs from V3 rooms default values
           room_hash[:room_settings].any? && room_hash[:room_settings].each do |name, value|
-            room_meeting_option = room.room_meeting_options.includes(:meeting_option).find_by(meeting_option: { name: })
+            # TODO - samuel: is room.room_meeting_options cached? is it equivalent to RoomMeetingOption.where(room:)
+            # room_meeting_option = room.room_meeting_options.includes(:meeting_option).find_by(meeting_option: { name: })
+            room_meeting_option = room_meeting_options.find_by('meeting_options.name': name)
             return render_error status: :bad_request unless room_meeting_option
 
             room_meeting_option.update!(value:)

--- a/app/controllers/api/v1/migrations/external_controller.rb
+++ b/app/controllers/api/v1/migrations/external_controller.rb
@@ -107,9 +107,9 @@ module Api
 
           # Finds all the RoomMeetingOptions that need to be updated
           room_meeting_options_temp = RoomMeetingOption.includes(:meeting_option)
-                                                .where(room_id: room.id, 'meeting_options.name': room_hash[:room_settings].keys)
-                                                .pluck(:id, :'meeting_options.name')
-                                                .to_h
+                                                       .where(room_id: room.id, 'meeting_options.name': room_hash[:room_settings].keys)
+                                                       .pluck(:id, :'meeting_options.name')
+                                                       .to_h
           # Re-structure the data so it is in the format: { <room_meeting_option_id>: { value: <room_meeting_option_new_value> } }
           room_meeting_options = room_meeting_options_temp.map { |k, v| [k, { value: room_hash[:room_settings][v.to_sym] }] }
           RoomMeetingOption.update!(room_meeting_options)
@@ -139,18 +139,18 @@ module Api
 
           # Finds all the SiteSettings that need to be updated
           site_settings_temp = SiteSetting.joins(:setting)
-                                                .where('settings.name': settings_hash[:site_settings].keys, provider: 'greenlight')
-                                                .pluck(:id, :'settings.name')
-                                                .to_h
+                                          .where('settings.name': settings_hash[:site_settings].keys, provider: 'greenlight')
+                                          .pluck(:id, :'settings.name')
+                                          .to_h
           # Re-structure the data so it is in the format: { <site_setting_id>: { value: <site_setting_new_value> } }
           site_settings = site_settings_temp.map { |k, v| [k, { value: settings_hash[:site_settings][v.to_sym] }] }
           SiteSetting.update!(site_settings)
 
           # Finds all the RoomsConfiguration that need to be updated
           room_configurations_temp = RoomConfiguration.joins(:meeting_option)
-                                                .where('meeting_options.name': settings_hash[:room_configurations].keys, provider: 'greenlight')
-                                                .pluck(:id, :'meeting_options.name')
-                                                .to_h
+                                                      .where('meeting_options.name': settings_hash[:room_configurations].keys, provider: 'greenlight')
+                                                      .pluck(:id, :'meeting_options.name')
+                                                      .to_h
           # Re-structure the data so it is in the format: { <rooms_configuration_id>: { value: <rooms_configuration_new_value> } }
           room_configurations = room_configurations_temp.map { |k, v| [k, { value: settings_hash[:room_configurations][v.to_sym] }] }
           RoomsConfiguration.update!(room_configurations)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
         post '/roles', to: 'external#create_role'
         post '/users', to: 'external#create_user'
         post '/rooms', to: 'external#create_room'
+        post '/site_settings', to: 'external#create_site_settings'
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,7 +95,7 @@ Rails.application.routes.draw do
         post '/roles', to: 'external#create_role'
         post '/users', to: 'external#create_user'
         post '/rooms', to: 'external#create_room'
-        post '/site_settings', to: 'external#create_site_settings'
+        post '/settings', to: 'external#create_settings'
       end
     end
   end

--- a/spec/controllers/migrations/external_controller_spec.rb
+++ b/spec/controllers/migrations/external_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
     context 'when decryption passes' do
       describe 'when decrypted params encapsulation is conform and data is valid' do
         it 'returns :created and creates a role' do
-          encrypted_params = encrypt_params({ role: { name: 'CrazyRole', role_permissions: { } } }, expires_in: 10.seconds)
+          encrypted_params = encrypt_params({ role: { name: 'CrazyRole', role_permissions: {} } }, expires_in: 10.seconds)
           expect { post :create_role, params: { v2: { encrypted_params: } } }.to change(Role, :count).from(0).to(1)
           role = Role.take
           expect(role.name).to eq('CrazyRole')
@@ -23,7 +23,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
 
       describe 'when decrypted params data are invalid' do
         it 'returns :bad_request without creating a role' do
-          encrypted_params = encrypt_params({ role: { name: '', role_permissions: { } } }, expires_in: 10.seconds)
+          encrypted_params = encrypt_params({ role: { name: '', role_permissions: {} } }, expires_in: 10.seconds)
           expect { post :create_role, params: { v2: { encrypted_params: } } }.not_to change(Role, :count)
           expect(response).to have_http_status(:bad_request)
         end
@@ -31,7 +31,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
 
       describe 'when decrypted params encapsulation is not conform' do
         it 'returns :bad_request without creating a role' do
-          encrypted_params = encrypt_params({ not_role: { name: 'CrazyRole', role_permissions: { } } }, expires_in: 10.seconds)
+          encrypted_params = encrypt_params({ not_role: { name: 'CrazyRole', role_permissions: {} } }, expires_in: 10.seconds)
           expect { post :create_role, params: { v2: { encrypted_params: } } }.not_to change(Role, :count)
           expect(response).to have_http_status(:bad_request)
         end
@@ -41,7 +41,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
         let(:role) { create(:role, provider: 'greenlight', name: 'OnlyOne') }
 
         it 'returns :created without creating a role' do
-          encrypted_params = encrypt_params({ role: { name: role.name, role_permissions: { } } }, expires_in: 10.seconds)
+          encrypted_params = encrypt_params({ role: { name: role.name, role_permissions: {} } }, expires_in: 10.seconds)
           expect { post :create_role, params: { v2: { encrypted_params: } } }.not_to change(Role, :count)
           expect(response).to have_http_status(:created)
         end
@@ -51,7 +51,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
     context 'when decryption failes' do
       describe 'because payload encapsulation is not conform' do
         it 'returns :bad_request without creating a role' do
-          encrypted_params = encrypt_params({ role: { name: 'CrazyRole', role_permissions: { } } }, expires_in: 10.seconds)
+          encrypted_params = encrypt_params({ role: { name: 'CrazyRole', role_permissions: {} } }, expires_in: 10.seconds)
           expect { post :create_role, params: { not_v2: { encrypted_params: } } }.not_to change(Role, :count)
           expect(response).to have_http_status(:bad_request)
         end
@@ -74,7 +74,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
 
       describe 'because the encrypted payload expired' do
         it 'returns :bad_request without creating a role' do
-          encrypted_params = encrypt_params({ role: { name: 'CrazyRole', role_permissions: { } } }, expires_in: 10.seconds)
+          encrypted_params = encrypt_params({ role: { name: 'CrazyRole', role_permissions: {} } }, expires_in: 10.seconds)
           travel_to 11.seconds.from_now
           expect { post :create_role, params: { v2: { encrypted_params: } } }.not_to change(Role, :count)
           expect(response).to have_http_status(:bad_request)
@@ -85,7 +85,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
         it 'returns :bad_request without creating a role' do
           key = Rails.application.secrets.secret_key_base[1..32]
 
-          encrypted_params = encrypt_params({ role: { name: 'CrazyRole', role_permissions: { } } }, key:, expires_in: 10.seconds)
+          encrypted_params = encrypt_params({ role: { name: 'CrazyRole', role_permissions: {} } }, key:, expires_in: 10.seconds)
           expect { post :create_role, params: { v2: { encrypted_params: } } }.not_to change(Role, :count)
           expect(response).to have_http_status(:bad_request)
         end

--- a/spec/controllers/migrations/external_controller_spec.rb
+++ b/spec/controllers/migrations/external_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
     context 'when decryption passes' do
       describe 'when decrypted params encapsulation is conform and data is valid' do
         it 'returns :created and creates a role' do
-          encrypted_params = encrypt_params({ role: { name: 'CrazyRole' } }, expires_in: 10.seconds)
+          encrypted_params = encrypt_params({ role: { name: 'CrazyRole', role_permissions: { } } }, expires_in: 10.seconds)
           expect { post :create_role, params: { v2: { encrypted_params: } } }.to change(Role, :count).from(0).to(1)
           role = Role.take
           expect(role.name).to eq('CrazyRole')
@@ -23,7 +23,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
 
       describe 'when decrypted params data are invalid' do
         it 'returns :bad_request without creating a role' do
-          encrypted_params = encrypt_params({ role: { name: '' } }, expires_in: 10.seconds)
+          encrypted_params = encrypt_params({ role: { name: '', role_permissions: { } } }, expires_in: 10.seconds)
           expect { post :create_role, params: { v2: { encrypted_params: } } }.not_to change(Role, :count)
           expect(response).to have_http_status(:bad_request)
         end
@@ -31,7 +31,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
 
       describe 'when decrypted params encapsulation is not conform' do
         it 'returns :bad_request without creating a role' do
-          encrypted_params = encrypt_params({ not_role: { name: 'CrazyRole' } }, expires_in: 10.seconds)
+          encrypted_params = encrypt_params({ not_role: { name: 'CrazyRole', role_permissions: { } } }, expires_in: 10.seconds)
           expect { post :create_role, params: { v2: { encrypted_params: } } }.not_to change(Role, :count)
           expect(response).to have_http_status(:bad_request)
         end
@@ -41,7 +41,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
         let(:role) { create(:role, provider: 'greenlight', name: 'OnlyOne') }
 
         it 'returns :created without creating a role' do
-          encrypted_params = encrypt_params({ role: { name: role.name } }, expires_in: 10.seconds)
+          encrypted_params = encrypt_params({ role: { name: role.name, role_permissions: { } } }, expires_in: 10.seconds)
           expect { post :create_role, params: { v2: { encrypted_params: } } }.not_to change(Role, :count)
           expect(response).to have_http_status(:created)
         end
@@ -51,7 +51,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
     context 'when decryption failes' do
       describe 'because payload encapsulation is not conform' do
         it 'returns :bad_request without creating a role' do
-          encrypted_params = encrypt_params({ role: { name: 'CrazyRole' } }, expires_in: 10.seconds)
+          encrypted_params = encrypt_params({ role: { name: 'CrazyRole', role_permissions: { } } }, expires_in: 10.seconds)
           expect { post :create_role, params: { not_v2: { encrypted_params: } } }.not_to change(Role, :count)
           expect(response).to have_http_status(:bad_request)
         end
@@ -74,7 +74,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
 
       describe 'because the encrypted payload expired' do
         it 'returns :bad_request without creating a role' do
-          encrypted_params = encrypt_params({ role: { name: 'CrazyRole' } }, expires_in: 10.seconds)
+          encrypted_params = encrypt_params({ role: { name: 'CrazyRole', role_permissions: { } } }, expires_in: 10.seconds)
           travel_to 11.seconds.from_now
           expect { post :create_role, params: { v2: { encrypted_params: } } }.not_to change(Role, :count)
           expect(response).to have_http_status(:bad_request)
@@ -85,7 +85,7 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
         it 'returns :bad_request without creating a role' do
           key = Rails.application.secrets.secret_key_base[1..32]
 
-          encrypted_params = encrypt_params({ role: { name: 'CrazyRole' } }, key:, expires_in: 10.seconds)
+          encrypted_params = encrypt_params({ role: { name: 'CrazyRole', role_permissions: { } } }, key:, expires_in: 10.seconds)
           expect { post :create_role, params: { v2: { encrypted_params: } } }.not_to change(Role, :count)
           expect(response).to have_http_status(:bad_request)
         end
@@ -366,7 +366,8 @@ RSpec.describe Api::V1::Migrations::ExternalController, type: :controller do
         meeting_id: 'kzukaw3xk7ql5kefbfpsruud61pztf00jzltgafs',
         last_session: Time.zone.now.to_datetime,
         owner_email: user.email,
-        owner_provider: user.provider
+        room_settings: {},
+        shared_users_emails: []
       }
     end
 


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Regarding https://github.com/bigbluebutton/greenlight/issues/4085

The existing migrations endpoints (Roles, Users, Rooms) have been upgraded to include the subsequent data (Role Permissions, Room Settings, Shared Access).

Also, the SiteSetting migration endpoint has been added and will migrate the SiteSettings and the RoomsConfiguration data.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
Duplicate GLv2 and GLv3 so that the apps are located in a different directory and open a terminal for both directory.

**For GLv1**
1. Launch GLv3 with the following commands
```
rails db:create
rails db:migrate:with_data
./bin/dev
```

**For GLv2**
1. Launch GLv2 with the following commands
```
rails db:create
rails db:migrate
rails db:seed
rails s -p 3001
```

3. Populate GLv2 database

- Access GLV2 via your browser [(localhost:3001](http://localhost:3001/) so that the default settings are loaded into the database.
- Log in via the default Admin account (admin@example.com // Administrator1!) 
- Create new Role(s), edit the role settings
- Create new User(s), assign the users different roles
- Create new Room(s), edit the room settings, share the room
- Edit the SiteSettings and the RoomsConfigurations

4. Migrate the data to GLv3

- Make sure that GLv3 server is up and running
- In the terminal, run the following tasks in that order

```
rake migrations:roles
rake migrations:users
rake migrations:rooms
rake migrations:settings
```

## TODO
Improve error-logging
