### PR TITLE
Add Empty Rooms List layout

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -92,6 +92,8 @@
     "last_session": "Last Session: {{ room.last_session }}",
     "no_last_session": "No previous session created",
     "no_rooms_found": "No rooms found",
+    "rooms_list_is_empty": "Your rooms list is empty!",
+    "rooms_list_empty_create_room": "Create your first room by clicking on the button below and entering a room name.",
     "meeting": {
       "start_meeting": "Start Meeting",
       "join_meeting": "Join Meeting",

--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -92,7 +92,7 @@
     "last_session": "Last Session: {{ room.last_session }}",
     "no_last_session": "No previous session created",
     "no_rooms_found": "No rooms found",
-    "rooms_list_is_empty": "Your rooms list is empty!",
+    "rooms_list_is_empty": "You don't have any room yet!",
     "rooms_list_empty_create_room": "Create your first room by clicking on the button below and entering a room name.",
     "meeting": {
       "start_meeting": "Start Meeting",

--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -92,7 +92,7 @@
     "last_session": "Last Session: {{ room.last_session }}",
     "no_last_session": "No previous session created",
     "no_rooms_found": "No rooms found",
-    "rooms_list_is_empty": "You don't have any room yet!",
+    "rooms_list_is_empty": "You don't have any rooms yet!",
     "rooms_list_empty_create_room": "Create your first room by clicking on the button below and entering a room name.",
     "meeting": {
       "start_meeting": "Start Meeting",

--- a/app/assets/stylesheets/rooms.scss
+++ b/app/assets/stylesheets/rooms.scss
@@ -108,3 +108,9 @@
     opacity: 0.6;
   }
 }
+
+#rooms-list-empty {
+  svg {
+    padding-top: 2rem;
+  }
+}

--- a/app/javascript/components/rooms/EmptyRoomsList.jsx
+++ b/app/javascript/components/rooms/EmptyRoomsList.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Button, Card } from 'react-bootstrap';
+import { useTranslation } from 'react-i18next';
+import Modal from '../shared_components/modals/Modal';
+import CreateRoomForm from './room/forms/CreateRoomForm';
+import useCreateRoom from '../../hooks/mutations/rooms/useCreateRoom';
+import { useAuth } from '../../contexts/auth/AuthProvider';
+import UserBoardIcon from './UserBoardIcon';
+
+export default function EmptyRoomsList() {
+  const { t } = useTranslation();
+  const currentUser = useAuth();
+  const mutationWrapper = (args) => useCreateRoom({ userId: currentUser.id, ...args });
+
+  return (
+    <div id="rooms-list-empty">
+      <Card className="border-0 shadow-sm mt-5 text-center">
+        <Card.Body className="py-5">
+          <div className="icon-circle rounded-circle d-block mx-auto mb-3">
+            <UserBoardIcon className="hi-l text-brand d-block mx-auto" />
+          </div>
+          <Card.Title className="text-brand"> { t('room.rooms_list_is_empty') }</Card.Title>
+          <Card.Text>
+            { t('room.rooms_list_empty_create_room') }
+          </Card.Text>
+          <Modal
+            modalButton={<Button variant="brand" className="ms-auto me-xxl-1">{ t('room.add_new_room') }</Button>}
+            title={t('room.create_new_room')}
+            body={<CreateRoomForm mutation={mutationWrapper} userId={currentUser.id} />}
+          />
+        </Card.Body>
+      </Card>
+    </div>
+  );
+
+}

--- a/app/javascript/components/rooms/EmptyRoomsList.jsx
+++ b/app/javascript/components/rooms/EmptyRoomsList.jsx
@@ -32,5 +32,4 @@ export default function EmptyRoomsList() {
       </Card>
     </div>
   );
-
 }

--- a/app/javascript/components/rooms/RoomCard.jsx
+++ b/app/javascript/components/rooms/RoomCard.jsx
@@ -28,7 +28,7 @@ export default function RoomCard({ room }) {
           <div className="room-icon rounded">
             { room?.shared_owner
               ? <LinkIcon className="hi-m text-brand pt-4 d-block mx-auto" />
-              : <UserBoardIcon />}
+              : <UserBoardIcon className="hi-m text-brand pt-4 d-block mx-auto" />}
           </div>
           { room?.online
             && <MeetingBadges count={room?.participants} />}

--- a/app/javascript/components/rooms/RoomsList.jsx
+++ b/app/javascript/components/rooms/RoomsList.jsx
@@ -11,6 +11,7 @@ import Modal from '../shared_components/modals/Modal';
 import CreateRoomForm from './room/forms/CreateRoomForm';
 import { useAuth } from '../../contexts/auth/AuthProvider';
 import SearchBar from '../shared_components/search/SearchBar';
+import EmptyRoomsList from './EmptyRoomsList';
 
 export default function RoomsList() {
   const { t } = useTranslation();
@@ -18,6 +19,8 @@ export default function RoomsList() {
   const { isLoading, data: rooms } = useRooms(searchInput);
   const currentUser = useAuth();
   const mutationWrapper = (args) => useCreateRoom({ userId: currentUser.id, ...args });
+
+  if (rooms?.length === 0) return <EmptyRoomsList />;
 
   return (
     <>

--- a/app/javascript/components/rooms/UserBoardIcon.jsx
+++ b/app/javascript/components/rooms/UserBoardIcon.jsx
@@ -1,7 +1,6 @@
-/* eslint-disable max-len */
 import React from 'react';
 
-export default function UserBoardIcon({...props}) {
+export default function UserBoardIcon({ ...props }) {
   return (
     <svg
       aria-hidden="true"
@@ -9,10 +8,12 @@ export default function UserBoardIcon({...props}) {
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 640 512"
       strokeWidth="1.5"
+      /* eslint-disable-next-line react/jsx-props-no-spreading */
       {...props}
     >
       <path
         fill="currentColor"
+        /* eslint-disable-next-line max-len */
         d="M160 320c53.02 0 96-42.98 96-96c0-53.02-42.98-96-96-96C106.1 128 64 170.1 64 224C64 277 106.1 320 160 320zM160 160c35.29 0 64 28.71 64 64S195.3 288 160 288S96 259.3 96 224S124.7 160 160 160zM192 352H128c-70.69 0-128 57.31-128 128c0 17.67 14.33 32 32 32h256c17.67 0 32-14.33 32-32C320 409.3 262.7 352 192 352zM32 480c0-52.94 43.07-96 96-96h64c52.94 0 96 43.06 96 96H32zM592 0h-384C181.5 0 160 21.53 160 48v32C160 88.84 167.2 96 176 96S192 88.84 192 80v-32C192 39.19 199.2 32 208 32h384C600.8 32 608 39.19 608 48v320c0 8.812-7.172 16-16 16H576v-48C576 309.5 554.5 288 528 288h-96C405.5 288 384 309.5 384 336V384h-32c-8.844 0-16 7.156-16 16S343.2 416 352 416h240C618.5 416 640 394.5 640 368v-320C640 21.53 618.5 0 592 0zM544 384h-128v-48c0-8.812 7.172-16 16-16h96c8.828 0 16 7.188 16 16V384z"
       />
     </svg>

--- a/app/javascript/components/rooms/UserBoardIcon.jsx
+++ b/app/javascript/components/rooms/UserBoardIcon.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import React from 'react';
 
-export default function UserBoardIcon() {
+export default function UserBoardIcon({...props}) {
   return (
     <svg
       aria-hidden="true"
@@ -9,7 +9,7 @@ export default function UserBoardIcon() {
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 640 512"
       strokeWidth="1.5"
-      className="hi-m text-brand pt-4 d-block mx-auto"
+      {...props}
     >
       <path
         fill="currentColor"


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add EmptyRoomsList layout so that user are prompted to create a Room after creating an account.
Showed our demo to a friend, and he was confused because the landing page was empty - this should help guide a new user.
Not sure about the text, please comment if you have a better text.

![image](https://user-images.githubusercontent.com/43917914/211434675-1e9bb992-198d-4f51-b744-1cde98ae4131.png)

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
