### PR TITLE
Remove Brand Color on Input hover and focus

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -120,6 +120,10 @@ input.search-bar {
   @include media-breakpoint-down(sm) {
     min-width: $button-min-width;
   }
+
+  &:focus {
+    box-shadow: none !important
+  }
 }
 
 .icon-circle {
@@ -348,9 +352,9 @@ input.search-bar {
   }
 }
 
-input[type='text']:focus {
-    border-color: var(--brand-color) !important;
-}
+//input[type='text']:focus {
+//    border-color: var(--brand-color) !important;
+//}
 
 input[type='checkbox'] {
   &:checked {
@@ -385,13 +389,8 @@ input[type='checkbox'] {
 }
 
 .form-control:focus {
-  box-shadow: none;
+  box-shadow: 0 0 0 0.05rem rgba(13, 110, 253, 0.25);
 }
-
-.form-control:focus, .form-control:hover {
-  border-color: var(--brand-color) !important;
-}
-
 
 //Semantic UI pagination
 .pagination-wrapper {

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -352,10 +352,6 @@ input.search-bar {
   }
 }
 
-//input[type='text']:focus {
-//    border-color: var(--brand-color) !important;
-//}
-
 input[type='checkbox'] {
   &:checked {
     background-color: var(--brand-color) !important;
@@ -367,7 +363,6 @@ input[type='checkbox'] {
     border-color: var(--brand-color) !important;
     box-shadow: 0 0 0 0.25rem var(--brand-color-light) !important;
   }
-
 }
 
 //Bootstrap overwrite


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed the hover and focus effect on the form inputs that would change the border color to brand color.
Re-added the default bootstrap box-shadow but changed the width so it's a bit smaller.

It was doing some free games with the SearchBar and the Select fields and it can be really ugly/weird depending in the brand color.
Having the default bootstrap blue box-shadow on input select is widely accepted and it was (my) bad idea to have it another way (the effect is actually a box-shadow, not a border-color).


## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/43917914/212206452-6929dacf-7024-40cb-a67d-3a7a7a48784f.png)

