### PR TITLE
Fix Recording Spec Flaky Test failure

### DIFF
--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
       get :recordings, params: { friendly_id: room1.friendly_id }
       recording_ids = JSON.parse(response.body)['data'].map { |recording| recording['id'] }
       expect(response).to have_http_status(:ok)
-      expect(recording_ids).to eq(recordings.pluck(:id))
+      expect(recording_ids).to match_array(recordings.pluck(:id))
     end
 
     it 'returns an empty array if the room has no recordings' do


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Spec would fail the Flaky Tests because it is using `to eq` instead of `to match_array` for an array comparison

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
