### PR TITLE
Fix Modal padding bug

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -17,7 +17,6 @@ body {
 
 body {
   background: whitesmoke;
-
 }
 
 #navbar {
@@ -100,7 +99,6 @@ body {
 
 // Smoothen bootstrap transition
 .fade {
-  padding-right: 0 !important;
   transition: opacity 0.3s ease !important;
 
   & .modal-dialog {

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -17,6 +17,7 @@ body {
 
 body {
   background: whitesmoke;
+
 }
 
 #navbar {
@@ -99,12 +100,17 @@ body {
 
 // Smoothen bootstrap transition
 .fade {
+  padding-right: 0 !important;
   transition: opacity 0.3s ease !important;
 
   & .modal-dialog {
     transition: opacity 0.3s ease !important;
     transform: none !important;
   }
+}
+
+.modal-open {
+  padding-right: 0 !important;
 }
 
 //TODO: samuel - need to confirm for Browsers compatibility (maybe Scope this a bit more?)


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix weird bug with Bootstrap modal
Go to Rooms and click on "+ New Room"
The modal will add a `padding-right: 10px` to the root `body` for some reason
The bug seems to be old & documented
https://stackoverflow.com/questions/52164002/bootstrap-modal-on-hiding-adds-padding-right-to-html-body
https://stackoverflow.com/questions/32862394/bootstrap-modals-keep-adding-padding-right-to-body-after-closed

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
