### PR TITLE
Added duplicate email error to Admin User Create

### DIFF
--- a/app/javascript/hooks/mutations/admin/manage_users/useAdminCreateUser.jsx
+++ b/app/javascript/hooks/mutations/admin/manage_users/useAdminCreateUser.jsx
@@ -14,8 +14,12 @@ export default function useAdminCreateUser({ onSettled }) {
         queryClient.invalidateQueries('getAdminUsers');
         toast.success(t('toast.success.user.user_created'));
       },
-      onError: () => {
-        toast.error(t('toast.error.problem_completing_action'));
+      onError: (err) => {
+        if (err.response.data.errors === 'EmailAlreadyExists'){
+          toast.error(t('toast.error.users.email_exists'));
+        } else {
+          toast.error(t('toast.error.problem_completing_action'));
+        }
       },
       onSettled,
     },

--- a/app/javascript/hooks/mutations/admin/manage_users/useAdminCreateUser.jsx
+++ b/app/javascript/hooks/mutations/admin/manage_users/useAdminCreateUser.jsx
@@ -15,7 +15,7 @@ export default function useAdminCreateUser({ onSettled }) {
         toast.success(t('toast.success.user.user_created'));
       },
       onError: (err) => {
-        if (err.response.data.errors === 'EmailAlreadyExists'){
+        if (err.response.data.errors === 'EmailAlreadyExists') {
           toast.error(t('toast.error.users.email_exists'));
         } else {
           toast.error(t('toast.error.problem_completing_action'));


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->
## Description
<!--- Describe your changes in detail -->
Added a toast error to account for duplicate emails when creating a user from the admin panel
## Testing Steps
<!--- Please describe in detail how to test your changes. -->
Added a toast error to account for duplicate emails when creating a user from the admin panel

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/113048174/213827381-49b7e49c-e27b-49f6-a02e-6c320d67d1d5.png)

will be using "blankemail@email.com" as a test
***
![image](https://user-images.githubusercontent.com/113048174/213827468-a0fefdd8-c8ef-404b-9f95-bec91b1f14b9.png)
***
![image](https://user-images.githubusercontent.com/113048174/213827541-89d40e5d-5bd5-4d3c-871d-4b8485c0ab5d.png)

Proper error displayed

