### PR TITLE
Adding ability to remove custom branding image

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -230,7 +230,8 @@
         "brand_image": "Brand Image",
         "click_to_upload": "Click to Upload",
         "drag_and_drop": " or drag and drop",
-        "upload_brand_image_description": "Upload any PNG, JPG, or SVG file. Depending on the size of the file, it may require additional time to upload before it can be used"
+        "upload_brand_image_description": "Upload any PNG, JPG, or SVG file. Depending on the size of the file, it may require additional time to upload before it can be used",
+        "remove_branding_image": "Remove Custom Branding Image"
       },
       "administration": {
         "administration": "Administration",

--- a/app/controllers/api/v1/admin/site_settings_controller.rb
+++ b/app/controllers/api/v1/admin/site_settings_controller.rb
@@ -29,17 +29,17 @@ module Api
                                     )
           return render_error status: :not_found unless site_setting
 
-          # Case where user is removing the custom branding image
-          if params[:site_setting][:value].nil?
-            site_setting.image.purge
-            update = true
-          else
-            update = if params[:name] == 'BrandingImage'
-                       site_setting.image.attach params[:site_setting][:value]
+          update = if params[:name] == 'BrandingImage'
+                     # Case where user is removing the custom branding image
+                     if params[:site_setting][:value].nil?
+                       site_setting.image.purge
+                       return true
                      else
-                       site_setting.update(value: params[:site_setting][:value].to_s)
+                       site_setting.image.attach params[:site_setting][:value]
                      end
-          end
+                   else
+                     site_setting.update(value: params[:site_setting][:value].to_s)
+                   end
 
           return render_error status: :bad_request unless update
 

--- a/app/controllers/api/v1/admin/site_settings_controller.rb
+++ b/app/controllers/api/v1/admin/site_settings_controller.rb
@@ -30,18 +30,25 @@ module Api
           return render_error status: :not_found unless site_setting
 
           update = if params[:name] == 'BrandingImage'
-                     # Case where user is removing the custom branding image
-                     if params[:site_setting][:value].nil?
-                       site_setting.image.purge
-                       return true
-                     else
-                       site_setting.image.attach params[:site_setting][:value]
-                     end
+                     site_setting.image.attach params[:site_setting][:value]
                    else
                      site_setting.update(value: params[:site_setting][:value].to_s)
                    end
 
           return render_error status: :bad_request unless update
+
+          render_data status: :ok
+        end
+
+        # DELETE /api/v1/admin/site_settings/purge_branding_image.json
+        # Removes the custom branding image back to bbb default
+        def purge_branding_image
+          site_setting = SiteSetting.joins(:setting)
+                                    .find_by(
+                                      provider: current_provider,
+                                      setting: { name: 'BrandingImage' }
+                                    )
+          site_setting.image.purge
 
           render_data status: :ok
         end

--- a/app/controllers/api/v1/admin/site_settings_controller.rb
+++ b/app/controllers/api/v1/admin/site_settings_controller.rb
@@ -29,11 +29,17 @@ module Api
                                     )
           return render_error status: :not_found unless site_setting
 
-          update = if params[:name] == 'BrandingImage'
-                     site_setting.image.attach params[:site_setting][:value]
-                   else
-                     site_setting.update(value: params[:site_setting][:value].to_s)
-                   end
+          # Case where user is removing the custom branding image
+          if params[:site_setting][:value].nil?
+            site_setting.image.purge
+            update = true
+          else
+            update = if params[:name] == 'BrandingImage'
+                       site_setting.image.attach params[:site_setting][:value]
+                     else
+                       site_setting.update(value: params[:site_setting][:value].to_s)
+                     end
+          end
 
           return render_error status: :bad_request unless update
 

--- a/app/javascript/components/admin/site_settings/appearance/BrandingImage.jsx
+++ b/app/javascript/components/admin/site_settings/appearance/BrandingImage.jsx
@@ -4,10 +4,12 @@ import { CloudArrowUpIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 import useUpdateSiteSetting from '../../../../hooks/mutations/admin/site_settings/useUpdateSiteSetting';
 import FilesDragAndDrop from '../../../shared_components/utilities/FilesDragAndDrop';
+import useDeleteBrandingImage from '../../../../hooks/mutations/admin/site_settings/useDeleteBrandingImage';
 
 export default function BrandingImage() {
   const { t } = useTranslation();
   const updateSiteSetting = useUpdateSiteSetting('BrandingImage');
+  const updateBrandingImage = useDeleteBrandingImage();
 
   return (
     <div className="mb-3">
@@ -46,7 +48,7 @@ export default function BrandingImage() {
       <Button
         variant="neutral"
         className="btn-sm my-4"
-        onClick={() => updateSiteSetting.mutate('bbb_logo')}
+        onClick={() => updateBrandingImage.mutate()}
       > { t('admin.site_settings.appearance.remove_branding_image') }
       </Button>
     </div>

--- a/app/javascript/components/admin/site_settings/appearance/BrandingImage.jsx
+++ b/app/javascript/components/admin/site_settings/appearance/BrandingImage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card } from 'react-bootstrap';
+import { Card, Button } from 'react-bootstrap';
 import { CloudArrowUpIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 import useUpdateSiteSetting from '../../../../hooks/mutations/admin/site_settings/useUpdateSiteSetting';
@@ -43,6 +43,12 @@ export default function BrandingImage() {
           </label>
         </Card>
       </FilesDragAndDrop>
+      <Button
+        variant="neutral"
+        className="btn-sm my-4"
+        onClick={() => updateSiteSetting.mutate('bbb_logo')}
+      > { t('admin.site_settings.appearance.remove_branding_image') }
+      </Button>
     </div>
   );
 }

--- a/app/javascript/hooks/mutations/admin/site_settings/useDeleteBrandingImage.jsx
+++ b/app/javascript/hooks/mutations/admin/site_settings/useDeleteBrandingImage.jsx
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from 'react-query';
+import { toast } from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import axios from '../../../../helpers/Axios';
+
+export default function useDeleteBrandingImage() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    () => axios.delete('/admin/site_settings.json'),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['getSiteSettings', 'BrandingImage']);
+        queryClient.invalidateQueries('getSiteSettings');
+        toast.success(t('toast.success.site_settings.site_setting_updated'));
+      },
+      onError: () => {
+        toast.error(t('toast.error.problem_completing_action'));
+      },
+    },
+  );
+}

--- a/app/javascript/hooks/mutations/admin/site_settings/useUpdateSiteSetting.jsx
+++ b/app/javascript/hooks/mutations/admin/site_settings/useUpdateSiteSetting.jsx
@@ -22,7 +22,7 @@ export default function useUpdateSiteSetting(name) {
   const uploadPresentation = (data) => {
     let settings;
 
-    if (name === 'BrandingImage') {
+    if (name === 'BrandingImage' && data !== 'bbb_logo') {
       imageValidation(data);
       settings = new FormData();
       settings.append('site_setting[value]', data);

--- a/app/javascript/hooks/mutations/admin/site_settings/useUpdateSiteSetting.jsx
+++ b/app/javascript/hooks/mutations/admin/site_settings/useUpdateSiteSetting.jsx
@@ -22,7 +22,7 @@ export default function useUpdateSiteSetting(name) {
   const uploadPresentation = (data) => {
     let settings;
 
-    if (name === 'BrandingImage' && data !== 'bbb_logo') {
+    if (name === 'BrandingImage') {
       imageValidation(data);
       settings = new FormData();
       settings.append('site_setting[value]', data);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,7 +77,11 @@ Rails.application.routes.draw do
         resources :server_rooms, only: %i[index destroy], param: :friendly_id do
           get '/resync', to: 'server_rooms#resync', on: :member
         end
-        resources :site_settings, only: %i[index update], param: :name
+        resources :site_settings, only: %i[index update], param: :name do
+          collection do
+            delete '/', to: 'site_settings#purge_branding_image'
+          end
+        end
         resources :rooms_configurations, only: :update, param: :name
         resources :roles
         resources :invitations, only: %i[index create]

--- a/spec/controllers/admin/site_settings_controller_spec.rb
+++ b/spec/controllers/admin/site_settings_controller_spec.rb
@@ -58,4 +58,17 @@ RSpec.describe Api::V1::Admin::SiteSettingsController, type: :controller do
       end
     end
   end
+
+  describe '#purge_branding_image' do
+    it 'deletes the BrandingImage' do
+      setting = create(:setting, name: 'BrandingImage')
+      site_setting = create(:site_setting, setting:)
+
+      site_setting.image.attach(io: fixture_file_upload('default-avatar.png'), filename: 'default-avatar.png', content_type: 'image/png')
+
+      expect(site_setting.reload.image).to be_attached
+      delete :purge_branding_image
+      expect(site_setting.reload.image).not_to be_attached
+    end
+  end
 end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added ability to remove the custom branding image and make it return to the bbb_logo.png default
- Solves #4376 
## Testing Steps
<!--- Please describe in detail how to test your changes. -->
- Add custom image
- Click on remove custom branding image button
- Make sure it goes back to default
## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/38328371/213885417-3ac063eb-3fb9-4838-80c7-56ae148bfdb4.png)

