### PR TITLE
Fix bbb logo spacing on 'Cant create room' home page

### DIFF
--- a/app/javascript/components/shared_components/Logo.jsx
+++ b/app/javascript/components/shared_components/Logo.jsx
@@ -10,8 +10,8 @@ export default function Logo({ size }) {
 
   // Logo can be small or regular size
   const sizeClass = size === 'small'
-    ? 'small-logo cursor-pointer'
-    : 'logo cursor-pointer position-absolute bottom-0 mx-auto start-0 end-0 text-center';
+    ? 'mb-4 small-logo cursor-pointer'
+    : 'mb-4 logo cursor-pointer position-absolute bottom-0 mx-auto start-0 end-0 text-center';
   // Small Logo is used in Header only and does not require a wrapper
   const sizeWrapperClass = !size ? 'logo-wrapper position-relative d-block mx-auto' : undefined;
 


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fixing the spacing on the can't create rooms home page
- Just added margin on bottom
## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
Before:
![image](https://user-images.githubusercontent.com/38328371/215359418-47c6599b-586d-4f6d-b171-6df93208252d.png)

After (with spacing under logo):
![image](https://user-images.githubusercontent.com/38328371/215359373-160a5ae0-dfd4-4961-8d9a-cf4b1eed8440.png)
