### PR TITLE
Fix Moderator Access Code

### DIFF
--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -57,7 +57,7 @@ module Api
           provider: current_provider,
           current_user:,
           show_codes: false,
-          settings: %w[glRequireAuthentication glViewerAccessCode glModeratorAccessCode record]
+          settings: %w[glRequireAuthentication glViewerAccessCode glModeratorAccessCode record glAnyoneJoinAsModerator]
         ).call
 
         render_data data: @room, serializer: PublicRoomSerializer, options: { settings: }, status: :ok

--- a/app/javascript/components/rooms/room/join/RoomJoin.jsx
+++ b/app/javascript/components/rooms/room/join/RoomJoin.jsx
@@ -124,10 +124,13 @@ export default function RoomJoin() {
 
   const hasAccessCode = publicRoom.data?.viewer_access_code || publicRoom.data?.moderator_access_code;
 
-  if (!publicRoom.data?.viewer_access_code && publicRoom.data?.moderator_access_code) {
-    fields.accessCode.label = t('room.settings.mod_access_code_optional');
-  } else {
+  if (publicRoom.data?.viewer_access_code || !publicRoom.data?.moderator_access_code) {
     fields.accessCode.label = t('room.settings.access_code');
+  // for the case where anyone_join_as_moderator is true and only the moderator access code is required
+  } else if (publicRoom.data?.anyone_join_as_moderator === 'true') {
+    fields.accessCode.label = t('room.settings.mod_access_code');
+  } else {
+    fields.accessCode.label = t('room.settings.mod_access_code_optional');
   }
 
   const WaitingPage = (

--- a/app/serializers/public_room_serializer.rb
+++ b/app/serializers/public_room_serializer.rb
@@ -4,7 +4,7 @@ class PublicRoomSerializer < ApplicationSerializer
   include Avatarable
 
   attributes :name, :recording_consent, :require_authentication, :viewer_access_code, :moderator_access_code,
-             :friendly_id, :owner_name, :owner_id, :owner_avatar, :shared_user_ids
+             :anyone_join_as_moderator, :friendly_id, :owner_name, :owner_id, :owner_avatar, :shared_user_ids
 
   def recording_consent
     @instance_options[:options][:settings]['record']
@@ -20,6 +20,10 @@ class PublicRoomSerializer < ApplicationSerializer
 
   def moderator_access_code
     @instance_options[:options][:settings]['glModeratorAccessCode']
+  end
+
+  def anyone_join_as_moderator
+    @instance_options[:options][:settings]['glAnyoneJoinAsModerator']
   end
 
   def owner_name

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
 
       allow(RoomSettingsGetter).to receive(:new).and_return(fake_room_settings_getter)
       allow(fake_room_settings_getter).to receive(:call).and_return(
-        { 'glRequireAuthentication' => true, 'glViewerAccessCode' => true, 'glModeratorAccessCode' => false }
+        { 'glRequireAuthentication' => true, 'glViewerAccessCode' => true, 'glModeratorAccessCode' => false, 'glAnyoneJoinAsModerator' => true }
       )
     end
 
@@ -104,7 +104,11 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
       room = create(:room, user:)
 
       expect(RoomSettingsGetter).to receive(:new).with(room_id: room.id, provider: 'greenlight', current_user: nil, show_codes: false,
-                                                       settings: %w[glRequireAuthentication glViewerAccessCode glModeratorAccessCode record])
+                                                       settings: %w[glRequireAuthentication
+                                                                    glViewerAccessCode
+                                                                    glModeratorAccessCode
+                                                                    record
+                                                                    glAnyoneJoinAsModerator])
       expect(fake_room_settings_getter).to receive(:call)
 
       get :public_show, params: { friendly_id: room.friendly_id }
@@ -113,6 +117,7 @@ RSpec.describe Api::V1::RoomsController, type: :controller do
       expect(JSON.parse(response.body)['data']['require_authentication']).to be(true)
       expect(JSON.parse(response.body)['data']['viewer_access_code']).to be(true)
       expect(JSON.parse(response.body)['data']['moderator_access_code']).to be(false)
+      expect(JSON.parse(response.body)['data']['anyone_join_as_moderator']).to be(true)
       expect(JSON.parse(response.body)['data']['owner_name']).to eq(user.name)
       expect(JSON.parse(response.body)['data']['owner_avatar']).to be_present
     end


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Solution for the case when:
1. AnyoneJoinAsModerator is enabled
2. The meeting requires a Moderator Access Code - but does not require a Viewer Access Code.

There could be confusion as the Moderator Access Code is labelled as (Optional).

Solution is to add AnyoneJoinAsModerator as a Room public information and remove the (Optional) from the string in that case.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
