### PR TITLE
Creating empty list for server users+rooms

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -109,7 +109,6 @@
     "shared_by": "shared by ",
     "last_session": "Last Session: {{ room.last_session }}",
     "no_last_session": "No previous session created",
-    "no_rooms_found": "No Rooms found",
     "search_not_found": "No Rooms found",
     "rooms_list_is_empty": "You don't have any rooms yet!",
     "rooms_list_empty_create_room": "Create your first room by clicking on the button below and entering a room name.",
@@ -204,6 +203,14 @@
       "user_created_at": "Created: {{user.created_at}}",
       "are_you_sure_delete_account": "Are you sure you want to delete {{user.name}}'s account?",
       "delete_account_warning": "If you choose to delete this account, it will NOT be recoverable.",
+      "empty_active_users": "There are no active users on this server yet!",
+      "empty_active_users_subtext": "When a user's status gets changed to active, they will appear here.",
+      "empty_pending_users": "There are no pending users on this server yet!",
+      "empty_pending_users_subtext": "When a user's status gets changed to pending, they will appear here.",
+      "empty_banned_users": "There are no banned users on this server yet!",
+      "empty_banned_users_subtext": "When a user's status gets changed to banned, they will appear here.",
+      "empty_invited_users": "There are no invited users on this server yet!",
+      "empty_invited_users_subtext": "When a user's status gets changed to invited, they will appear here.",
       "invited": {
         "time_sent": "Time Sent",
         "valid": "Valid"
@@ -223,7 +230,9 @@
       "last_session": "Last Session: {{lastSession}}",
       "no_meeting_yet": "No meeting yet.",
       "delete_server_rooms": "Delete Server Room",
-      "resync_recordings": "Re-Sync Recordings"
+      "resync_recordings": "Re-Sync Recordings",
+      "empty_room_list": "There are no server rooms yet!",
+      "empty_room_list_subtext": "Rooms will appear here after creating your first room."
     },
     "server_recordings": {
       "server_recordings": "Server Recordings",

--- a/app/assets/stylesheets/admin_panel.scss
+++ b/app/assets/stylesheets/admin_panel.scss
@@ -200,3 +200,9 @@
     box-shadow: none !important;
   }
 }
+
+#list-empty {
+  svg {
+    padding-top: 2rem;
+  }
+}

--- a/app/javascript/components/admin/manage_users/BannedPendingUsersTable.jsx
+++ b/app/javascript/components/admin/manage_users/BannedPendingUsersTable.jsx
@@ -3,10 +3,18 @@ import { Table } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import BannedPendingRow from './BannedPendingRow';
+import EmptyUsersList from './EmptyUsersList';
 
 // pendingTable prop is true when table is being used for pending data, false when table is being used for banned data
 export default function BannedPendingUsersTable({ users, pendingTable }) {
   const { t } = useTranslation();
+
+  if (users.length === 0) {
+    if (pendingTable) {
+      return <EmptyUsersList text="pending" />;
+    }
+    return <EmptyUsersList text="banned" />;
+  }
 
   return (
     <div id="admin-table">
@@ -20,17 +28,10 @@ export default function BannedPendingUsersTable({ users, pendingTable }) {
         </thead>
         <tbody className="border-top-0">
           {users?.length
-            ? (
+            && (
               users?.map((user) => (
                 <BannedPendingRow key={user.id} user={user} pendingTable={pendingTable} />
               ))
-            )
-            : (
-              <tr>
-                <td className="fw-bold" colSpan="6">
-                  { t('user.no_user_found') }
-                </td>
-              </tr>
             )}
         </tbody>
       </Table>

--- a/app/javascript/components/admin/manage_users/BannedPendingUsersTable.jsx
+++ b/app/javascript/components/admin/manage_users/BannedPendingUsersTable.jsx
@@ -11,9 +11,9 @@ export default function BannedPendingUsersTable({ users, pendingTable }) {
 
   if (users.length === 0) {
     if (pendingTable) {
-      return <EmptyUsersList text="pending" />;
+      return <EmptyUsersList text={t('admin.manage_users.empty_pending_users')} subtext={t('admin.manage_users.empty_pending_users_subtext')} />;
     }
-    return <EmptyUsersList text="banned" />;
+    return <EmptyUsersList text={t('admin.manage_users.empty_banned_users')} subtext={t('admin.manage_users.empty_banned_users_subtext')} />;
   }
 
   return (

--- a/app/javascript/components/admin/manage_users/EmptyUsersList.jsx
+++ b/app/javascript/components/admin/manage_users/EmptyUsersList.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Card } from 'react-bootstrap';
+// import { useTranslation } from 'react-i18next';
+import { UsersIcon } from '@heroicons/react/24/outline';
+import PropTypes from 'prop-types';
+
+export default function EmptyUsersList({ text }) {
+  // const { t } = useTranslation();
+
+  return (
+    <div id="list-empty">
+      <Card className="border-0 text-center">
+        <Card.Body className="py-5">
+          <div className="icon-circle rounded-circle d-block mx-auto mb-3">
+            <UsersIcon className="hi-l text-brand d-block mx-auto" />
+          </div>
+          <Card.Title className="text-brand"> {`There are no ${text} users on this server yet!`}</Card.Title>
+          <Card.Text>
+            {`When a user's status gets changed to ${text}, they will appear here.`}
+          </Card.Text>
+        </Card.Body>
+      </Card>
+    </div>
+  );
+}
+
+EmptyUsersList.propTypes = {
+  text: PropTypes.string.isRequired,
+};

--- a/app/javascript/components/admin/manage_users/EmptyUsersList.jsx
+++ b/app/javascript/components/admin/manage_users/EmptyUsersList.jsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import { Card } from 'react-bootstrap';
-// import { useTranslation } from 'react-i18next';
 import { UsersIcon } from '@heroicons/react/24/outline';
 import PropTypes from 'prop-types';
 
-export default function EmptyUsersList({ text }) {
-  // const { t } = useTranslation();
-
+export default function EmptyUsersList({ text, subtext }) {
   return (
     <div id="list-empty">
       <Card className="border-0 text-center">
@@ -14,9 +11,9 @@ export default function EmptyUsersList({ text }) {
           <div className="icon-circle rounded-circle d-block mx-auto mb-3">
             <UsersIcon className="hi-l text-brand d-block mx-auto" />
           </div>
-          <Card.Title className="text-brand"> {`There are no ${text} users on this server yet!`}</Card.Title>
+          <Card.Title className="text-brand"> {text}</Card.Title>
           <Card.Text>
-            {`When a user's status gets changed to ${text}, they will appear here.`}
+            {subtext}
           </Card.Text>
         </Card.Body>
       </Card>
@@ -26,4 +23,5 @@ export default function EmptyUsersList({ text }) {
 
 EmptyUsersList.propTypes = {
   text: PropTypes.string.isRequired,
+  subtext: PropTypes.string.isRequired,
 };

--- a/app/javascript/components/admin/manage_users/InvitedUsers.jsx
+++ b/app/javascript/components/admin/manage_users/InvitedUsers.jsx
@@ -7,11 +7,16 @@ import SortBy from '../../shared_components/search/SortBy';
 import useInvitations from '../../../hooks/queries/admin/manage_users/useInvitations';
 import Pagination from '../../shared_components/Pagination';
 import NoSearchResults from '../../shared_components/search/NoSearchResults';
+import EmptyUsersList from './EmptyUsersList';
 
 export default function InvitedUsers({ searchInput }) {
   const { t } = useTranslation();
   const [page, setPage] = useState();
   const { data: invitations } = useInvitations(searchInput, page);
+
+  if (!searchInput && invitations.length === 0) {
+    return <EmptyUsersList text="invited" />;
+  }
 
   return (
     <div>
@@ -33,7 +38,7 @@ export default function InvitedUsers({ searchInput }) {
               </thead>
               <tbody className="border-top-0">
                 {invitations?.data?.length
-                  ? (
+                  && (
                     invitations?.data?.map((invitation) => (
                       <tr key={invitation.email} className="align-middle text-muted">
                         <td className="text-dark border-0">{invitation.email}</td>
@@ -43,13 +48,6 @@ export default function InvitedUsers({ searchInput }) {
                         </td>
                       </tr>
                     ))
-                  )
-                  : (
-                    <tr>
-                      <td className="fw-bold">
-                        { t('user.no_user_found') }
-                      </td>
-                    </tr>
                   )}
               </tbody>
             </Table>

--- a/app/javascript/components/admin/manage_users/InvitedUsers.jsx
+++ b/app/javascript/components/admin/manage_users/InvitedUsers.jsx
@@ -15,7 +15,7 @@ export default function InvitedUsers({ searchInput }) {
   const { data: invitations } = useInvitations(searchInput, page);
 
   if (!searchInput && invitations?.data?.length === 0) {
-    return <EmptyUsersList text="invited" />;
+    return <EmptyUsersList text={t('admin.manage_users.empty_invited_users')} subtext={t('admin.manage_users.empty_invited_users_subtext')} />;
   }
 
   return (

--- a/app/javascript/components/admin/manage_users/InvitedUsers.jsx
+++ b/app/javascript/components/admin/manage_users/InvitedUsers.jsx
@@ -14,7 +14,7 @@ export default function InvitedUsers({ searchInput }) {
   const [page, setPage] = useState();
   const { data: invitations } = useInvitations(searchInput, page);
 
-  if (!searchInput && invitations.length === 0) {
+  if (!searchInput && invitations?.data?.length === 0) {
     return <EmptyUsersList text="invited" />;
   }
 

--- a/app/javascript/components/admin/manage_users/ManageUsersTable.jsx
+++ b/app/javascript/components/admin/manage_users/ManageUsersTable.jsx
@@ -6,8 +6,14 @@ import ManageUserRow from './ManageUserRow';
 import SortBy from '../../shared_components/search/SortBy';
 import ManageUsersRowPlaceHolder from './ManageUsersRowPlaceHolder';
 
+import EmptyUsersList from './EmptyUsersList';
+
 export default function ManageUsersTable({ users, isLoading }) {
   const { t } = useTranslation();
+
+  if (users.length === 0) {
+    return <EmptyUsersList text="active" />;
+  }
 
   return (
     <Table id="manage-users-table" className="table-bordered border border-2 mb-0" hover responsive>

--- a/app/javascript/components/admin/manage_users/ManageUsersTable.jsx
+++ b/app/javascript/components/admin/manage_users/ManageUsersTable.jsx
@@ -12,7 +12,7 @@ export default function ManageUsersTable({ users, isLoading }) {
   const { t } = useTranslation();
 
   if (users.length === 0) {
-    return <EmptyUsersList text="active" />;
+    return <EmptyUsersList text={t('admin.manage_users.empty_active_users')} subtext={t('admin.manage_users.empty_active_users_subtext')} />;
   }
 
   return (
@@ -34,15 +34,8 @@ export default function ManageUsersTable({ users, isLoading }) {
             )
             : (
               users?.length
-                ? (
+                && (
                   users?.map((user) => <ManageUserRow key={user.id} user={user} />)
-                )
-                : (
-                  <tr>
-                    <td className="fw-bold" colSpan="6">
-                      {t('user.no_user_found')}
-                    </td>
-                  </tr>
                 )
             )
         }

--- a/app/javascript/components/admin/manage_users/ManageUsersTable.jsx
+++ b/app/javascript/components/admin/manage_users/ManageUsersTable.jsx
@@ -11,7 +11,7 @@ import EmptyUsersList from './EmptyUsersList';
 export default function ManageUsersTable({ users, isLoading }) {
   const { t } = useTranslation();
 
-  if (users.length === 0) {
+  if (!isLoading && users.length === 0) {
     return <EmptyUsersList text={t('admin.manage_users.empty_active_users')} subtext={t('admin.manage_users.empty_active_users_subtext')} />;
   }
 

--- a/app/javascript/components/admin/server_rooms/ServerRooms.jsx
+++ b/app/javascript/components/admin/server_rooms/ServerRooms.jsx
@@ -14,6 +14,7 @@ import SortBy from '../../shared_components/search/SortBy';
 import { useAuth } from '../../../contexts/auth/AuthProvider';
 import ServerRoomsRowPlaceHolder from './ServerRoomsRowPlaceHolder';
 import NoSearchResults from '../../shared_components/search/NoSearchResults';
+import EmptyServerRoomsList from '../../rooms/EmptyServerRoomsList';
 
 export default function ServerRooms() {
   const { t } = useTranslation();
@@ -46,65 +47,61 @@ export default function ServerRooms() {
                   <div className="px-4 pt-4">
                     <SearchBar searchInput={searchInput} setSearchInput={setSearchInput} />
                   </div>
-
                   {
-                      (searchInput && serverRooms?.data.length === 0)
+                      (!searchInput && serverRooms?.data.length === 0)
                         ? (
-                          <div className="mt-5">
-                            <NoSearchResults text={t('room.search_not_found')} searchInput={searchInput} />
-                          </div>
+                          <EmptyServerRoomsList />
                         ) : (
-                          <div className="p-4">
 
-                            <Table id="server-rooms-table" className="table-bordered border border-2 mt-4 mb-0" hover responsive>
-                              <thead>
-                                <tr className="text-muted small">
-                                  <th className="fw-normal border-end-0">{ t('admin.server_rooms.name') }<SortBy fieldName="name" /></th>
-                                  <th className="fw-normal border-0">{ t('admin.server_rooms.owner') }<SortBy fieldName="users.name" /></th>
-                                  <th className="fw-normal border-0">{ t('admin.server_rooms.room_id') }</th>
-                                  <th className="fw-normal border-0">{ t('admin.server_rooms.participants') }</th>
-                                  <th className="fw-normal border-0">{ t('admin.server_rooms.status') }</th>
-                                  <th className="border-start-0" aria-label="options" />
-                                </tr>
-                              </thead>
-
-                              <tbody className="border-top-0">
-
-                                {
-                          isLoading
+                          (searchInput && serverRooms?.data.length === 0)
                             ? (
-                              // eslint-disable-next-line react/no-array-index-key
-                              [...Array(10)].map((val, idx) => <ServerRoomsRowPlaceHolder key={idx} />)
-                            )
-                            : (
-                              serverRooms?.data.length
-                                ? (
-                                  serverRooms?.data.map((room) => <ServerRoomRow key={room.friendly_id} room={room} />)
-                                )
-                                : (
-                                  <tr>
-                                    <td className="fw-bold" colSpan="6">
-                                      { t('room.no_rooms_found') }
-                                    </td>
-                                  </tr>
-                                )
-                            )
-                        }
+                              <div className="mt-5">
+                                <NoSearchResults text={t('room.search_not_found')} searchInput={searchInput} />
+                              </div>
+                            ) : (
+                              <div className="p-4">
 
-                              </tbody>
-                            </Table>
-                            {!isLoading
-                      && (
-                        <Pagination
-                          page={serverRooms.meta.page}
-                          totalPages={serverRooms.meta.pages}
-                          setPage={setPage}
-                        />
-                      )}
+                                <Table id="server-rooms-table" className="table-bordered border border-2 mt-4 mb-0" hover responsive>
+                                  <thead>
+                                    <tr className="text-muted small">
+                                      <th className="fw-normal border-end-0">{ t('admin.server_rooms.name') }<SortBy fieldName="name" /></th>
+                                      <th className="fw-normal border-0">{ t('admin.server_rooms.owner') }<SortBy fieldName="users.name" /></th>
+                                      <th className="fw-normal border-0">{ t('admin.server_rooms.room_id') }</th>
+                                      <th className="fw-normal border-0">{ t('admin.server_rooms.participants') }</th>
+                                      <th className="fw-normal border-0">{ t('admin.server_rooms.status') }</th>
+                                      <th className="border-start-0" aria-label="options" />
+                                    </tr>
+                                  </thead>
 
-                          </div>
+                                  <tbody className="border-top-0">
+
+                                    {
+                                    isLoading
+                                      ? (
+                                        // eslint-disable-next-line react/no-array-index-key
+                                        [...Array(10)].map((val, idx) => <ServerRoomsRowPlaceHolder key={idx} />)
+                                      )
+                                      : (
+                                        serverRooms?.data.length
+                                          && (
+                                            serverRooms?.data.map((room) => <ServerRoomRow key={room.friendly_id} room={room} />)
+                                          )
+                                      )
+                                  }
+                                  </tbody>
+                                </Table>
+                                {!isLoading
+                                && (
+                                <Pagination
+                                  page={serverRooms.meta.page}
+                                  totalPages={serverRooms.meta.pages}
+                                  setPage={setPage}
+                                />
+                                )}
+                              </div>
+                            )
                         )
-}
+                    }
                 </Container>
               </Tab.Content>
             </Col>

--- a/app/javascript/components/rooms/EmptyServerRoomsList.jsx
+++ b/app/javascript/components/rooms/EmptyServerRoomsList.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Card } from 'react-bootstrap';
+// import { useTranslation } from 'react-i18next';
+
+import UserBoardIcon from './UserBoardIcon';
+
+export default function EmptyServerRoomsList() {
+  // const { t } = useTranslation();
+
+  return (
+    <div id="list-empty">
+      <Card className="border-0 text-center">
+        <Card.Body className="py-5">
+          <div className="icon-circle rounded-circle d-block mx-auto mb-3">
+            <UserBoardIcon className="hi-l text-brand d-block mx-auto" />
+          </div>
+          <Card.Title className="text-brand"> There are no server rooms yet!</Card.Title>
+          <Card.Text>
+            Rooms will appear here after creating your first room.
+          </Card.Text>
+        </Card.Body>
+      </Card>
+    </div>
+  );
+}

--- a/app/javascript/components/rooms/EmptyServerRoomsList.jsx
+++ b/app/javascript/components/rooms/EmptyServerRoomsList.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Card } from 'react-bootstrap';
-// import { useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import UserBoardIcon from './UserBoardIcon';
 
 export default function EmptyServerRoomsList() {
-  // const { t } = useTranslation();
+  const { t } = useTranslation();
 
   return (
     <div id="list-empty">
@@ -14,9 +14,9 @@ export default function EmptyServerRoomsList() {
           <div className="icon-circle rounded-circle d-block mx-auto mb-3">
             <UserBoardIcon className="hi-l text-brand d-block mx-auto" />
           </div>
-          <Card.Title className="text-brand"> There are no server rooms yet!</Card.Title>
+          <Card.Title className="text-brand"> { t('admin.server_rooms.empty_room_list') } </Card.Title>
           <Card.Text>
-            Rooms will appear here after creating your first room.
+            { t('admin.server_rooms.empty_room_list_subtext') }
           </Card.Text>
         </Card.Body>
       </Card>


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Creating empty list components for Server users (Active, Banned, Pending, and Invited) and rooms
- Created two components to do this: `EmptyUsersList` which can be re-used across all user status tabs, and `EmptyServerRoomsList`
## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
![image](https://user-images.githubusercontent.com/38328371/216212910-163aa9bc-326b-4fe5-b2c5-3ea53abf6750.png)
![image](https://user-images.githubusercontent.com/38328371/216212939-dc0e3942-7897-4f62-b93d-55973b65b464.png)
![image](https://user-images.githubusercontent.com/38328371/216212961-16271061-5c72-4205-a068-e967a9693f19.png)
