### PR TITLE
Fix start script not accepting non-localhost params

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -1,32 +1,42 @@
 #!/usr/bin/env bash
 
+if [ -f .env ]; then
+  export $(echo $(cat .env | sed 's/#.*//g'| xargs) | envsubst)
+fi
+
 PORT="${PORT:=3000}"
 
 # Parse Rails DATABASE and REDIS urls to get host and port
-pgProtocol="$(echo $DATABASE_URL | grep :// | sed -e's,^\(.*://\).*,\1,g')" # extract the protocol
-pgUrl="${DATABASE_URL/$pgProtocol/}" # remove the protocol
-pgUser="$(echo $pgUrl | grep @ | cut -d@ -f1)" # extract the user (if any)
-pgHostport="$(echo ${pgUrl/$pgUser@/} | cut -d/ -f1)" # extract the host and port
-pgHost="$(echo $pgHostport | cut -d: -f1)" # by request host without port
-pgPort="$(echo $pgHostport | cut -d: -f2)" # by request - try to extract the port
+TXADDR=${DATABASE_URL/*:\/\/}
+TXADDR=${TXADDR/*@/}
+TXADDR=${TXADDR/\/*/}
+IFS=: TXADDR=($TXADDR) IFS=' '
+PGHOST=${TXADDR[0]}
+PGPORT=${TXADDR[1]:-5432}
 
-rdProtocol="$(echo $REDIS_URL | grep :// | sed -e's,^\(.*://\).*,\1,g')" # extract the protocol
-rdUrl="${REDIS_URL/$rdProtocol/}" # remove the protocol
-rdUser="$(echo $rdUrl | grep @ | cut -d@ -f1)" # extract the user (if any)
-rdHostport="$(echo ${rdUrl/$rdUser@/} | cut -d/ -f1)" # extract the host and port
-rdHost="$(echo $rdHostport | cut -d: -f1)" # by request host without port
-rdPort="$(echo $rdHostport | cut -d: -f2)" # by request - try to extract the port
+TXADDR=${REDIS_URL/*:\/\/}
+TXADDR=${TXADDR/*@/}
+TXADDR=${TXADDR/\/*/}
+IFS=: TXADDR=($TXADDR) IFS=' '
+RDHOST=${TXADDR[0]}
+RDPORT=${TXADDR[1]:-6379}
 
 echo "Greenlight-v3 starting on port: $PORT"
 
+echo $PGHOST
+echo $PGPORT
+
+echo $RDHOST
+echo $RDPORT
+
 if [ "$RAILS_ENV" = "production" ]; then
-  while ! nc -zw3 $pgHost $pgPort
+  while ! nc -zw3 $PGHOST $PGPORT
   do
     echo "Waiting for postgres to start up ..."
     sleep 1
   done
 
-  while ! nc -zw3 $rdHost $rdPort
+  while ! nc -zw3 $RDHOST $RDPORT
   do
     echo "Waiting for redis to start up ..."
     sleep 1

--- a/bin/start
+++ b/bin/start
@@ -1,22 +1,36 @@
 #!/usr/bin/env bash
 
+if [ -f .env ]; then
+  export $(echo $(cat .env | sed 's/#.*//g'| xargs) | envsubst)
+fi
+
 PORT="${PORT:=3000}"
-PGHOST=postgres
-PGPORT=5432
-RSHOST=redis
-RSPORT=6379
+
+# Parse Rails DATABASE and REDIS urls to get host and port
+pgProtocol="$(echo $DATABASE_URL | grep :// | sed -e's,^\(.*://\).*,\1,g')" # extract the protocol
+pgUrl="$(echo ${DATABASE_URL/$pgProtocol/})" # remove the protocol
+pgUser="$(echo $pgUrl | grep @ | cut -d@ -f1)" # extract the user (if any)
+pgHostport="$(echo ${pgUrl/$pgUser@/} | cut -d/ -f1)" # extract the host and port
+pgHost="$(echo $pgHostport | sed -e 's,:.*,,g')" # by request host without port
+pgPort="$(echo $pgHostport | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')" # by request - try to extract the port
+
+rdProtocol="$(echo $REDIS_URL | grep :// | sed -e's,^\(.*://\).*,\1,g')" # extract the protocol
+rdUrl="$(echo ${REDIS_URL/$rdProtocol/})" # remove the protocol
+rdUser="$(echo $rdUrl | grep @ | cut -d@ -f1)" # extract the user (if any)
+rdHostport="$(echo ${rdUrl/$rdUser@/} | cut -d/ -f1)" # extract the host and port
+rdHost="$(echo $rdHostport | sed -e 's,:.*,,g')" # by request host without port
+rdPort="$(echo $rdHostport | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')" # by request - try to extract the port
 
 echo "Greenlight-v3 starting on port: $PORT"
 
-
 if [ "$RAILS_ENV" = "production" ]; then
-  while ! nc -zw3 $PGHOST $PGPORT
+  while ! nc -zw3 $pgHost $pgPort
   do
     echo "Waiting for postgres to start up ..."
     sleep 1
   done
 
-  while ! nc -zw3 $RSHOST $RSPORT
+  while ! nc -zw3 $rdHost $rdPort
   do
     echo "Waiting for redis to start up ..."
     sleep 1

--- a/bin/start
+++ b/bin/start
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-if [ -f .env ]; then
-  export $(echo $(cat .env | sed 's/#.*//g'| xargs) | envsubst)
-fi
-
 PORT="${PORT:=3000}"
 
 # Parse Rails DATABASE and REDIS urls to get host and port

--- a/bin/start
+++ b/bin/start
@@ -1,25 +1,21 @@
 #!/usr/bin/env bash
 
-if [ -f .env ]; then
-  export $(echo $(cat .env | sed 's/#.*//g'| xargs) | envsubst)
-fi
-
 PORT="${PORT:=3000}"
 
 # Parse Rails DATABASE and REDIS urls to get host and port
 pgProtocol="$(echo $DATABASE_URL | grep :// | sed -e's,^\(.*://\).*,\1,g')" # extract the protocol
-pgUrl="$(echo ${DATABASE_URL/$pgProtocol/})" # remove the protocol
+pgUrl="${DATABASE_URL/$pgProtocol/}" # remove the protocol
 pgUser="$(echo $pgUrl | grep @ | cut -d@ -f1)" # extract the user (if any)
 pgHostport="$(echo ${pgUrl/$pgUser@/} | cut -d/ -f1)" # extract the host and port
-pgHost="$(echo $pgHostport | sed -e 's,:.*,,g')" # by request host without port
-pgPort="$(echo $pgHostport | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')" # by request - try to extract the port
+pgHost="$(echo $pgHostport | cut -d: -f1)" # by request host without port
+pgPort="$(echo $pgHostport | cut -d: -f2)" # by request - try to extract the port
 
 rdProtocol="$(echo $REDIS_URL | grep :// | sed -e's,^\(.*://\).*,\1,g')" # extract the protocol
-rdUrl="$(echo ${REDIS_URL/$rdProtocol/})" # remove the protocol
+rdUrl="${REDIS_URL/$rdProtocol/}" # remove the protocol
 rdUser="$(echo $rdUrl | grep @ | cut -d@ -f1)" # extract the user (if any)
 rdHostport="$(echo ${rdUrl/$rdUser@/} | cut -d/ -f1)" # extract the host and port
-rdHost="$(echo $rdHostport | sed -e 's,:.*,,g')" # by request host without port
-rdPort="$(echo $rdHostport | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')" # by request - try to extract the port
+rdHost="$(echo $rdHostport | cut -d: -f1)" # by request host without port
+rdPort="$(echo $rdHostport | cut -d: -f2)" # by request - try to extract the port
 
 echo "Greenlight-v3 starting on port: $PORT"
 


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The host and port variables were hardcoded to localhost, meaning external PG and RD was resulting in never starting. 

As far as I'm aware, this is the cleanest way to parse URLs in bash without any external libraries. We should revisit this to simplify it as some point

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
