### PR TITLE
Remove Rails Time Formatting from Emails

### DIFF
--- a/app/controllers/api/v1/reset_password_controller.rb
+++ b/app/controllers/api/v1/reset_password_controller.rb
@@ -21,7 +21,7 @@ module Api
 
         token = user.generate_reset_token!
 
-        UserMailer.with(user:, expires_in: User::RESET_TOKEN_VALIDITY_PERIOD.from_now,
+        UserMailer.with(user:,
                         reset_url: reset_password_url(token), base_url: request.base_url,
                         provider: current_provider).reset_password_email.deliver_later
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -51,7 +51,7 @@ module Api
         if user.save
           if smtp_enabled
             token = user.generate_activation_token!
-            UserMailer.with(user:, expires_in: User::ACTIVATION_TOKEN_VALIDITY_PERIOD.from_now,
+            UserMailer.with(user:,
                             activation_url: activate_account_url(token), base_url: request.base_url,
                             provider: current_provider).activate_account_email.deliver_later
           end

--- a/app/controllers/api/v1/verify_account_controller.rb
+++ b/app/controllers/api/v1/verify_account_controller.rb
@@ -13,7 +13,7 @@ module Api
       def create
         token = @user.generate_activation_token!
 
-        UserMailer.with(user: @user, expires_in: User::ACTIVATION_TOKEN_VALIDITY_PERIOD.from_now,
+        UserMailer.with(user: @user,
                         activation_url: activate_account_url(token), base_url: request.base_url,
                         provider: current_provider).activate_account_email.deliver_later
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,7 +11,6 @@ class UserMailer < ApplicationMailer
   def reset_password_email
     @user = params[:user]
     @reset_url = params[:reset_url]
-    @expires_in = params[:expires_in]
 
     mail(to: email_address_with_name(@user.email, @user.name), subject: t('email.reset.password_reset'))
   end
@@ -19,7 +18,6 @@ class UserMailer < ApplicationMailer
   def activate_account_email
     @user = params[:user]
     @activation_url = params[:activation_url]
-    @expires_in = params[:expires_in]
 
     mail(to: email_address_with_name(@user.email, @user.name), subject: t('email.activation.account_activation'))
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   RESET_TOKEN_VALIDITY_PERIOD = 1.hour
   # Account activation token max validity period.
   # It's advised to not increase this to more than 1 hour.
-  ACTIVATION_TOKEN_VALIDITY_PERIOD = 1.hour
+  ACTIVATION_TOKEN_VALIDITY_PERIOD = 24.hours
 
   has_secure_password validations: false
 

--- a/app/views/user_mailer/activate_account_email.html.erb
+++ b/app/views/user_mailer/activate_account_email.html.erb
@@ -14,6 +14,5 @@
 
 <div style="padding: 32px; color: grey;">
   <p> <%= t('email.activation.link_expires') %> </p>
-  <p> <%= 1.hour %> </p>
   <p> <%= t('email.activation.if_link_expires') %> </p>
 </div>

--- a/app/views/user_mailer/activate_account_email.html.erb
+++ b/app/views/user_mailer/activate_account_email.html.erb
@@ -13,6 +13,7 @@
 <div style="border-top: 2px solid whitesmoke"></div>
 
 <div style="padding: 32px; color: grey;">
-  <p> <%= t('email.link_expires', time: time_ago_in_words(@expires_in)) %> </p>
+  <p> <%= t('email.activation.link_expires') %> </p>
+  <p> <%= 1.hour %> </p>
   <p> <%= t('email.activation.if_link_expires') %> </p>
 </div>

--- a/app/views/user_mailer/activate_account_email.text.erb
+++ b/app/views/user_mailer/activate_account_email.text.erb
@@ -2,6 +2,6 @@
 <%= t('email.activation.welcome_to_bbb') %>
 <%= t('email.activation.get_started') %>
 <%= t('email.activation.activate_account') %>  <%= @activation_url %>
-<%= t('email.link_expires', time: time_ago_in_words(@expires_in)) %>
+<%= t('email.activation.link_expires') %>
 <%= t('email.activation.if_link_expires') %>
 ---

--- a/app/views/user_mailer/reset_password_email.html.erb
+++ b/app/views/user_mailer/reset_password_email.html.erb
@@ -13,6 +13,6 @@
 <div style="border-top: 2px solid whitesmoke"></div>
 
 <div style="padding: 32px; color: grey;">
-    <p><%= t('email.link_expires', time: time_ago_in_words(@expires_in)) %>  </p>
+    <p><%= t('email.reset.link_expires') %>  </p>
     <p><%= t('email.reset.ignore_request') %> </p>
 </div>

--- a/app/views/user_mailer/reset_password_email.text.erb
+++ b/app/views/user_mailer/reset_password_email.text.erb
@@ -2,6 +2,6 @@
 <%= t('email.reset.password_reset') %>
 <%= t('email.reset.password_reset_requested', email: @user.email) %>
 <%= t('email.reset.reset_password') %> <%= @reset_url %>
-<%= t('email.link_expires', time: time_ago_in_words(@expires_in)) %>
+<%= t('email.reset.link_expires') %>
 <%= t('email.reset.ignore_request') %>
 ---

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,22 +36,23 @@ en:
     moderator_message: "To invite someone to the meeting, send them this link:"
     access_code: "Access Code: %{code}"
   email:
-    link_expires: The link will expire in %{time}.
     activation:
       account_activation: Account Activation
       welcome_to_bbb: Welcome to BigBlueButton!
       get_started: To get started, please activate your account by clicking on the button below.
       activate_account: Activate Account
+      link_expires: The link will expire in 24 hours.
       if_link_expires: If the link expires, please log in and request a new activation email.
     invitation:
       invitation_to_join: BigBlueButton Invitation
       you_have_been_invited: You have been invited to create a BigBlueButton account by %{name}.
       get_started: To sign up, please click the button below and follow the steps.
-      valid_invitation: The invitation is valid for 48 hours.
+      valid_invitation: The invitation is valid for 24 hours.
       sign_up: Sign Up
     reset:
       password_reset: Reset Password
       password_reset_requested: A password reset has been requested for %{email}.
       password_reset_confirmation: To reset your password, please click on the button below.
       reset_password: Reset Password
+      link_expires: The link will expire in 1 hour.
       ignore_request: If you did not make a request to change your password, please ignore this email.

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -8,18 +8,18 @@ class UserMailerPreview < ActionMailer::Preview
   def reset_password_email
     fake_user = Struct.new(:name, :email)
 
-    UserMailer.with(user: fake_user.new('user', 'user@users.com'), expires_in: 1.hour.from_now, reset_url: 'https://example.com/reset').reset_password_email
+    UserMailer.with(user: fake_user.new('user', 'user@users.com'), reset_url: 'https://example.com/reset').reset_password_email
   end
 
   def activate_account_email
     fake_user = Struct.new(:name, :email)
 
-    UserMailer.with(user: fake_user.new('user', 'user@users.com'), expires_in: 1.hour.from_now, activation_url: 'https://example.com/activate').activate_account_email
+    UserMailer.with(user: fake_user.new('user', 'user@users.com'), activation_url: 'https://example.com/activate').activate_account_email
   end
 
   def invitation_email
     fake_user = Struct.new(:name, :email)
 
-    UserMailer.with(user: fake_user.new('user', 'user@users'), expires_in: 1.hour.from_now, invitation_url: 'https://example.com/invite').invitation_email
+    UserMailer.with(user: fake_user.new('user', 'user@users'), invitation_url: 'https://example.com/invite').invitation_email
   end
 end


### PR DESCRIPTION
Rails (or Ruby?) time formatting would need to add additional locales.
The time formatting was due to the configurable nature of the `account activation` and the `reset password` link.
Set the `account activation` time to 24 hours and `reset password` to 1 hour so it is easier to localize.

Fixes #4816