### PR TITLE
Add recorded_at Column to Recordings

### DIFF
--- a/app/controllers/api/v1/recordings_controller.rb
+++ b/app/controllers/api/v1/recordings_controller.rb
@@ -35,7 +35,7 @@ module Api
       def index
         sort_config = config_sorting(allowed_columns: %w[name length visibility])
 
-        pagy, recordings = pagy(current_user.recordings&.order(sort_config, meeting_date: :desc)&.search(params[:search]))
+        pagy, recordings = pagy(current_user.recordings&.order(sort_config, recorded_at: :desc)&.search(params[:search]))
         render_data data: recordings, meta: pagy_metadata(pagy), status: :ok
       end
 

--- a/app/controllers/api/v1/recordings_controller.rb
+++ b/app/controllers/api/v1/recordings_controller.rb
@@ -35,7 +35,7 @@ module Api
       def index
         sort_config = config_sorting(allowed_columns: %w[name length visibility])
 
-        pagy, recordings = pagy(current_user.recordings&.order(sort_config, created_at: :desc)&.search(params[:search]))
+        pagy, recordings = pagy(current_user.recordings&.order(sort_config, meeting_date: :desc)&.search(params[:search]))
         render_data data: recordings, meta: pagy_metadata(pagy), status: :ok
       end
 

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -132,7 +132,7 @@ module Api
       def recordings
         sort_config = config_sorting(allowed_columns: %w[name length visibility])
 
-        pagy, room_recordings = pagy(@room.recordings&.order(sort_config, created_at: :desc)&.search(params[:q]))
+        pagy, room_recordings = pagy(@room.recordings&.order(sort_config, meeting_date: :desc)&.search(params[:q]))
         render_data data: room_recordings, meta: pagy_metadata(pagy), status: :ok
       end
 

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -132,7 +132,7 @@ module Api
       def recordings
         sort_config = config_sorting(allowed_columns: %w[name length visibility])
 
-        pagy, room_recordings = pagy(@room.recordings&.order(sort_config, meeting_date: :desc)&.search(params[:q]))
+        pagy, room_recordings = pagy(@room.recordings&.order(sort_config, recorded_at: :desc)&.search(params[:q]))
         render_data data: room_recordings, meta: pagy_metadata(pagy), status: :ok
       end
 

--- a/app/javascript/components/recordings/RecordingRow.jsx
+++ b/app/javascript/components/recordings/RecordingRow.jsx
@@ -48,7 +48,7 @@ export default function RecordingRow({
   const [isEditing, setIsEditing] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   const currentUser = useAuth();
-  const localizedTime = localizeDateTimeString(recording?.created_at, currentUser?.language);
+  const localizedTime = localizeDateTimeString(recording?.meeting_date, currentUser?.language);
   const formats = recording.formats.sort(
     (a, b) => (a.recording_type.toLowerCase() > b.recording_type.toLowerCase() ? 1 : -1),
   );
@@ -186,7 +186,7 @@ RecordingRow.propTypes = {
     })),
     visibility: PropTypes.string.isRequired,
     protectable: PropTypes.bool,
-    created_at: PropTypes.string.isRequired,
+    meeting_date: PropTypes.string.isRequired,
     map: PropTypes.func,
   }).isRequired,
   visibilityMutation: PropTypes.func.isRequired,

--- a/app/javascript/components/recordings/RecordingRow.jsx
+++ b/app/javascript/components/recordings/RecordingRow.jsx
@@ -48,7 +48,7 @@ export default function RecordingRow({
   const [isEditing, setIsEditing] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   const currentUser = useAuth();
-  const localizedTime = localizeDateTimeString(recording?.meeting_date, currentUser?.language);
+  const localizedTime = localizeDateTimeString(recording?.recorded_at, currentUser?.language);
   const formats = recording.formats.sort(
     (a, b) => (a.recording_type.toLowerCase() > b.recording_type.toLowerCase() ? 1 : -1),
   );
@@ -186,7 +186,7 @@ RecordingRow.propTypes = {
     })),
     visibility: PropTypes.string.isRequired,
     protectable: PropTypes.bool,
-    meeting_date: PropTypes.string.isRequired,
+    recorded_at: PropTypes.string.isRequired,
     map: PropTypes.func,
   }).isRequired,
   visibilityMutation: PropTypes.func.isRequired,

--- a/app/services/recording_creator.rb
+++ b/app/services/recording_creator.rb
@@ -30,8 +30,13 @@ class RecordingCreator
 
     new_name = @recording[:metadata][:name] || @recording[:name]
 
-    new_recording = Recording.find_or_create_by(room_id:, name: new_name, record_id: @recording[:recordID], visibility:,
-                                                participants: @recording[:participants], length:, protectable: @recording[:protected].present?)
+    new_recording = Recording.find_or_create_by(room_id:,
+                                                name: new_name,
+                                                record_id: @recording[:recordID],
+                                                visibility:,
+                                                participants: @recording[:participants],
+                                                length:, protectable: @recording[:protected].present?,
+                                                meeting_date: @recording[:startTime])
 
     # Create format(s)
     create_formats(recording: @recording, new_recording:)

--- a/app/services/recording_creator.rb
+++ b/app/services/recording_creator.rb
@@ -36,7 +36,7 @@ class RecordingCreator
                                                 visibility:,
                                                 participants: @recording[:participants],
                                                 length:, protectable: @recording[:protected].present?,
-                                                meeting_date: @recording[:startTime])
+                                                recorded_at: @recording[:startTime])
 
     # Create format(s)
     create_formats(recording: @recording, new_recording:)

--- a/db/data/20230228193705_populate_recorded_at_recording.rb
+++ b/db/data/20230228193705_populate_recorded_at_recording.rb
@@ -20,6 +20,7 @@ class PopulateRecordedAtRecording < ActiveRecord::Migration[7.0]
   def up
     # rubocop:disable Rails/SkipsModelValidations
     Recording.update_all('recorded_at = created_at')
+    # rubocop:enable Rails/SkipsModelValidations
   end
 
   def down

--- a/db/data/20230228193705_populate_recorded_at_recording.rb
+++ b/db/data/20230228193705_populate_recorded_at_recording.rb
@@ -16,26 +16,13 @@
 
 # frozen_string_literal: true
 
-class Recording < ApplicationRecord
-  belongs_to :room
-  has_one :user, through: :room
-  has_many :formats, dependent: :destroy
+class PopulateRecordedAtRecording < ActiveRecord::Migration[7.0]
+  def up
+    # rubocop:disable Rails/SkipsModelValidations
+    Recording.update_all('recorded_at = created_at')
+  end
 
-  validates :name, presence: true
-  validates :record_id, presence: true
-  validates :visibility, presence: true
-  validates :length, presence: true
-  validates :participants, presence: true
-  validates :recorded_at, presence: true
-
-  scope :with_provider, ->(current_provider) { where(user: { provider: current_provider }) }
-
-  def self.search(input)
-    if input
-      return joins(:formats).where('recordings.name ILIKE :input OR recordings.visibility ILIKE :input OR formats.recording_type ILIKE :input',
-                                   input: "%#{input}%").includes(:formats)
-    end
-
-    all.includes(:formats)
+  def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,17 @@
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+#
+# Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+#
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free Software
+# Foundation; either version 3.0 of the License, or (at your option) any later
+# version.
+#
+# Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with Greenlight; if not, see <http://www.gnu.org/licenses/>.
+
 DataMigrate::Data.define(version: 20230123174546)

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,17 +1,1 @@
-# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
-#
-# Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
-#
-# This program is free software; you can redistribute it and/or modify it under the
-# terms of the GNU Lesser General Public License as published by the Free Software
-# Foundation; either version 3.0 of the License, or (at your option) any later
-# version.
-#
-# Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License along
-# with Greenlight; if not, see <http://www.gnu.org/licenses/>.
-
-DataMigrate::Data.define(version: 20230123174546)
+DataMigrate::Data.define(version: 20230228193705)

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,17 +1,1 @@
-# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
-#
-# Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
-#
-# This program is free software; you can redistribute it and/or modify it under the
-# terms of the GNU Lesser General Public License as published by the Free Software
-# Foundation; either version 3.0 of the License, or (at your option) any later
-# version.
-#
-# Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License along
-# with Greenlight; if not, see <http://www.gnu.org/licenses/>.
-
 DataMigrate::Data.define(version: 20230123174546)

--- a/db/migrate/20230227213252_add_meeting_date_to_recordings.rb
+++ b/db/migrate/20230227213252_add_meeting_date_to_recordings.rb
@@ -16,26 +16,8 @@
 
 # frozen_string_literal: true
 
-class Recording < ApplicationRecord
-  belongs_to :room
-  has_one :user, through: :room
-  has_many :formats, dependent: :destroy
-
-  validates :name, presence: true
-  validates :record_id, presence: true
-  validates :visibility, presence: true
-  validates :length, presence: true
-  validates :participants, presence: true
-  validates :meeting_date, presence: true
-
-  scope :with_provider, ->(current_provider) { where(user: { provider: current_provider }) }
-
-  def self.search(input)
-    if input
-      return joins(:formats).where('recordings.name ILIKE :input OR recordings.visibility ILIKE :input OR formats.recording_type ILIKE :input',
-                                   input: "%#{input}%").includes(:formats)
-    end
-
-    all.includes(:formats)
+class AddMeetingDateToRecordings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :recordings, :meeting_date, :datetime
   end
 end

--- a/db/migrate/20230227213252_add_recorded_at_to_recordings.rb
+++ b/db/migrate/20230227213252_add_recorded_at_to_recordings.rb
@@ -18,7 +18,6 @@
 
 class AddRecordedAtToRecordings < ActiveRecord::Migration[7.0]
   def change
-    # rubocop:disable Rails/NotNullColumn
-    add_column :recordings, :recorded_at, :datetime, null: false
+    add_column :recordings, :recorded_at, :datetime
   end
 end

--- a/db/migrate/20230227213252_add_recorded_at_to_recordings.rb
+++ b/db/migrate/20230227213252_add_recorded_at_to_recordings.rb
@@ -16,8 +16,9 @@
 
 # frozen_string_literal: true
 
-class AddMeetingDateToRecordings < ActiveRecord::Migration[7.0]
+class AddRecordedAtToRecordings < ActiveRecord::Migration[7.0]
   def change
-    add_column :recordings, :meeting_date, :datetime
+    # rubocop:disable Rails/NotNullColumn
+    add_column :recordings, :recorded_at, :datetime, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,7 +89,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_27_213252) do
     t.integer "length", null: false
     t.integer "participants", null: false
     t.boolean "protectable"
-    t.datetime "meeting_date"
+    t.datetime "recorded_at", null: false
     t.index ["room_id"], name: "index_recordings_on_room_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,19 +1,3 @@
-# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
-#
-# Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
-#
-# This program is free software; you can redistribute it and/or modify it under the
-# terms of the GNU Lesser General Public License as published by the Free Software
-# Foundation; either version 3.0 of the License, or (at your option) any later
-# version.
-#
-# Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License along
-# with Greenlight; if not, see <http://www.gnu.org/licenses/>.
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -26,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_25_184305) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_27_213252) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -105,6 +89,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_25_184305) do
     t.integer "length", null: false
     t.integer "participants", null: false
     t.boolean "protectable"
+    t.datetime "meeting_date"
     t.index ["room_id"], name: "index_recordings_on_room_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,7 +89,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_27_213252) do
     t.integer "length", null: false
     t.integer "participants", null: false
     t.boolean "protectable"
-    t.datetime "recorded_at", null: false
+    t.datetime "recorded_at"
     t.index ["room_id"], name: "index_recordings_on_room_id"
   end
 

--- a/spec/factories/recording_factory.rb
+++ b/spec/factories/recording_factory.rb
@@ -24,6 +24,7 @@ FactoryBot.define do
     visibility { 'Unpublished' }
     length { Faker::Number.within(range: 1..60) }
     participants { Faker::Number.within(range: 1..100) }
+    recorded_at { Faker::Time.between(from: 2.days.ago, to: Time.zone.now) }
 
     after(:create) do |recording|
       create(:format, recording:)


### PR DESCRIPTION
**Problem:**
Recording `created_at` timestamp is used to sort, display the meeting/recording date of creation.
But, when Syncing Recordings with the BBB server, the process deletes all the current recordings and re-creates them from the BBB response.
Hence, upon syncing, the `created_at` will be the date of the sync instead of the date of the meeting.

Solution:
This PR attempts to solve the issue by creating a new `meeting_date` column on Recordings. The `meeting_date` is initiated from BBB `startTime` response.

Note: Upon migrating the new column, the users will have to sync  the recordings to populate the `meeting_date` column.