### PR TITLE
Fix Rooms/Recordings gap

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -704,3 +704,9 @@ input[type="range"]:focus::-moz-range-thumb {
     width: 25px;
   }
 }
+
+#rooms-list-empty, #recordings-list-empty {
+  .card-body {
+    min-height: 20rem;
+  }
+}

--- a/app/javascript/components/recordings/EmptyRecordingsList.jsx
+++ b/app/javascript/components/recordings/EmptyRecordingsList.jsx
@@ -23,7 +23,7 @@ export default function EmptyRecordingsList() {
   const { t } = useTranslation();
 
   return (
-    <div className="pt-3">
+    <div id="recordings-list-empty" className="pt-3">
       <Card className="border-0 card-shadow text-center">
         <Card.Body className="py-5">
           <div className="icon-circle rounded-circle d-block mx-auto mb-3">

--- a/app/javascript/components/rooms/EmptyRoomsList.jsx
+++ b/app/javascript/components/rooms/EmptyRoomsList.jsx
@@ -29,7 +29,7 @@ export default function EmptyRoomsList() {
   const mutationWrapper = (args) => useCreateRoom({ userId: currentUser.id, ...args });
 
   return (
-    <div id="rooms-list-empty" className="pt-5">
+    <div id="rooms-list-empty" className="pt-3">
       <Card className="border-0 card-shadow text-center">
         <Card.Body className="py-5">
           <div className="icon-circle rounded-circle d-block mx-auto mb-3">


### PR DESCRIPTION
Fix gap between Rooms/Recordings tab and EmptyResource card layout
Set EmptyRecordings and EmptyRooms card height to be the same so it doesn't "jump"

![image](https://user-images.githubusercontent.com/43917914/223868155-edbb66c2-8060-4cdb-bd39-6f684ec09a6c.png)
