### PR TITLE
Add SuperAdmin provider bypass

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -35,11 +35,11 @@ module Api
         # TODO: Add proper error logging for non-verified token hcaptcha
         return render_error if hcaptcha_enabled? && !verify_hcaptcha(response: params[:token])
 
-        user = User.find_by(email: session_params[:email])
+        user = User.find_by(email: session_params[:email], provider: [current_provider, 'bn'])
 
         return render_error if user.blank?
 
-        # Checks if the user is from the current provider or if the user is a super admin
+        # Will return an error if the user is NOT from the current provider and if the user is NOT a super admin
         return render_error if user.provider != current_provider && !user.super_admin?
 
         # TODO: Add proper error logging for non-verified token hcaptcha

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -36,7 +36,7 @@ module Api
         return render_error if hcaptcha_enabled? && !verify_hcaptcha(response: params[:token])
 
         # Search for a user within the current provider and, if not found, search for a super admin within bn provider
-        user = find_user(session_params[:email], current_provider)
+        user = User.find_by(email: session_params[:email], provider: current_provider) || User.find_by(email: session_params[:email], provider: 'bn')
 
         # Return an error if the user is not found
         return render_error if user.blank?
@@ -68,13 +68,6 @@ module Api
 
       def session_params
         params.require(:session).permit(:email, :password, :extend_session)
-      end
-
-      def find_user(email, provider)
-        user = User.find_by(email:, provider:)
-        # If the user is not found in the current provider, search for a super admin with bn provider
-        user = User.find_by(email:, provider: 'bn') if user.blank?
-        user
       end
 
       def sign_in(user)

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -103,4 +103,3 @@ module Api
     end
   end
 end
-

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -78,10 +78,10 @@ class ApplicationController < ActionController::Base
 
   # Parses the url for the user domain
   def parse_user_domain(hostname)
-    provider = hostname&.split('.')&.first
+    tenant = hostname&.split('.')&.first
 
-    raise 'Invalid domain' unless Tenant.exists?(name: hostname)
+    raise 'Invalid domain' unless Tenant.exists?(name: tenant)
 
-    provider
+    tenant
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -207,7 +207,7 @@ class User < ApplicationRecord
   end
 
   def super_admin?
-    role.name == 'SuperAdmin' && provider == 'bn'
+    role.name == 'SuperAdmin' && role.provider == 'bn'
   end
 
   def check_user_role_provider

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -206,6 +206,10 @@ class User < ApplicationRecord
     update! verified: false
   end
 
+  def super_admin?
+    role.name == 'SuperAdmin' && provider == 'bn'
+  end
+
   def check_user_role_provider
     return unless role
 

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -35,6 +35,6 @@ class CurrentUserSerializer < UserSerializer
   end
 
   def super_admin
-    object.role.name == 'SuperAdmin' && object.role.provider == 'bn'
+    object.super_admin?
   end
 end

--- a/spec/factories/role_factory.rb
+++ b/spec/factories/role_factory.rb
@@ -29,5 +29,10 @@ FactoryBot.define do
       RolePermission.find_or_create_by(permission: perm2, role:, value: '100')
       RolePermission.find_or_create_by(permission: perm3, role:, value: 'true')
     end
+
+    trait :with_super_admin do
+      name { 'SuperAdmin' }
+      provider { 'bn' }
+    end
   end
 end


### PR DESCRIPTION
# Context
A SuperAdmin should be able to login into any tenant and bypass all the provider checks.

# How the feature was tested:
Create initial resources

- Created a `super_admin_user`
- Created two tenants from the Admin Panel: `tenant_one` and `tenant_two`.

Setup multitenancy

- Assigned `tenant_one.greenlight.com` and `tenant_two.greenlight.com` to locahost via /etc/hosts
- Add `LOADBALANCER_ENDPOINT` and `LOADBALANCER_SECRET` var in .env

Create multitenancy resources

- Create `tenant_one_user` via `tenant_one` sign up form

Testing steps

- Successfully log in `tenant_one_user` into `tenant_one`
- Error when trying to log in `tenant_one_user` into `tenant_two`
- Successfully log in `super_admin_user` in both tenants