### PR TITLE
Add Reset Password Email Task

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,10 +65,10 @@ Rails.application.configure do
       user_name: ENV.fetch('SMTP_USERNAME', nil),
       password: ENV.fetch('SMTP_PASSWORD', nil),
       authentication: ENV.fetch('SMTP_AUTH', nil),
-      enable_starttls_auto: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_STARTTLS_AUTO', 'true')),
-      enable_starttls: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_STARTTLS', 'false')),
-      tls: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_TLS', 'false')),
-      openssl_verify_mode: ENV.fetch('SMTP_SSL_VERIFY', 'true') == 'false' ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+      enable_starttls_auto: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_STARTTLS_AUTO', nil)),
+      enable_starttls: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_STARTTLS', nil)),
+      tls: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_TLS', nil)),
+      openssl_verify_mode: ENV.fetch('SMTP_SSL_VERIFY', nil) == 'false' ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
     }.compact
 
     config.action_mailer.smtp_settings = smtp_settings

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,7 +68,7 @@ Rails.application.configure do
       enable_starttls_auto: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_STARTTLS_AUTO', nil)),
       enable_starttls: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_STARTTLS', nil)),
       tls: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_TLS', nil)),
-      openssl_verify_mode: ENV.fetch('SMTP_SSL_VERIFY', nil) == 'false' ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+      openssl_verify_mode: ENV.fetch('SMTP_SSL_VERIFY', 'true') == 'false' ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
     }.compact
 
     config.action_mailer.smtp_settings = smtp_settings

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,9 +75,9 @@ Rails.application.configure do
       user_name: ENV.fetch('SMTP_USERNAME', nil),
       password: ENV.fetch('SMTP_PASSWORD', nil),
       authentication: ENV.fetch('SMTP_AUTH', nil),
-      enable_starttls_auto: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_STARTTLS_AUTO', 'true')),
-      enable_starttls: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_STARTTLS', 'false')),
-      tls: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_TLS', 'false')),
+      enable_starttls_auto: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_STARTTLS_AUTO', nil)),
+      enable_starttls: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_STARTTLS', nil)),
+      tls: ActiveModel::Type::Boolean.new.cast(ENV.fetch('SMTP_TLS', nil)),
       openssl_verify_mode: ENV.fetch('SMTP_SSL_VERIFY', 'true') == 'false' ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
     }.compact
 

--- a/lib/tasks/reset_password_email.rake
+++ b/lib/tasks/reset_password_email.rake
@@ -19,7 +19,7 @@
 require_relative 'task_helpers'
 
 namespace :migration do
-  BATCH_SIZE = 500
+  batch_size = 500
 
   desc 'Send a reset password email to users'
   task :reset_password_email, %i[base_url provider] => :environment do |_task, args|
@@ -32,7 +32,7 @@ namespace :migration do
       begin
         # After the migration, all the users except those with an external_id will need to reset their password
         User.where(external_id: nil, provider: args[:provider])
-            .find_each(batch_size: BATCH_SIZE) do |user|
+            .find_each(batch_size:) do |user|
           token = user.generate_reset_token!
 
           UserMailer.with(user:,

--- a/lib/tasks/reset_password_email.rake
+++ b/lib/tasks/reset_password_email.rake
@@ -32,16 +32,6 @@ namespace :migration do
       exit 0
     end
 
-    info 'Checking connection to SMTP Server...'
-    if ENV['SMTP_SERVER'].present?
-      begin
-        UserMailer.with(to: ENV.fetch('SMTP_SENDER_EMAIL', nil), subject: ENV.fetch('SMTP_SENDER_EMAIL', nil)).test_email.deliver_now
-      rescue StandardError => e
-        failed("Unable to connect to SMTP Server - #{e}")
-        exit 0
-      end
-    end
-
     info 'Sending reset password emails...'
     User.where(external_id: nil, provider: args[:provider])
         .find_each(batch_size:) do |user|

--- a/lib/tasks/reset_password_email.rake
+++ b/lib/tasks/reset_password_email.rake
@@ -37,7 +37,9 @@ namespace :migration do
                       base_url: args[:base_url],
                       provider: args[:provider]).reset_password_email.deliver_later
 
-      success "Sent reset password email to #{user.email}"
+      success 'Successfully sent reset password email to:'
+      info    "  name: #{user.name}"
+      info    "  email: #{user.email}"
     end
   end
 

--- a/lib/tasks/reset_password_email.rake
+++ b/lib/tasks/reset_password_email.rake
@@ -1,0 +1,60 @@
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+#
+# Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+#
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free Software
+# Foundation; either version 3.0 of the License, or (at your option) any later
+# version.
+#
+# Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with Greenlight; if not, see <http://www.gnu.org/licenses/>.
+
+# frozen_string_literal: true
+
+require_relative 'task_helpers'
+
+namespace :migration do
+  include ActionView::Helpers::AssetUrlHelper
+
+  desc 'Send a reset password email to users'
+  task :reset_password_email, %i[provider start stop root_url] => :environment do |_task, args|
+    args.with_defaults(provider: 'greenlight')
+    start, stop = range(args)
+
+    User.where(external_id: nil, provider: args[:provider])
+        .find_each do |user|
+      token = user.generate_reset_token!
+
+      UserMailer.with(user:,
+                      reset_url: reset_password_url(args[:root_url], token),
+                      base_url: args[:root_url],
+                      provider: args[:provider]).reset_password_email.deliver_later
+
+      success "Sent reset password email to #{user.email}"
+    end
+
+  end
+
+  private
+
+  def range(args)
+    start = args[:start].to_i
+    start = 1 unless start.positive?
+
+    stop = args[:stop].to_i
+    stop = nil unless stop.positive?
+
+    raise red "Unable to migrate: Invalid provided range [start: #{start}, stop: #{stop}]" if stop && start > stop
+
+    [start, stop]
+  end
+
+  def reset_password_url(root_url, token)
+    "#{root_url}reset_password/#{token}"
+  end
+end

--- a/lib/tasks/reset_password_email.rake
+++ b/lib/tasks/reset_password_email.rake
@@ -22,17 +22,19 @@ namespace :migration do
   include ActionView::Helpers::AssetUrlHelper
 
   desc 'Send a reset password email to users'
-  task :reset_password_email, %i[provider start stop root_url] => :environment do |_task, args|
+  task :reset_password_email, %i[provider start stop base_url] => :environment do |_task, args|
     args.with_defaults(provider: 'greenlight')
     start, stop = range(args)
+
+    root_url = "#{args[:base_url]}/"
 
     User.where(external_id: nil, provider: args[:provider])
         .find_each do |user|
       token = user.generate_reset_token!
 
       UserMailer.with(user:,
-                      reset_url: reset_password_url(args[:root_url], token),
-                      base_url: args[:root_url],
+                      reset_url: reset_password_url(root_url, token),
+                      base_url: args[:base_url],
                       provider: args[:provider]).reset_password_email.deliver_later
 
       success "Sent reset password email to #{user.email}"


### PR DESCRIPTION
Upon migrating the users from V2 to V3, the user's passwords are reset.
This tasks aims to provide the system administrator an easy way to inform the users that their password have been reset.
SA will have to manually provide the `root_url` for now.

How To Test:

- Needs #5039 for proper email template
- Run the command below from the project dir. Pleas set your base url as an argument to the rake task.
`rake migration:reset_password_email\[<base url>]`
`rake migration:reset_password_email\[https://b1b3-24-203-33-70.ngrok.io]`
- The users that have been sent an email should appear in the console
![image](https://user-images.githubusercontent.com/43917914/226463953-24cd7151-71ce-4260-84e7-ddd6d5c2668a.png)
