### PR TITLE
Add Missing Toast String

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -406,6 +406,7 @@
       "problem_completing_action": "The action can't be completed. \n Please try again.",
       "file_type_not_supported": "The file type is not supported.",
       "file_size_too_large": "The file size is too large.",
+      "file_upload_error": "The file can't be uploaded.",
       "signin_required": "You must be signed in to access this page.",
       "roles": {
         "role_assigned": "This role can't be deleted because it is assigned to at least one user."


### PR DESCRIPTION
Add missing error toast on presentation upload failure.

As noted per one of our users [in the google group.](https://groups.google.com/g/bigbluebutton-dev/c/Mfwa7wSvTCM)

I have no clue yet on how this error would show up as we are catching the "file size too large" and "file type not supported".
