### PR TITLE
Fix Recording initial Visibility

### DIFF
--- a/app/services/recording_creator.rb
+++ b/app/services/recording_creator.rb
@@ -48,9 +48,9 @@ class RecordingCreator
 
   # Returns the visibility of the recording (published, unpublished or protected)
   def get_recording_visibility(recording:)
-    return 'Protected' if recording[:protected] == 'true'
+    return 'Protected' if recording[:protected].to_s == 'true'
 
-    return 'Published' if recording[:published] == 'true'
+    return 'Published' if recording[:published].to_s == 'true'
 
     'Unpublished'
   end


### PR DESCRIPTION
Fixes #5030 

Upon the initial creation of a Recording, the recording visibility would always return "Unpublished".

It is because BBB is returning a boolean but we are expecting a string in recording_creator.

Add a `to_s` conversion to the `recording[:published]` response.

![image](https://user-images.githubusercontent.com/43917914/225653808-f11996d8-1a0f-4070-b12a-d7dc3252cec0.png)
