### PR TITLE
Fix Mailer Views

### DIFF
--- a/app/views/user_mailer/activate_account_email.html.erb
+++ b/app/views/user_mailer/activate_account_email.html.erb
@@ -19,10 +19,8 @@
 
   <p style="font-size: 24px;"> <%= t('email.activation.get_started') %> </p>
 
-  <a href="<%= @activation_url %>" target="_blank">
-    <button style="background-color: <%= @brand_color %>; border-radius: 8px; border: none; color: white; padding: 15px 32px; text-align: center; text-decoration: none; display: inline-block; font-size: 16px; font-weight: 600; margin-top: 16px; margin-bottom: 64px;">
-      <%= t('email.activation.activate_account') %>
-    </button>
+  <a href="<%= @activation_url %>" target="_blank" style="background-color: <%= @brand_color %>; border-radius: 8px; border: none; color: white; padding: 15px 32px; text-align: center; text-decoration: none; display: inline-block; font-size: 16px; font-weight: 600; margin-top: 16px; margin-bottom: 64px;">
+    <%= t('email.activation.activate_account') %>
   </a>
 </div>
 

--- a/app/views/user_mailer/activate_account_email.text.erb
+++ b/app/views/user_mailer/activate_account_email.text.erb
@@ -17,7 +17,7 @@
 ---
 <%= t('email.activation.welcome_to_bbb') %>
 <%= t('email.activation.get_started') %>
-<%= t('email.activation.activate_account') %>  <%= @activation_url %>
+& lt;a href="<%= @activation_url %>"& gt;  test & lt; /a & gt;
 <%= t('email.activation.link_expires') %>
 <%= t('email.activation.if_link_expires') %>
 ---

--- a/app/views/user_mailer/activate_account_email.text.erb
+++ b/app/views/user_mailer/activate_account_email.text.erb
@@ -1,23 +1,25 @@
-<!--BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.-->
+<%#
+  BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
 
-<!--Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).-->
+  Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
 
-<!--This program is free software; you can redistribute it and/or modify it under the-->
-<!--terms of the GNU Lesser General Public License as published by the Free Software-->
-<!--Foundation; either version 3.0 of the License, or (at your option) any later-->
-<!--version.-->
+  This program is free software; you can redistribute it and/or modify it under the
+  terms of the GNU Lesser General Public License as published by the Free Software
+  Foundation; either version 3.0 of the License, or (at your option) any later
+  version.
 
-<!--Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY-->
-<!--WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A-->
-<!--PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.-->
+  Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
 
-<!--You should have received a copy of the GNU Lesser General Public License along-->
-<!--with Greenlight; if not, see <http://www.gnu.org/licenses/>.-->
+  You should have received a copy of the GNU Lesser General Public License along
+  with Greenlight; if not, see http://www.gnu.org/licenses/.
+%>
 
 ---
 <%= t('email.activation.welcome_to_bbb') %>
 <%= t('email.activation.get_started') %>
-& lt;a href="<%= @activation_url %>"& gt;  test & lt; /a & gt;
+<%= @activation_url %>
 <%= t('email.activation.link_expires') %>
 <%= t('email.activation.if_link_expires') %>
 ---

--- a/app/views/user_mailer/invitation_email.html.erb
+++ b/app/views/user_mailer/invitation_email.html.erb
@@ -21,10 +21,8 @@
 
   <p style="font-size: 24px;"><%= t('email.invitation.get_started') %></p>
 
-  <a href="<%= @signup_url %>">
-    <button style="background-color: <%= @brand_color %>; border-radius: 8px; border: none; color: white; padding: 15px 32px; text-align: center; text-decoration: none; display: inline-block; font-size: 16px; font-weight: 600; margin-top: 16px; margin-bottom: 64px;">
-      <%= t('email.invitation.sign_up') %>
-    </button>
+  <a href="<%= @signup_url %>" target="_blank" style="background-color: <%= @brand_color %>; border-radius: 8px; border: none; color: white; padding: 15px 32px; text-align: center; text-decoration: none; display: inline-block; font-size: 16px; font-weight: 600; margin-top: 16px; margin-bottom: 64px;">
+    <%= t('email.invitation.sign_up') %>
   </a>
 </div>
 

--- a/app/views/user_mailer/invitation_email.text.erb
+++ b/app/views/user_mailer/invitation_email.text.erb
@@ -18,6 +18,6 @@
 <%= t('email.invitation.invitation_to_join') %>
 <%= t('email.invitation.you_have_been_invited', name: @name) %>
 <%= t('email.invitation.get_started') %>
-<%= t('email.invitation.sign_up') %> <%= @signup_url %>
+& lt;a href="<%= @signup_url %>"& gt;  test & lt; /a & gt;
 <%= t('email.invitation.valid_invitation') %>
 ---

--- a/app/views/user_mailer/invitation_email.text.erb
+++ b/app/views/user_mailer/invitation_email.text.erb
@@ -1,23 +1,25 @@
-<!--BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.-->
+<%#
+  BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
 
-<!--Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).-->
+  Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
 
-<!--This program is free software; you can redistribute it and/or modify it under the-->
-<!--terms of the GNU Lesser General Public License as published by the Free Software-->
-<!--Foundation; either version 3.0 of the License, or (at your option) any later-->
-<!--version.-->
+  This program is free software; you can redistribute it and/or modify it under the
+  terms of the GNU Lesser General Public License as published by the Free Software
+  Foundation; either version 3.0 of the License, or (at your option) any later
+  version.
 
-<!--Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY-->
-<!--WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A-->
-<!--PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.-->
+  Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
 
-<!--You should have received a copy of the GNU Lesser General Public License along-->
-<!--with Greenlight; if not, see <http://www.gnu.org/licenses/>.-->
+  You should have received a copy of the GNU Lesser General Public License along
+  with Greenlight; if not, see http://www.gnu.org/licenses/.
+%>
 
 ---
 <%= t('email.invitation.invitation_to_join') %>
 <%= t('email.invitation.you_have_been_invited', name: @name) %>
 <%= t('email.invitation.get_started') %>
-& lt;a href="<%= @signup_url %>"& gt;  test & lt; /a & gt;
+<%= @signup_url %>
 <%= t('email.invitation.valid_invitation') %>
 ---

--- a/app/views/user_mailer/reset_password_email.html.erb
+++ b/app/views/user_mailer/reset_password_email.html.erb
@@ -1,28 +1,28 @@
-<!--BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.-->
+<%#
+  BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
 
-<!--Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).-->
+  Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
 
-<!--This program is free software; you can redistribute it and/or modify it under the-->
-<!--terms of the GNU Lesser General Public License as published by the Free Software-->
-<!--Foundation; either version 3.0 of the License, or (at your option) any later-->
-<!--version.-->
+  This program is free software; you can redistribute it and/or modify it under the
+  terms of the GNU Lesser General Public License as published by the Free Software
+  Foundation; either version 3.0 of the License, or (at your option) any later
+  version.
 
-<!--Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY-->
-<!--WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A-->
-<!--PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.-->
+  Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
 
-<!--You should have received a copy of the GNU Lesser General Public License along-->
-<!--with Greenlight; if not, see <http://www.gnu.org/licenses/>.-->
+  You should have received a copy of the GNU Lesser General Public License along
+  with Greenlight; if not, see http://www.gnu.org/licenses/.
+%>
 
 <div style="padding-left: 80px; padding-right: 80px;">
     <p style="font-size: 40px; margin-bottom: 20px; font-weight: 600;"> <%= t('email.reset.password_reset') %> </p>
 
     <p style="font-size: 24px;"> <%= t('email.reset.password_reset_requested', email: @user.email) %>  </p>
 
-    <a href="<%= @reset_url %>" target="_blank">
-      <button style="background-color: <%= @brand_color %>; border-radius: 8px; border: none; color: white; padding: 15px 32px; text-align: center; text-decoration: none; display: inline-block; font-size: 16px; font-weight: 600; margin-top: 16px; margin-bottom: 64px;">
-       <%= t('email.reset.reset_password') %>
-      </button>
+    <a href="<%= @reset_url %>" style="background-color: <%= @brand_color %>; border-radius: 8px; border: none; color: white; padding: 15px 32px; text-align: center; text-decoration: none; display: inline-block; font-size: 16px; font-weight: 600; margin-top: 16px; margin-bottom: 64px;" target="_blank">
+      <%= t('email.reset.reset_password') %>
     </a>
 </div>
 

--- a/app/views/user_mailer/reset_password_email.text.erb
+++ b/app/views/user_mailer/reset_password_email.text.erb
@@ -19,7 +19,7 @@
 ---
 <%= t('email.reset.password_reset') %>
 <%= t('email.reset.password_reset_requested', email: @user.email) %>
-& lt;a href="<%= @reset_url %>"& gt;  test & lt; /a & gt;
+<%= @reset_url %>
 <%= t('email.reset.link_expires') %>
 <%= t('email.reset.ignore_request') %>
 ---

--- a/app/views/user_mailer/reset_password_email.text.erb
+++ b/app/views/user_mailer/reset_password_email.text.erb
@@ -1,23 +1,25 @@
-<!--BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.-->
+<%#
+  BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
 
-<!--Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).-->
+  Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
 
-<!--This program is free software; you can redistribute it and/or modify it under the-->
-<!--terms of the GNU Lesser General Public License as published by the Free Software-->
-<!--Foundation; either version 3.0 of the License, or (at your option) any later-->
-<!--version.-->
+  This program is free software; you can redistribute it and/or modify it under the
+  terms of the GNU Lesser General Public License as published by the Free Software
+  Foundation; either version 3.0 of the License, or (at your option) any later
+  version.
 
-<!--Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY-->
-<!--WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A-->
-<!--PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.-->
+  Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
 
-<!--You should have received a copy of the GNU Lesser General Public License along-->
-<!--with Greenlight; if not, see <http://www.gnu.org/licenses/>.-->
+  You should have received a copy of the GNU Lesser General Public License along
+  with Greenlight; if not, see http://www.gnu.org/licenses/.
+%>
 
 ---
 <%= t('email.reset.password_reset') %>
 <%= t('email.reset.password_reset_requested', email: @user.email) %>
-<%= t('email.reset.reset_password') %> <%= @reset_url %>
+& lt;a href="<%= @reset_url %>"& gt;  test & lt; /a & gt;
 <%= t('email.reset.link_expires') %>
 <%= t('email.reset.ignore_request') %>
 ---


### PR DESCRIPTION
This aims to solve #5027 

Remove the <button> element which is not a proper simple HTML element - and is useless.
Fix the .text.erb templates

Emails now seem to work on GMAIL, Thunderbird. In HTML, simple HTML, text.