### PR TITLE
fix(active storage): stop svg+xml from being served as binary files

### DIFF
--- a/app/javascript/helpers/FileValidationHelper.jsx
+++ b/app/javascript/helpers/FileValidationHelper.jsx
@@ -16,7 +16,7 @@
 
 export const fileValidation = (file, type) => {
   const IMAGE_MAX_FILE_SIZE = 3_000_000;
-  const IMAGE_SUPPORTED_FORMATS = ['image/jpeg', 'image/png', 'image/svg'];
+  const IMAGE_SUPPORTED_FORMATS = ['image/jpeg', 'image/png', 'image/svg+xml'];
 
   const PRESENTATION_MAX_FILE_SIZE = 10_000_000;
   const PRESENTATION_SUPPORTED_FORMATS = [

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,9 @@ module Greenlight
 
     config.active_storage.variant_processor = :mini_magick
 
+    # SVGs are served as binary by default, which causes the browser to download the file instead of displaying it
+    config.active_storage.content_types_to_serve_as_binary -= ['image/svg+xml']
+
     config.bigbluebutton_endpoint = ENV.fetch('BIGBLUEBUTTON_ENDPOINT', 'https://test-install.blindsidenetworks.com/bigbluebutton/api')
     config.bigbluebutton_endpoint = File.join(config.bigbluebutton_endpoint, '') unless config.bigbluebutton_endpoint.end_with?('/')
     config.bigbluebutton_endpoint = File.join(config.bigbluebutton_endpoint, '/api/') unless config.bigbluebutton_endpoint.end_with?('api', 'api/')


### PR DESCRIPTION
Related to #5065 

ActiveStorage SVG+XML files are served as binary by default since Rails 5, which makes it downloadable instead of displaying the image.

This is because SVG+XML can be edited to embed Javascript and conduct Cross-Site Scripting (XSS) attacks.

In Greenlight v3, there are two places where svg files could be uploaded:
- the user avatar
- the site logo

For the user avatar, the user is allowed to upload a svg file but it will be converted to a png by the avatar cropping process before being saved to the servers.

As for the site logo, the endpoint to upload the logo is private and the access is strictly limited to system administrators.

But, even if the access is limited, we should also add a sanitizer to check the svg files before being saved to our servers. There are Javascript libraries for that.

We could also obviously restrict SVG images from being used.




