### PR TITLE
Adding support for relative URL root path

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
 web: bin/rails server -p $PORT
-js: yarn build:development --watch
+js: yarn build:development
 css: yarn build:development:css --watch

--- a/app/javascript/helpers/Axios.jsx
+++ b/app/javascript/helpers/Axios.jsx
@@ -21,7 +21,7 @@ const axiosInstance = axios.create(
     // `baseURL` will be prepended to `url` unless `url` is absolute.
     // It can be convenient to set `baseURL` for an instance of axios to pass relative URLs
     // to methods of that instance.
-    baseURL: '/api/v1',
+    baseURL: `${process.env.RELATIVE_URL_ROOT}/api/v1`,
 
     // `headers` are custom headers to be sent
     headers: {

--- a/app/javascript/i18n.jsx
+++ b/app/javascript/i18n.jsx
@@ -23,7 +23,7 @@ i18next
   .use(HttpApi)
   .init({
     backend: {
-      loadPath: '/api/v1/locales/{{lng}}.json',
+      loadPath: `${process.env.RELATIVE_URL_ROOT}/api/v1/locales/{{lng}}.json`,
     },
     load: 'currentOnly',
     fallbackLng: (locale) => {

--- a/app/javascript/main.jsx
+++ b/app/javascript/main.jsx
@@ -102,6 +102,7 @@ const router = createBrowserRouter(
       <Route path="/rooms/:friendlyId/join" element={<RoomJoin />} />
     </Route>,
   ),
+  { basename: process.env.RELATIVE_URL_ROOT },
 );
 
 const rootElement = document.getElementById('root');

--- a/app/services/setting_getter.rb
+++ b/app/services/setting_getter.rb
@@ -31,8 +31,12 @@ class SettingGetter
                            setting: { name: @setting_name }
                          )
 
-    value = if @setting_name == 'BrandingImage' && setting.image.attached?
-              rails_blob_path setting.image, only_path: true
+    value = if @setting_name == 'BrandingImage'
+              if setting.image.attached?
+                rails_blob_path setting.image, only_path: true
+              else
+                ActionController::Base.helpers.image_path('bbb_logo.png')
+              end
             else
               setting&.value
             end

--- a/config.ru
+++ b/config.ru
@@ -4,5 +4,8 @@
 
 require_relative 'config/environment'
 
-run Rails.application
+map Greenlight::Application.config.relative_url_root do
+  run Rails.application
+end
+
 Rails.application.load_server

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,5 +62,7 @@ module Greenlight
     config.bigbluebutton_endpoint = File.join(config.bigbluebutton_endpoint, '/api/') unless config.bigbluebutton_endpoint.end_with?('api', 'api/')
 
     config.bigbluebutton_secret = ENV.fetch('BIGBLUEBUTTON_SECRET', '8cd8ef52e8e101574e400365b55e11a6')
+
+    config.relative_url_root = ENV.fetch('RELATIVE_URL_ROOT', '/')
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,4 +76,6 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  config.relative_url_root = '/'
 end

--- a/esbuild.dev.mjs
+++ b/esbuild.dev.mjs
@@ -1,0 +1,25 @@
+import * as esbuild from 'esbuild';
+
+const relativeUrlRoot = (process.env.RELATIVE_URL_ROOT || '').replace(/\/$/, '');
+
+await esbuild.build({
+  entryPoints: ['app/javascript/main.jsx'],
+  bundle: true,
+  sourcemap: true,
+  outdir: 'app/assets/builds',
+  loader: {
+    '.png': 'dataurl',
+    '.svg': 'text',
+  },
+  watch: {
+    onRebuild: (error, result) => {
+      if (error) console.error('watch build failed:', error);
+      else console.log('watch build succeeded:', result);
+    },
+  },
+  define: {
+    'process.env.RELATIVE_URL_ROOT': `"${relativeUrlRoot}"`,
+  },
+});
+
+console.log('watch build started');

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -1,0 +1,19 @@
+import * as esbuild from 'esbuild';
+
+const relativeUrlRoot = (process.env.RELATIVE_URL_ROOT || '').replace(/\/$/, '');
+
+await esbuild.build({
+  entryPoints: ['app/javascript/main.jsx'],
+  bundle: true,
+  minify: true,
+  outdir: 'app/assets/builds',
+  loader: {
+    '.png': 'dataurl',
+    '.svg': 'text',
+  },
+  define: {
+    'process.env.RELATIVE_URL_ROOT': `"${relativeUrlRoot}"`,
+  },
+});
+
+console.log('watch build finished');

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "yup": "^0.32.11"
   },
   "scripts": {
-    "build": "esbuild app/javascript/*.* --bundle --outdir=app/assets/builds --loader:.png=dataurl --minify",
+    "build": "node esbuild.mjs",
     "build:css": "sass ./app/assets/stylesheets/application.bootstrap.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules --style compressed",
-    "build:development": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --loader:.png=dataurl",
+    "build:development": "node esbuild.dev.mjs",
     "build:development:css": "sass ./app/assets/stylesheets/application.bootstrap.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules"
   },
   "devDependencies": {

--- a/sample.env
+++ b/sample.env
@@ -61,3 +61,5 @@ REDIS_URL=
 #  [en, ar, fr, es]
 #DEFAULT_LOCALE=en
 
+# Set this if you like to deploy Greenlight on a relative root path other than /
+#RELATIVE_URL_ROOT=/gl


### PR DESCRIPTION
<!---
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for relative URL root path  to Greenlight making it deployable behind a reverse proxy on any root path.


## Testing Steps
- Set the `RELATIVE_URL_ROOT` variable in `.env` to whatever you like e.g. `/gl` (notice the `/` at the beginning).
- Restart Greenlight: on dev run the `dev` script and for production use `khamirtn/greenlight:relative_path_compilation` docker image for testing or if having a production environment run the `start` script.
- The application should be served relatively to your `$RELATIVE_URL_ROOT` e.g. `http://localhost:5050/rooms -> https://localhost:5050/gl/rooms` if `RELATIVE_URL_ROOT=/gl`.
- Assets, images, active storage, localization,... everything should be working.

## Screenshots (if appropriate):
<!--- Please include screenshots that may help to visualize your changes. -->
