### PR TITLE
Client routes helpers: Minor improvements.

### DIFF
--- a/app/controllers/api/v1/admin/invitations_controller.rb
+++ b/app/controllers/api/v1/admin/invitations_controller.rb
@@ -20,6 +20,8 @@ module Api
   module V1
     module Admin
       class InvitationsController < ApiController
+        include ClientRoutable
+
         before_action do
           ensure_authorized('ManageUsers')
         end
@@ -47,7 +49,7 @@ module Api
             UserMailer.with(
               email:,
               name: current_user.name,
-              signup_url: root_url(inviteToken: invitation.token),
+              signup_url: client_invitation_url(inviteToken: invitation.token),
               base_url: request.base_url,
               provider: current_provider
             ).invitation_email.deliver_later

--- a/app/controllers/api/v1/migrations/external_controller.rb
+++ b/app/controllers/api/v1/migrations/external_controller.rb
@@ -22,7 +22,6 @@ module Api
   module V1
     module Migrations
       class ExternalController < ApiController
-        include ClientRoutable
         CHARS = {
           degits: [*'0'..'9'],
           lower_letters: [*'a'..'z'],

--- a/app/controllers/api/v1/reset_password_controller.rb
+++ b/app/controllers/api/v1/reset_password_controller.rb
@@ -38,7 +38,7 @@ module Api
         token = user.generate_reset_token!
 
         UserMailer.with(user:,
-                        reset_url: reset_password_url(token), base_url: request.base_url,
+                        reset_url: client_reset_password_url(token:), base_url: request.base_url,
                         provider: current_provider).reset_password_email.deliver_later
 
         render_data status: :ok

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -68,7 +68,7 @@ module Api
           if smtp_enabled
             token = user.generate_activation_token!
             UserMailer.with(user:,
-                            activation_url: activate_account_url(token), base_url: request.base_url,
+                            activation_url: client_activate_account_url(token:), base_url: request.base_url,
                             provider: current_provider).activate_account_email.deliver_later
           end
 

--- a/app/controllers/api/v1/verify_account_controller.rb
+++ b/app/controllers/api/v1/verify_account_controller.rb
@@ -30,7 +30,7 @@ module Api
         token = @user.generate_activation_token!
 
         UserMailer.with(user: @user,
-                        activation_url: activate_account_url(token), base_url: request.base_url,
+                        activation_url: client_activate_account_url(token:), base_url: request.base_url,
                         provider: current_provider).activate_account_email.deliver_later
 
         render_data status: :ok

--- a/app/controllers/concerns/client_routable.rb
+++ b/app/controllers/concerns/client_routable.rb
@@ -18,14 +18,31 @@
 
 module ClientRoutable
   extend ActiveSupport::Concern
+  include Rails.application.routes.url_helpers
 
-  # Generates a client side activate account url.
-  def activate_account_url(token)
-    "#{root_url}activate_account/#{token}"
+  # Generates a client side activate account URL.
+  def client_activate_account_url(token:, **opts)
+    client_url_for(path: "activate_account/#{token}", **opts)
   end
 
-  # Generates a client side reset password url.
-  def reset_password_url(token)
-    "#{root_url}reset_password/#{token}"
+  # Generates a client side reset password URL.
+  def client_reset_password_url(token:, **opts)
+    client_url_for(path: "reset_password/#{token}", **opts)
+  end
+
+  # Generates a client side room join URL.
+  def client_room_join_url(friendly_id:, **opts)
+    client_url_for(path: "rooms/#{friendly_id}/join", **opts)
+  end
+
+  # Generates a client side invite URL.
+  def client_invitation_url(**opts)
+    client_url_for(**opts)
+  end
+
+  private
+
+  def client_url_for(path: nil, **opts)
+    "#{root_url(**opts.compact)}#{path}"
   end
 end

--- a/app/services/meeting_starter.rb
+++ b/app/services/meeting_starter.rb
@@ -18,6 +18,7 @@
 
 class MeetingStarter
   include Rails.application.routes.url_helpers
+  include ClientRoutable
 
   def initialize(room:, base_url:, current_user:, provider:)
     @room = room
@@ -56,7 +57,7 @@ class MeetingStarter
   private
 
   def computed_options(access_code:)
-    room_url = "#{root_url(host: @base_url)}rooms/#{@room.friendly_id}/join"
+    room_url = client_room_join_url(friendly_id: @room.friendly_id, host: @base_url)
     moderator_message = "#{I18n.t('meeting.moderator_message')}<br>#{room_url}"
     moderator_message += "<br>#{I18n.t('meeting.access_code', code: access_code)}" if access_code.present?
     {


### PR DESCRIPTION
## Description
This PR introduces some improvements (namespacing, refactoring) to the current `ClientRoutable` concern mainly to make the source of truth for all client routes helpers on the backend while being as closer as possible to the rails routes helpers API.
So, one should be able to work with the `ClientRoutable` with the same API of the `Rails.application.routes.url_helpers`.

> `client_` prefix was added indicate that the used route helper is for a client side route and to avoid conflicts with the rails routes helpers.

## Testing Steps
- Set the `RELATIVE_URL_ROOT` variable in `.env` to whatever you like e.g. `/gl`.
- Restart Greenlight: on dev run the `dev` script and for production use `khamirtn/greenlight:relative_path_fixes` docker image for testing or if having a production environment run the `start` script.
- The application should be served relatively to your `$RELATIVE_URL_ROOT` e.g. `http://localhost:5050/rooms becomes https://localhost:5050/gl/rooms` if `RELATIVE_URL_ROOT=/gl`.
- Everything on the application should work as expected and the issues mentioned above should not be observed.
- Try different `RELATIVE_URL_ROOT` and test the application.