### PR TITLE
Updated docs links.

### DIFF
--- a/app/javascript/components/home/NavbarSignedIn.jsx
+++ b/app/javascript/components/home/NavbarSignedIn.jsx
@@ -61,7 +61,7 @@ export default function NavbarSignedIn({ currentUser }) {
             <IdentificationIcon className="hi-s me-3" />
             {t('user.profile.profile')}
           </Nav.Link>
-          <Nav.Link eventKey={2} href="https://docs.bigbluebutton.org/greenlight/gl-overview.html">
+          <Nav.Link eventKey={2} href="https://docs.bigbluebutton.org/greenlight/v3/install">
             <QuestionMarkCircleIcon className="hi-s me-3" />
             {t('help_center')}
           </Nav.Link>
@@ -103,7 +103,7 @@ export default function NavbarSignedIn({ currentUser }) {
             <IdentificationIcon className="hi-s me-3" />
             { t('user.profile.profile') }
           </NavDropdown.Item>
-          <NavDropdown.Item href="https://docs.bigbluebutton.org/greenlight/gl-overview.html">
+          <NavDropdown.Item href="https://docs.bigbluebutton.org/greenlight/v3/install">
             <QuestionMarkCircleIcon className="hi-s me-3" />
             {t('help_center')}
           </NavDropdown.Item>

--- a/app/javascript/components/shared_components/Footer.jsx
+++ b/app/javascript/components/shared_components/Footer.jsx
@@ -28,7 +28,7 @@ export default function Footer() {
   return (
     <footer id="footer" className="footer background-whitesmoke text-center">
       <Container id="footer-container" className="py-3">
-        <a href="https://docs.bigbluebutton.org/greenlight_v3/gl3-install.html" target="_blank" rel="noreferrer">Greenlight</a>
+        <a href="https://docs.bigbluebutton.org/greenlight/v3/install" target="_blank" rel="noreferrer">Greenlight</a>
         <span className="text-muted"> {env?.VERSION_TAG} </span>
         { links?.Terms
           && (

--- a/gl-install.sh
+++ b/gl-install.sh
@@ -18,7 +18,7 @@
 #    https://www.bigbluebutton.org/.
 #
 # This gl-install.sh script automates many of the installation and configuration
-# steps at https://docs.bigbluebutton.org/greenlight_v3/gl3-install.html
+# steps at https://docs.bigbluebutton.org/greenlight/v3/install
 #
 #
 #  Examples
@@ -76,7 +76,7 @@ Sample options for setup a Greenlight 3.x server with pre-owned SSL certificates
 SUPPORT:
          Community: https://groups.google.com/g/bigbluebutton-greenlight
          Source: https://github.com/bigbluebutton/greenlight-run
-         Docs: https://docs.bigbluebutton.org/greenlight_v3/gl3-install.html
+         Docs: https://docs.bigbluebutton.org/greenlight/v3/install
 
 HERE
 }
@@ -359,7 +359,7 @@ check_host() {
 
 # This function will install the latest official version of greenlight-v3 and set it as the hosting Bigbluebutton default frontend or update greenlight-v3 if installed.
 # Greenlight is a simple to use Bigbluebutton room manager that offers a set of features useful to online workloads especially virtual schooling.
-# https://docs.bigbluebutton.org/greenlight/gl-overview.html
+# https://docs.bigbluebutton.org/greenlight/v3/install
 install_greenlight_v3(){
   check_root
   install_docker


### PR DESCRIPTION
There was a major upgrade in https://docs.bigbluebutton.org that changed the docs URLs for Greenlight 3.
This PR updates the links to use the new version.