### PR TITLE
add `inlang` to make the contribution of translations easier

### DIFF
--- a/app/assets/locales/cs.json
+++ b/app/assets/locales/cs.json
@@ -246,7 +246,7 @@
         "default_role_description": "Výchozí role je přidělena nově vytvořeným uživatelům",
         "registration_method": "Metoda registrace",
         "registration_method_description": "Nastavit způsob registrace uživatelů",
-        "registration_methods" : {
+        "registration_methods": {
           "open": "Otevřená registrace",
           "invite": "Registrace na pozvánku",
           "approval": "Schvalování registrace"

--- a/app/assets/locales/de.json
+++ b/app/assets/locales/de.json
@@ -286,7 +286,7 @@
         "default_role_description": "Standard-Rolle, die neuen Nutzer:innen zugeteilt wird",
         "registration_method": "Registrierungs-Methode",
         "registration_method_description": "Registrierungs-Methoden ändern",
-        "registration_methods" : {
+        "registration_methods": {
           "open": "Offene Registrierung",
           "invite": "Per Einladung teilnehmen",
           "approval": "Zulassen/Ablehnen"

--- a/app/assets/locales/el.json
+++ b/app/assets/locales/el.json
@@ -286,7 +286,7 @@
         "default_role_description": "Ο προεπιλεγμένος ρόλος που αποδίδεται σε νέους χρήστες",
         "registration_method": "Μέθοδος εγγραφής",
         "registration_method_description": "Αλλαγή του τρόπου εγγραφής των χρηστών στον ιστότοπο",
-        "registration_methods" : {
+        "registration_methods": {
           "open": "Ενεργοποίηση εγγραφών",
           "invite": "Συμμετοχή με πρόσκληση",
           "approval": "Έγκριση/Απόρριψη"

--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -286,7 +286,7 @@
         "default_role_description": "The default role to be assigned to newly created users",
         "registration_method": "Registration Method",
         "registration_method_description": "Change the way that users register to the website",
-        "registration_methods" : {
+        "registration_methods": {
           "open": "Open Registration",
           "invite": "Join by Invitation",
           "approval": "Approve/Decline"

--- a/app/assets/locales/fa.json
+++ b/app/assets/locales/fa.json
@@ -248,7 +248,7 @@
         "default_role_description": "نقش پیش‌فرضی که به کاربران تازه ایجاد شده اختصاص داده می‌شود",
         "registration_method": "روش ثبت نام",
         "registration_method_description": "نحوه ثبت نام کاربران در وب‌سایت را تغییر دهید",
-        "registration_methods" : {
+        "registration_methods": {
           "open": "باز کردن ثبت نام",
           "invite": "پیوستن با دعوتنامه",
           "approval": "تایید/رد کردن"

--- a/app/assets/locales/fr.json
+++ b/app/assets/locales/fr.json
@@ -286,7 +286,7 @@
         "default_role_description": "Le rôle par défaut a été attribué aux nouveaux utilisateurs",
         "registration_method": "Mode d'inscription",
         "registration_method_description": "Modifier la façon dont les utilisateurs s'inscrivent  sur le site web",
-        "registration_methods" : {
+        "registration_methods": {
           "open": "Inscription libre",
           "invite": "Rejoindre sur invitation",
           "approval": "Approuver/Refuser"
@@ -423,7 +423,8 @@
       },
       "session": {
         "invalid_credentials": "Le nom d'utilisateur·rice ou le mot de passe sont incorrects. Veuillez vérifier vos identifiants et essayer à nouveau."
-      }
+      },
+      "file_upload_error": "Le fichier ne peut pas être téléchargé."
     }
   },
   "global_error_page": {
@@ -480,9 +481,9 @@
           "required": "Veuillez saisir le nombre limite pour la salle",
           "min": "Le minimum autorisé est 0",
           "max": "Le maximum autorisé est 100"
-        }, 
+        },
         "type": {
-          "error": "Vous devez stipuler un nombre" 
+          "error": "Vous devez stipuler un nombre"
         }
       },
       "room": {
@@ -490,7 +491,7 @@
           "required": "Veuillez saisir le nom de la salle",
           "min": "Le nom doit comporter 2 caractères au minimum "
         }
-      }, 
+      },
       "url": {
         "invalid": "URL non valide"
       }

--- a/app/assets/locales/hu.json
+++ b/app/assets/locales/hu.json
@@ -286,7 +286,7 @@
         "default_role_description": "A frissen létrehozott felhasználókhoz rendelt alapértelmezett szerepkör",
         "registration_method": "Regisztrációs mód",
         "registration_method_description": "A felhasználók regisztrációs módjának módosítása",
-        "registration_methods" : {
+        "registration_methods": {
           "open": "Nyílt regisztráció",
           "invite": "Csatlakozás meghívással",
           "approval": "Engedélyezés/elutasítás"

--- a/app/assets/locales/ja.json
+++ b/app/assets/locales/ja.json
@@ -286,7 +286,7 @@
         "default_role_description": "新しく作成されたユーザーに自動的に割り当てられる役割です",
         "registration_method": "登録方法",
         "registration_method_description": "ユーザーがこのサイトに登録する方法を変更します",
-        "registration_methods" : {
+        "registration_methods": {
           "open": "誰でも自由に登録",
           "invite": "招待制",
           "approval": "承認制"

--- a/app/assets/locales/ru.json
+++ b/app/assets/locales/ru.json
@@ -286,7 +286,7 @@
         "default_role_description": "Роль, по умолчанию назначаемая новым пользователям",
         "registration_method": "Метод регистрации",
         "registration_method_description": "Изменение способа регистрации пользователей на сайте",
-        "registration_methods" : {
+        "registration_methods": {
           "open": "Открытая регистрация",
           "invite": "Вход по приглашению",
           "approval": "Одобрить/отклонить"

--- a/app/assets/locales/tr.json
+++ b/app/assets/locales/tr.json
@@ -286,7 +286,7 @@
         "default_role_description": "Yeni eklenen kullanıcılara atanacak varsayılan rol",
         "registration_method": "Hesap açma yöntemi",
         "registration_method_description": "Kullanıcıların web sitesinde hesap açma yöntemini değiştirin",
-        "registration_methods" : {
+        "registration_methods": {
           "open": "Serbest hesap açma",
           "invite": "Çağrı ile katılma",
           "approval": "Onayla/Reddet"
@@ -487,7 +487,7 @@
           "required": "Lütfen bir oda adı yazın.",
           "min": "Ad en az 2 karakter uzunluğunda olabilir"
         }
-      }, 
+      },
       "url": {
         "invalid": "Adres geçersiz"
       }

--- a/app/assets/locales/uk.json
+++ b/app/assets/locales/uk.json
@@ -286,7 +286,7 @@
         "default_role_description": "Роль, що автоматично буде надаватись новоствореним користувачам",
         "registration_method": "Метод реєстрації",
         "registration_method_description": "Змінити спосіб реєстрації користувачів на сайті",
-        "registration_methods" : {
+        "registration_methods": {
           "open": "Відкрита раєстрація",
           "invite": "Приєднання за запрошенням",
           "approval": "Прийняти/Відхилити"

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,26 @@
+/**
+ * @type { import("@inlang/core/config").DefineConfig }
+ */
+export async function defineConfig(env) {
+  const plugin = await env.$import(
+    "https://cdn.jsdelivr.net/gh/samuelstroschein/inlang-plugin-json@1/dist/index.js"
+  );
+
+  const { standardLintRules } = await env.$import(
+    "https://cdn.jsdelivr.net/gh/inlang/standard-lint-rules@1/dist/index.js"
+  );
+
+  const pluginConfig = {
+    pathPattern: "./app/assets/locales/{language}.json",
+  };
+
+  return {
+    referenceLanguage: "en",
+    languages: await plugin.getLanguages({ ...env, pluginConfig }),
+    readResources: (args) => plugin.readResources({ ...args, ...env, pluginConfig }),
+    writeResources: (args) => plugin.writeResources({ ...args, ...env, pluginConfig }),
+    lint: {
+      rules: [standardLintRules()],
+    },
+  };
+}


### PR DESCRIPTION
Let me know what changes you request for merging this PR.

### Description
This pull request adds the possibility for contributors and translators to manage translations in a UI instead of files with no overhead for the maintainers.

To get a UI for translations contained in this repository, an [inlang.config.js](https://inlang.com/documentation/config) has been created at the root of the repository. The json files were cleaned and I added a missing `fr` translation.

### Preview
The changes of this PR and a live instance of the editor can be previewed with the following link https://inlang.com/editor/github.com/NilsJacobsen/greenlight. Note: This link should be changed to point to greenlight instead of NilsJacobsen after this PR has been merged.

### Limitations
**Certain actions are slow**
Inlang is running entirely on git, giving tremendous CI/CD and contribution power to localization (and potentially other verticals -> [the next git](https://www.youtube.com/watch?v=vJ3jGgCrz2I)). That means that the whole greenlight repo is cloned into the browser which makes certain actions like the initial load and pushing changes slow. Those limitations will be fixed with future releases and require no input from greenlight.

![pika-1680686287719-1x](https://user-images.githubusercontent.com/58360188/232016041-ec0c3da3-94a9-4492-85dd-d8478c66d945.jpeg)

### Badge
If you want to show the contributor the status of the translations, you could add a badge to your readme.
```
[![translation badge](https://inlang.com/badge?url=github.com/bigbluebutton/greenlight)](https://inlang.com/editor/github.com/bigbluebutton/greenlight?ref=badge)
```

Preview the messages on https://inlang.com/github.com/NilsJacobsen/greenlight .