### PR TITLE
fix(join meeting): Moderator are authorized to start the meeting

### DIFF
--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -54,7 +54,7 @@ module Api
           settings: %w[glRequireAuthentication glViewerAccessCode glModeratorAccessCode glAnyoneCanStart glAnyoneJoinAsModerator]
         ).call
 
-        return render_error status: :unauthorized if !current_user && settings['glRequireAuthentication'] == 'true'
+        return render_error status: :unauthorized if unauthorized_access?(settings)
 
         bbb_role = infer_bbb_role(mod_code: settings['glModeratorAccessCode'],
                                   viewer_code: settings['glViewerAccessCode'],
@@ -66,7 +66,8 @@ module Api
           status: BigBlueButtonApi.new(provider: current_provider).meeting_running?(room: @room)
         }
 
-        if !data[:status] && settings['glAnyoneCanStart'] == 'true' # Meeting isnt running and anyoneCanStart setting is enabled
+        # Starts meeting if meeting is not running and glAnyoneCanStart is enabled or user is a moderator
+        if !data[:status] && authorized_to_start_meeting?(settings, bbb_role)
           begin
             MeetingStarter.new(room: @room, base_url: request.base_url, current_user:, provider: current_provider).call
           rescue BigBlueButton::BigBlueButtonException => e
@@ -120,6 +121,14 @@ module Api
           access_code_validator(access_code: mod_code) ||
           (anyone_join_as_mod && viewer_code.blank? && mod_code.blank?) ||
           (anyone_join_as_mod && (access_code_validator(access_code: mod_code) || access_code_validator(access_code: viewer_code)))
+      end
+
+      def authorized_to_start_meeting?(settings, bbb_role)
+        settings['glAnyoneCanStart'] == 'true' || bbb_role == 'Moderator'
+      end
+
+      def unauthorized_access?(settings)
+        !current_user && settings['glRequireAuthentication'] == 'true'
       end
 
       def access_code_validator(access_code:)

--- a/spec/controllers/meetings_controller_spec.rb
+++ b/spec/controllers/meetings_controller_spec.rb
@@ -149,11 +149,12 @@ RSpec.describe Api::V1::MeetingsController, type: :controller do
       expect(JSON.parse(response.body)['data']).to eq({ 'joinUrl' => 'JOIN_URL', 'status' => true })
     end
 
-    it 'returns status false if the meeting is NOT running' do
+    it 'returns status false if the meeting is NOT running and the user is NOT authorized to start the meeting' do
       allow_any_instance_of(BigBlueButtonApi).to receive(:meeting_running?).and_return(false)
       expect_any_instance_of(BigBlueButtonApi).not_to receive(:join_meeting)
 
-      post :status, params: { friendly_id: room.friendly_id, name: user.name }
+      post :status, params: { friendly_id: test_room.friendly_id, name: user.name }
+
       expect(response).to have_http_status(:ok)
       expect(JSON.parse(response.body)['data']).to eq({ 'status' => false })
     end
@@ -182,6 +183,16 @@ RSpec.describe Api::V1::MeetingsController, type: :controller do
         .with(room: test_room, name: user.name, avatar_url:, role: 'Viewer')
 
       post :status, params: { friendly_id: test_room.friendly_id, name: user.name }
+    end
+
+    it 'starts the meeting if the user is a moderator' do
+      allow_any_instance_of(BigBlueButtonApi).to receive(:meeting_running?).and_return(false)
+      expect_any_instance_of(MeetingStarter).to receive(:call)
+
+      post :status, params: { friendly_id: room.friendly_id, name: user.name }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['data']).to eq({ 'joinUrl' => 'JOIN_URL', 'status' => true })
     end
 
     context 'user is joining a shared room' do


### PR DESCRIPTION
Moderators were not authorized to start a meeting. 
Add the logic to the MeetingsController.
Add the specs.
Fixes #5049 (and few threads on the google group)