### PR TITLE
fix(keycloak): user redirection on KC login

### DIFF
--- a/app/controllers/external_controller.rb
+++ b/app/controllers/external_controller.rb
@@ -69,7 +69,7 @@ class ExternalController < ApplicationController
     cookies.delete(:location)
     return redirect_to redirect_location if redirect_location&.match?('\A\/rooms\/\w{3}-\w{3}-\w{3}-\w{3}\/join\z')
 
-    redirect_to '/rooms'
+    redirect_to '/'
   rescue StandardError => e
     Rails.logger.error("Error during authentication: #{e}")
     redirect_to '/?error=SignupError'

--- a/spec/controllers/external_controller_spec.rb
+++ b/spec/controllers/external_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ExternalController, type: :controller do
       get :create_user, params: { provider: 'openid_connect' }
 
       expect(session[:session_token]).to eq(User.find_by(email: OmniAuth.config.mock_auth[:openid_connect][:info][:email]).session_token)
-      expect(response).to redirect_to('/rooms')
+      expect(response).to redirect_to('/')
     end
 
     it 'assigns the User role to the user' do
@@ -95,7 +95,7 @@ RSpec.describe ExternalController, type: :controller do
         }
         get :create_user, params: { provider: 'openid_connect' }
 
-        expect(response).to redirect_to('/rooms')
+        expect(response).to redirect_to('/')
       end
 
       it 'doesnt redirect if it doesnt match a room joins format check 2' do
@@ -107,7 +107,7 @@ RSpec.describe ExternalController, type: :controller do
         }
         get :create_user, params: { provider: 'openid_connect' }
 
-        expect(response).to redirect_to('/rooms')
+        expect(response).to redirect_to('/')
       end
 
       it 'doesnt redirect if it doesnt match a room joins format check 3' do
@@ -119,7 +119,7 @@ RSpec.describe ExternalController, type: :controller do
         }
         get :create_user, params: { provider: 'openid_connect' }
 
-        expect(response).to redirect_to('/rooms')
+        expect(response).to redirect_to('/')
       end
 
       it 'deletes the cookie after reading' do
@@ -215,7 +215,7 @@ RSpec.describe ExternalController, type: :controller do
           create(:user, external_id: OmniAuth.config.mock_auth[:openid_connect][:uid])
 
           expect { get :create_user, params: { provider: 'openid_connect' } }.not_to raise_error
-          expect(response).to redirect_to('/rooms')
+          expect(response).to redirect_to('/')
         end
 
         it 'returns an InviteInvalid error if no invite is passed' do


### PR DESCRIPTION
Fixes #5170 

Upon login via KC, the user gets redirected to '/rooms'
This causes an issue if the user do not have the 'Create Room' permission.
Change the redirect to from '/rooms' to '/' - users without 'Create Room' permission are redirected to '/home' and user with the permission are redirected to '/rooms'.