### PR TITLE
fix(shared rooms): shared rooms should be accessible to users without CreateRoom permission

### DIFF
--- a/app/controllers/api/v1/recordings_controller.rb
+++ b/app/controllers/api/v1/recordings_controller.rb
@@ -26,6 +26,9 @@ module Api
       before_action only: %i[update update_visibility] do
         ensure_authorized(%w[ManageRecordings SharedRoom], record_id: params[:id])
       end
+      before_action only: %i[index recordings_count] do
+        ensure_authorized(%w[CreateRoom SharedRoom], record_id: params[:id])
+      end
 
       # GET /api/v1/recordings.json
       # Returns all of the current_user's recordings

--- a/app/controllers/api/v1/recordings_controller.rb
+++ b/app/controllers/api/v1/recordings_controller.rb
@@ -26,9 +26,6 @@ module Api
       before_action only: %i[update update_visibility] do
         ensure_authorized(%w[ManageRecordings SharedRoom], record_id: params[:id])
       end
-      before_action only: %i[index recordings_count] do
-        ensure_authorized('CreateRoom')
-      end
 
       # GET /api/v1/recordings.json
       # Returns all of the current_user's recordings

--- a/app/controllers/api/v1/recordings_controller.rb
+++ b/app/controllers/api/v1/recordings_controller.rb
@@ -26,9 +26,6 @@ module Api
       before_action only: %i[update update_visibility] do
         ensure_authorized(%w[ManageRecordings SharedRoom], record_id: params[:id])
       end
-      before_action only: %i[index recordings_count] do
-        ensure_authorized(%w[CreateRoom SharedRoom], record_id: params[:id])
-      end
 
       # GET /api/v1/recordings.json
       # Returns all of the current_user's recordings

--- a/app/controllers/api/v1/rooms_configurations_controller.rb
+++ b/app/controllers/api/v1/rooms_configurations_controller.rb
@@ -20,7 +20,7 @@ module Api
   module V1
     class RoomsConfigurationsController < ApiController
       before_action only: %i[index] do
-        ensure_authorized(%w[CreateRoom ManageSiteSettings ManageRoles ManageRooms], friendly_id: params[:friendly_id])
+        ensure_authorized(%w[CreateRoom SharedRoom ManageSiteSettings ManageRoles ManageRooms], friendly_id: params[:friendly_id])
       end
 
       # GET /api/v1/rooms_configurations.json

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -23,8 +23,8 @@ module Api
 
       before_action :find_room, only: %i[show update destroy recordings recordings_processing purge_presentation public_show]
 
-      before_action only: %i[create] do
-        ensure_authorized('CreateRoom')
+      before_action only: %i[create index] do
+        ensure_authorized(%w[CreateRoom SharedRoom], friendly_id: params[:friendly_id])
       end
       before_action only: %i[create] do
         ensure_authorized('ManageUsers', user_id: room_params[:user_id])

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -23,7 +23,7 @@ module Api
 
       before_action :find_room, only: %i[show update destroy recordings recordings_processing purge_presentation public_show]
 
-      before_action only: %i[create index] do
+      before_action only: %i[create] do
         ensure_authorized('CreateRoom')
       end
       before_action only: %i[create] do

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -23,8 +23,8 @@ module Api
 
       before_action :find_room, only: %i[show update destroy recordings recordings_processing purge_presentation public_show]
 
-      before_action only: %i[create index] do
-        ensure_authorized(%w[CreateRoom SharedRoom], friendly_id: params[:friendly_id])
+      before_action only: %i[create] do
+        ensure_authorized('CreateRoom')
       end
       before_action only: %i[create] do
         ensure_authorized('ManageUsers', user_id: room_params[:user_id])

--- a/app/javascript/components/home/HomePage.jsx
+++ b/app/javascript/components/home/HomePage.jsx
@@ -41,16 +41,7 @@ export default function HomePage() {
       return;
     }
 
-    // If the user is signed in and has CreateRoom permission or shared rooms, navigate to '/rooms'.
-    if (currentUser.signed_in && (currentUser.permissions.CreateRoom === 'true' || currentUser.sharedRooms)) {
-      navigate('/rooms');
-      return;
-    }
-
-    // If the user is signed in and lacks both CreateRoom permission and shared rooms, navigate to '/home'.
-    if (currentUser.signed_in && currentUser.permissions.CreateRoom === 'false') {
-      navigate('/home');
-    }
+    navigate('/home');
   }, [currentUser.signed_in]);
 
   useEffect(() => {

--- a/app/javascript/components/home/HomePage.jsx
+++ b/app/javascript/components/home/HomePage.jsx
@@ -41,14 +41,8 @@ export default function HomePage() {
       return;
     }
 
-    // If the user is signed in and has CreateRoom permission, navigate to '/rooms'.
-    if (currentUser.signed_in && currentUser.permissions.CreateRoom === 'true') {
-      navigate('/rooms');
-      return;
-    }
-
-    // If the user is signed in, lacks CreateRoom permission, but has shared rooms, navigate to '/rooms'.
-    if (currentUser.signed_in && currentUser.permissions.CreateRoom === 'false' && currentUser.sharedRooms) {
+    // If the user is signed in and has CreateRoom permission or shared rooms, navigate to '/rooms'.
+    if (currentUser.signed_in && (currentUser.permissions.CreateRoom === 'true' || currentUser.sharedRooms)) {
       navigate('/rooms');
       return;
     }

--- a/app/javascript/components/home/HomePage.jsx
+++ b/app/javascript/components/home/HomePage.jsx
@@ -34,18 +34,30 @@ export default function HomePage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const error = searchParams.get('error');
 
-  // Redirects the user to the proper page based on signed in status and CreateRoom permission
-  useEffect(
-    () => {
-      // Todo: Use PermissionChecker.
-      if (!currentUser.stateChanging && currentUser.signed_in && currentUser.permissions.CreateRoom === 'true') {
-        navigate('/rooms');
-      } else if (!currentUser.stateChanging && currentUser.signed_in && currentUser.permissions.CreateRoom === 'false') {
-        navigate('/home');
-      }
-    },
-    [currentUser.signed_in],
-  );
+  // Hook to redirect users based on their sign-in status and CreateRoom permission.
+  useEffect(() => {
+    // Ensure the user's state is not changing before proceeding.
+    if (currentUser.stateChanging) {
+      return;
+    }
+
+    // If the user is signed in and has CreateRoom permission, navigate to '/rooms'.
+    if (currentUser.signed_in && currentUser.permissions.CreateRoom === 'true') {
+      navigate('/rooms');
+      return;
+    }
+
+    // If the user is signed in, lacks CreateRoom permission, but has shared rooms, navigate to '/rooms'.
+    if (currentUser.signed_in && currentUser.permissions.CreateRoom === 'false' && currentUser.sharedRooms) {
+      navigate('/rooms');
+      return;
+    }
+
+    // If the user is signed in and lacks both CreateRoom permission and shared rooms, navigate to '/home'.
+    if (currentUser.signed_in && currentUser.permissions.CreateRoom === 'false') {
+      navigate('/home');
+    }
+  }, [currentUser.signed_in]);
 
   useEffect(() => {
     switch (error) {

--- a/app/javascript/components/rooms/CantCreateRoom.jsx
+++ b/app/javascript/components/rooms/CantCreateRoom.jsx
@@ -20,7 +20,6 @@ import Button from 'react-bootstrap/Button';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
-// This page is shown if the user does NOT have the CreateRoom permission
 export default function CantCreateRoom() {
   const { t } = useTranslation();
   const navigate = useNavigate();

--- a/app/javascript/components/rooms/Rooms.jsx
+++ b/app/javascript/components/rooms/Rooms.jsx
@@ -23,10 +23,19 @@ import RoomsList from './RoomsList';
 import UserRecordings from '../recordings/UserRecordings';
 import RecordingsCountTab from '../recordings/RecordingsCountTab';
 import useRecordingsCount from '../../hooks/queries/recordings/useRecordingsCount';
+import CantCreateRoom from './CantCreateRoom';
+import { useAuth } from '../../contexts/auth/AuthProvider';
 
 export default function Rooms() {
   const { data: recordingsCount } = useRecordingsCount();
   const { t } = useTranslation();
+  const currentUser = useAuth();
+
+  // This CantCreateRoom is rendered if the user does NOT have the CreateRoom permission AND does not have any shared room
+  if (currentUser?.permissions?.CreateRoom === 'false' && !currentUser?.sharedRooms) {
+    return <CantCreateRoom />;
+  }
+
   return (
     <Tabs className="wide-white pt-5" defaultActiveKey="rooms" unmountOnExit>
       <Tab className="background-whitesmoke" eventKey="rooms" title={t('room.rooms')}>

--- a/app/javascript/components/rooms/RoomsList.jsx
+++ b/app/javascript/components/rooms/RoomsList.jsx
@@ -47,17 +47,22 @@ export default function RoomsList() {
         <div>
           <SearchBar searchInput={searchInput} id="rooms-search" setSearchInput={setSearchInput} />
         </div>
-        <Modal
-          modalButton={(
-            <Button
-              variant="brand"
-              className="ms-auto me-xxl-1"
-            >{t('room.add_new_room')}
-            </Button>
-          )}
-          title={t('room.create_new_room')}
-          body={<CreateRoomForm mutation={mutationWrapper} userId={currentUser.id} />}
-        />
+        {
+          currentUser.permissions.CreateRoom === 'true'
+          && (
+          <Modal
+            modalButton={(
+              <Button
+                variant="brand"
+                className="ms-auto me-xxl-1"
+              >{t('room.add_new_room')}
+              </Button>
+            )}
+            title={t('room.create_new_room')}
+            body={<CreateRoomForm mutation={mutationWrapper} userId={currentUser.id} />}
+          />
+          )
+        }
       </Stack>
       <Row className="g-4 mt-4">
         {

--- a/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
+++ b/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
@@ -39,7 +39,7 @@ export default function RoomSettings() {
   const currentUser = useAuth();
   const { friendlyId } = useParams();
   const roomSetting = useRoomSettings(friendlyId);
-  const { data: roomConfigs } = useRoomConfigs();
+  const { data: roomConfigs } = useRoomConfigs(friendlyId);
   const { data: room } = useRoom(friendlyId);
 
   const updateMutationWrapper = () => useUpdateRoomSetting(friendlyId);

--- a/app/javascript/components/shared_components/Header.jsx
+++ b/app/javascript/components/shared_components/Header.jsx
@@ -28,9 +28,11 @@ import NavbarNotSignedIn from '../home/NavbarNotSignedIn';
 export default function Header() {
   const currentUser = useAuth();
 
-  let homePath = '/';
-  if (currentUser?.permissions?.CreateRoom === 'false') {
-    homePath = '/home';
+  let homePath = '';
+  if (currentUser?.permissions?.CreateRoom === 'true' || currentUser?.sharedRooms) {
+    homePath = '/rooms';
+  } else {
+    homePath = 'home';
   }
 
   return (

--- a/app/javascript/components/shared_components/Header.jsx
+++ b/app/javascript/components/shared_components/Header.jsx
@@ -28,17 +28,10 @@ import NavbarNotSignedIn from '../home/NavbarNotSignedIn';
 export default function Header() {
   const currentUser = useAuth();
 
-  let homePath = '';
-  if (currentUser?.permissions?.CreateRoom === 'true' || currentUser?.sharedRooms) {
-    homePath = '/rooms';
-  } else {
-    homePath = 'home';
-  }
-
   return (
     <Navbar collapseOnSelect id="navbar" expand="sm">
       <Container className="ps-0">
-        <Navbar.Brand as={Link} to={homePath} className="ps-2">
+        <Navbar.Brand as={Link} to="/rooms" className="ps-2">
           <Logo size="small" />
         </Navbar.Brand>
         {

--- a/app/javascript/components/shared_components/Header.jsx
+++ b/app/javascript/components/shared_components/Header.jsx
@@ -31,7 +31,7 @@ export default function Header() {
   return (
     <Navbar collapseOnSelect id="navbar" expand="sm">
       <Container className="ps-0">
-        <Navbar.Brand as={Link} to="/rooms" className="ps-2">
+        <Navbar.Brand as={Link} to="/" className="ps-2">
           <Logo size="small" />
         </Navbar.Brand>
         {

--- a/app/javascript/contexts/auth/AuthProvider.jsx
+++ b/app/javascript/contexts/auth/AuthProvider.jsx
@@ -46,6 +46,7 @@ export default function AuthProvider({ children }) {
     external_account: currentUser?.external_account,
     stateChanging: false,
     isSuperAdmin: currentUser?.super_admin,
+    sharedRooms: currentUser?.shared_rooms,
   };
 
   const memoizedCurrentUser = useMemo(() => user, [user]);

--- a/app/javascript/hooks/mutations/shared_accesses/useUnshareRoom.jsx
+++ b/app/javascript/hooks/mutations/shared_accesses/useUnshareRoom.jsx
@@ -32,7 +32,7 @@ export default function useUnshareRoom(friendlyId) {
       onSuccess: () => {
         queryClient.invalidateQueries('getSharedUsers');
         queryClient.invalidateQueries(['getRoom', { friendlyId }]);
-        navigate('/rooms');
+        navigate('/');
         toast.success(t('toast.success.room.room_unshared'));
       },
       onError: () => {

--- a/app/javascript/hooks/queries/rooms/useRoomConfigs.jsx
+++ b/app/javascript/hooks/queries/rooms/useRoomConfigs.jsx
@@ -17,9 +17,12 @@
 import { useQuery } from 'react-query';
 import axios from '../../../helpers/Axios';
 
-export default function useRoomConfigs() {
+export default function useRoomConfigs(friendlyId = null) {
   return useQuery(
-    'getRoomsConfigs',
-    () => axios.get('/rooms_configurations.json').then((resp) => resp.data.data),
+    ['getRoomsConfigs', friendlyId],
+    () => {
+      console.log('firing query');
+      return axios.get('/rooms_configurations.json', { params: { friendly_id: friendlyId } }).then((resp) => resp.data.data);
+    },
   );
 }

--- a/app/javascript/main.jsx
+++ b/app/javascript/main.jsx
@@ -41,7 +41,6 @@ import Roles from './components/admin/roles/Roles';
 import ResetPassword from './components/users/password_management/ResetPassword';
 import EditUser from './components/admin/manage_users/EditUser';
 import EditRole from './components/admin/roles/EditRole';
-import CantCreateRoom from './components/rooms/CantCreateRoom';
 import ActivateAccount from './components/users/account_activation/ActivateAccount';
 import VerifyAccount from './components/users/account_activation/VerifyAccount';
 import AdminPanel from './components/admin/AdminPanel';

--- a/app/javascript/main.jsx
+++ b/app/javascript/main.jsx
@@ -86,7 +86,6 @@ const router = createBrowserRouter(
 
         <Route path="/rooms" element={<Rooms />} />
         <Route path="/rooms/:friendlyId" element={<Room />} />
-        <Route path="/home" element={<CantCreateRoom />} />
 
         <Route path="/admin" element={<AdminPanel />} />
         <Route path="/admin/users" element={<ManageUsers />} />

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -40,6 +40,6 @@ class CurrentUserSerializer < UserSerializer
 
   # Returns true if the user has any shared rooms
   def shared_rooms
-    SharedAccess.where(user_id: object.id).any?
+    object.shared_rooms.any?
   end
 end

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -17,7 +17,7 @@
 # frozen_string_literal: true
 
 class CurrentUserSerializer < UserSerializer
-  attributes :signed_in, :permissions, :status, :external_account, :super_admin
+  attributes :signed_in, :permissions, :status, :external_account, :super_admin, :shared_rooms
 
   def signed_in
     true
@@ -36,5 +36,10 @@ class CurrentUserSerializer < UserSerializer
 
   def super_admin
     object.super_admin?
+  end
+
+  # Returns true if the user has any shared rooms
+  def shared_rooms
+    SharedAccess.where(user_id: object.id).any?
   end
 end


### PR DESCRIPTION
Problem:
User without `CreateRoom` permission do not have access to `SharedRooms`.
This is a problem because in some cases, for example, the teachers do not have the `CreateRoom` permission - the System Admin will create the rooms for the teachers and share them instead.
GLv3 frontend will render the 'EnterURL' page if the user does not have the 'CreateRoom' permission.

Solution:

- Return a sharedRooms attribute with the currentUser object to the frontend.
- Add the ShareRoom permission in the PermissionCheck for RoomsConfig endpoint.
- Remove the '/home' page

How to Test:
This is a sizeable PR for production, it needs to be tested thoroughly. 

- Create an admin
- Create a user without any permissions
- Share a room with the user
- Delete the share access via the user