### PR TITLE
Fixed bad OmniAuth flow when deployed on a subdirectory (Closes #5176).

### DIFF
--- a/app/controllers/concerns/client_routable.rb
+++ b/app/controllers/concerns/client_routable.rb
@@ -28,4 +28,9 @@ module ClientRoutable
   def reset_password_url(token)
     "#{root_url}reset_password/#{token}"
   end
+
+  # Generates a client side pending url.
+  def pending_path
+    "#{root_path}pending"
+  end
 end

--- a/app/javascript/components/home/AuthButtons.jsx
+++ b/app/javascript/components/home/AuthButtons.jsx
@@ -42,7 +42,7 @@ export default function AuthButtons({ direction }) {
 
   if (env?.OPENID_CONNECT) {
     return (
-      <Form action="/auth/openid_connect" method="POST" data-turbo="false">
+      <Form action={process.env.OMNIAUTH_PATH} method="POST" data-turbo="false">
         <input type="hidden" name="authenticity_token" value={document.querySelector('meta[name="csrf-token"]').content} />
         <Stack direction={direction} gap={2}>
           <Button variant="brand-outline-color" className="btn" type="submit">{t('authentication.sign_up')}</Button>

--- a/app/javascript/components/rooms/room/join/RequireAuthentication.jsx
+++ b/app/javascript/components/rooms/room/join/RequireAuthentication.jsx
@@ -39,7 +39,7 @@ export default function RequireAuthentication({ path }) {
         <Card.Footer className="bg-white">
           {
             env?.OPENID_CONNECT ? (
-              <Form action="/auth/openid_connect" method="POST" data-turbo="false">
+              <Form action={process.env.OMNIAUTH_PATH} method="POST" data-turbo="false">
                 <input type="hidden" name="authenticity_token" value={document.querySelector('meta[name="csrf-token"]').content} />
                 <Button variant="brand-outline-color" className="btn btn-lg m-2" type="submit">{t('authentication.sign_up')}</Button>
                 <Button variant="brand" className="btn btn-lg m-2" type="submit">{t('authentication.sign_in')}</Button>

--- a/app/javascript/components/rooms/room/join/RoomJoin.jsx
+++ b/app/javascript/components/rooms/room/join/RoomJoin.jsx
@@ -18,7 +18,7 @@
 import React, { useState, useEffect } from 'react';
 import Card from 'react-bootstrap/Card';
 import {
-  Navigate, Link, useLocation, useParams,
+  Navigate, Link, useParams,
 } from 'react-router-dom';
 import {
   Button, Col, Row, Stack, Form as RegularForm,
@@ -54,8 +54,7 @@ export default function RoomJoin() {
 
   const { methods, fields } = useRoomJoinForm();
 
-  const location = useLocation();
-  const path = encodeURIComponent(location.pathname);
+  const path = encodeURIComponent(document.location.pathname);
 
   useEffect(() => { // set cookie to return to if needed
     const date = new Date();
@@ -243,7 +242,7 @@ export default function RoomJoin() {
       {!currentUser?.signed_in && (
         env?.OPENID_CONNECT ? (
           <Stack direction="horizontal" className="d-flex justify-content-center text-muted mt-3"> {t('authentication.already_have_account')}
-            <RegularForm action="/auth/openid_connect" method="POST" data-turbo="false">
+            <RegularForm action={process.env.OMNIAUTH_PATH} method="POST" data-turbo="false">
               <input type="hidden" name="authenticity_token" value={document.querySelector('meta[name="csrf-token"]').content} />
               <Button variant="link" className="btn-sm fs-6 cursor-pointer ms-2 ps-0" type="submit">{t('authentication.sign_in')}</Button>
             </RegularForm>

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,7 +50,8 @@ module Greenlight
       room_limit: 'RoomLimitError',
       pending_user: 'PendingUser',
       banned_user: 'BannedUser',
-      unverified_user: 'UnverifiedUser'
+      unverified_user: 'UnverifiedUser',
+      external_signup_error: 'SignupError'
     }
 
     config.uploads = {

--- a/esbuild.dev.mjs
+++ b/esbuild.dev.mjs
@@ -20,6 +20,7 @@ await esbuild.build({
   },
   define: {
     'process.env.RELATIVE_URL_ROOT': `"${relativeUrlRoot}"`,
+    'process.env.OMNIAUTH_PATH': `"${relativeUrlRoot}/auth/openid_connect"`,
   },
 });
 

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -14,6 +14,7 @@ await esbuild.build({
   },
   define: {
     'process.env.RELATIVE_URL_ROOT': `"${relativeUrlRoot}"`,
+    'process.env.OMNIAUTH_PATH': `"${relativeUrlRoot}/auth/openid_connect"`,
   },
 });
 

--- a/spec/controllers/external_controller_spec.rb
+++ b/spec/controllers/external_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe ExternalController, type: :controller do
     end
 
     context 'redirect' do
-      it 'redirects to the location cookie if the format is valid' do
+      it 'redirects to the location cookie if a relative redirection 1' do
         request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
 
         cookies[:location] = {
@@ -86,11 +86,23 @@ RSpec.describe ExternalController, type: :controller do
         expect(response).to redirect_to('/rooms/o5g-hvb-s44-p5t/join')
       end
 
-      it 'doesnt redirect if it doesnt match a room joins format' do
+      it 'redirects to the location cookie if a relative redirection 2' do
         request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
 
         cookies[:location] = {
-          value: 'https://google.com',
+          value: '/a/b/c/d/rooms/o5g-hvb-s44-p5t/join',
+          path: '/'
+        }
+        get :create_user, params: { provider: 'openid_connect' }
+
+        expect(response).to redirect_to('/a/b/c/d/rooms/o5g-hvb-s44-p5t/join')
+      end
+
+      it 'doesnt redirect if NOT a relative redirection check 1' do
+        request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
+
+        cookies[:location] = {
+          value: Faker::Internet.url,
           path: '/'
         }
         get :create_user, params: { provider: 'openid_connect' }
@@ -98,7 +110,7 @@ RSpec.describe ExternalController, type: :controller do
         expect(response).to redirect_to(root_path)
       end
 
-      it 'doesnt redirect if it doesnt match a room joins format check 2' do
+      it 'doesnt redirect if it NOT a relative redirection format check 2' do
         request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
 
         cookies[:location] = {
@@ -110,11 +122,35 @@ RSpec.describe ExternalController, type: :controller do
         expect(response).to redirect_to(root_path)
       end
 
-      it 'doesnt redirect if it doesnt match a room joins format check 3' do
+      it 'doesnt redirect if it NOT a relative redirection format check 3' do
         request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
 
         cookies[:location] = {
           value: "http://example.com/?ignore=\n/rooms/abc-def-ghi-jkl/join",
+          path: '/'
+        }
+        get :create_user, params: { provider: 'openid_connect' }
+
+        expect(response).to redirect_to(root_path)
+      end
+
+      it 'doesnt redirect if NOT a relative redirection check 4' do
+        request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
+
+        cookies[:location] = {
+          value: Faker::Internet.url(path: '/rooms/o5g-hvb-s44-p5t/join'),
+          path: '/'
+        }
+        get :create_user, params: { provider: 'openid_connect' }
+
+        expect(response).to redirect_to(root_path)
+      end
+
+      it 'doesnt redirect if NOT a valid room join link check 5' do
+        request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
+
+        cookies[:location] = {
+          value: '/romios/o5g-hvb-s44-p5t/join',
           path: '/'
         }
         get :create_user, params: { provider: 'openid_connect' }

--- a/spec/controllers/external_controller_spec.rb
+++ b/spec/controllers/external_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ExternalController, type: :controller do
       get :create_user, params: { provider: 'openid_connect' }
 
       expect(session[:session_token]).to eq(User.find_by(email: OmniAuth.config.mock_auth[:openid_connect][:info][:email]).session_token)
-      expect(response).to redirect_to('/')
+      expect(response).to redirect_to(root_path)
     end
 
     it 'assigns the User role to the user' do
@@ -95,7 +95,7 @@ RSpec.describe ExternalController, type: :controller do
         }
         get :create_user, params: { provider: 'openid_connect' }
 
-        expect(response).to redirect_to('/')
+        expect(response).to redirect_to(root_path)
       end
 
       it 'doesnt redirect if it doesnt match a room joins format check 2' do
@@ -107,7 +107,7 @@ RSpec.describe ExternalController, type: :controller do
         }
         get :create_user, params: { provider: 'openid_connect' }
 
-        expect(response).to redirect_to('/')
+        expect(response).to redirect_to(root_path)
       end
 
       it 'doesnt redirect if it doesnt match a room joins format check 3' do
@@ -119,7 +119,7 @@ RSpec.describe ExternalController, type: :controller do
         }
         get :create_user, params: { provider: 'openid_connect' }
 
-        expect(response).to redirect_to('/')
+        expect(response).to redirect_to(root_path)
       end
 
       it 'deletes the cookie after reading' do
@@ -215,7 +215,7 @@ RSpec.describe ExternalController, type: :controller do
           create(:user, external_id: OmniAuth.config.mock_auth[:openid_connect][:uid])
 
           expect { get :create_user, params: { provider: 'openid_connect' } }.not_to raise_error
-          expect(response).to redirect_to('/')
+          expect(response).to redirect_to(root_path)
         end
 
         it 'returns an InviteInvalid error if no invite is passed' do
@@ -223,7 +223,7 @@ RSpec.describe ExternalController, type: :controller do
 
           get :create_user, params: { provider: 'openid_connect' }
 
-          expect(response).to redirect_to('/?error=InviteInvalid')
+          expect(response).to redirect_to(root_path(error: Rails.configuration.custom_error_msgs[:invite_token_invalid]))
         end
 
         it 'returns an InviteInvalid error if the token is wrong' do
@@ -235,7 +235,7 @@ RSpec.describe ExternalController, type: :controller do
 
           get :create_user, params: { provider: 'openid_connect' }
 
-          expect(response).to redirect_to('/?error=InviteInvalid')
+          expect(response).to redirect_to(root_path(error: Rails.configuration.custom_error_msgs[:invite_token_invalid]))
         end
       end
 
@@ -252,6 +252,7 @@ RSpec.describe ExternalController, type: :controller do
           expect { get :create_user, params: { provider: 'openid_connect' } }.to change(User, :count).by(1)
 
           expect(User.find_by(email: OmniAuth.config.mock_auth[:openid_connect][:info][:email])).to be_pending
+          expect(response).to redirect_to(controller.pending_path)
         end
       end
     end


### PR DESCRIPTION
## Testing scenarios:
When external AuthN is enabled and a relative URL root path is set to **any value** the following cases should behave as expected:
1. Users should be able authenticate through the identity provider and have an account created and be signed on the app.
> If the registration method is set to `invite` or `approval` the app should behave as expected when external AuthN is enabled and no matter what relative URL root path is used **including edge cases like with an invalid Invite**. 
2. Users should be authenticated and redirected back to Room join page when choosing to signin before joining (Rooms with require AuthN setting **OFF**).
3. Users should be redirected to the require AuthN page where applicable and be able to authenticate and be redirected to the room join page (Rooms with require AuthN setting **ON**).
