### PR TITLE
Fix: Adding new line for copied recording links

### DIFF
--- a/app/javascript/components/recordings/RecordingRow.jsx
+++ b/app/javascript/components/recordings/RecordingRow.jsx
@@ -40,7 +40,7 @@ export default function RecordingRow({
 
   function copyUrls() {
     const formatUrls = recording.formats.map((format) => format.url);
-    navigator.clipboard.writeText(formatUrls);
+    navigator.clipboard.writeText(formatUrls.join('\n'));
     toast.success(t('toast.success.recording.copied_urls'));
   }
 


### PR DESCRIPTION
This is a patch for #5213 

Before this patch:  When clicked on the copy, different format recording links are joined as a single string
```bash
https://example.bbb.com/playback/presentation/2.3/b60c4329a82a6844f5991941349fc106a7c3f602-1685857681833,https://example.bbb.com/playback/video/b60c4329a82a6844f5991941349fc106a7c3f602-1685857681833/
```
After this patch:  When clicked on the copy, different format recording links are separated by new line
```bash
https://example.bbb.com/playback/presentation/2.3/b60c4329a82a6844f5991941349fc106a7c3f602-1685857681833

https://example.bbb.com/playback/video/b60c4329a82a6844f5991941349fc106a7c3f602-1685857681833/
```
