### PR TITLE
Set optional room configs to default_disabled

### DIFF
--- a/lib/tasks/migrations/migrations.rake
+++ b/lib/tasks/migrations/migrations.rake
@@ -202,9 +202,13 @@ namespace :migrations do
       PreuploadPresentation: setting.get_value('Preupload Presentation'),
     }.compact
 
+
+    # Sets Record to default_enabled in V3 if set to optional in V2
+    rooms_config_record_value = infer_room_config_value(setting.get_value('Room Configuration Recording'))
+
     # RoomConfigurations
     rooms_configurations = {
-      record: infer_room_config_value(setting.get_value('Room Configuration Recording')),
+      record: rooms_config_record_value == "optional" ? "default_enabled" : rooms_config_record_value,
       muteOnStart: infer_room_config_value(setting.get_value('Room Configuration Mute On Join')),
       guestPolicy: infer_room_config_value(setting.get_value('Room Configuration Require Moderator')),
       glAnyoneCanStart: infer_room_config_value(setting.get_value('Room Configuration Allow Any Start')),
@@ -307,8 +311,6 @@ namespace :migrations do
         "true"
       when "disabled"
         "false"
-      when "optional"
-        "default_enabled"
       when "true"
         "true"
       else


### PR DESCRIPTION
V2 Rooms configs that are set to "optional" are currently set to "default_enabled". 
V2 Rooms configs that are set to "optional" will now be set to "default_disabled".
Add exception for the Record Rooms Config, which if set to "optional" will be set to "default_enabled".

