### PR TITLE
Fix relative root in Migrations task

### DIFF
--- a/lib/tasks/migrations/migrations.rake
+++ b/lib/tasks/migrations/migrations.rake
@@ -265,8 +265,8 @@ namespace :migrations do
   def uri(path)
     raise red 'Unable to migrate: No "V3_ENDPOINT" provided, please check your .env file.' unless ENV["V3_ENDPOINT"].present?
 
-    res = URI(ENV["V3_ENDPOINT"])
-    res.path = "/api/v1/migrations/#{path}.json"
+    base_uri = URI(ENV["V3_ENDPOINT"])
+    res = URI::join(base_uri, "/api/v1/migrations/#{path}.json")
     res
   end
 

--- a/lib/tasks/migrations/migrations.rake
+++ b/lib/tasks/migrations/migrations.rake
@@ -266,7 +266,7 @@ namespace :migrations do
     raise red 'Unable to migrate: No "V3_ENDPOINT" provided, please check your .env file.' unless ENV["V3_ENDPOINT"].present?
 
     base_uri = URI(ENV["V3_ENDPOINT"])
-    res = URI::join(base_uri, "/api/v1/migrations/#{path}.json")
+    res = URI::join(base_uri, "api/v1/migrations/#{path}.json")
     res
   end
 


### PR DESCRIPTION
Fixes #5258 

The reason why `URI::join` is preferred over setting path directly is that it can correctly handle different situations and ensure a valid URI. For example, if the base URI already ends with a slash or if the path already starts with a slash, `URI::join` will not add or remove any slashes, thus ensuring the correct URL structure.