### PR TITLE
Add "return button" to empty public Recordings

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -179,9 +179,9 @@
     "processing_recording": "Processing recording, this may take several minutes...",
     "copy_recording_urls": "Copy Recording Url(s)",
     "recordings_list_empty": "You don't have any recordings yet!",
-    "public_recordings_list_empty": "There's no shared recordings yet!",
+    "public_recordings_list_empty": "There are no public recordings yet!",
     "recordings_list_empty_description": "Recordings will appear here after you start a meeting and record it.",
-    "public_recordings_list_empty_description": "Recordings will appear here after a mentor share it.",
+    "public_recordings_list_empty_description": "Recordings will appear here when available.",
     "delete_recording": "Delete Recording",
     "are_you_sure_delete_recording": "Are you sure you want to delete this recording?",
     "search_not_found": "No Recordings Found"

--- a/app/javascript/components/rooms/room/public_recordings/PublicRecordingsList.jsx
+++ b/app/javascript/components/rooms/room/public_recordings/PublicRecordingsList.jsx
@@ -45,6 +45,13 @@ export default function PublicRecordingsList({ friendlyId }) {
         <p>
           {t('recording.public_recordings_list_empty_description')}
         </p>
+        <ButtonLink
+          variant="brand"
+          className="ms-auto my-0 py-2"
+          to={`/rooms/${friendlyId}/join`}
+        >
+          <span> <UserBoardIcon className="hi-s cursor-pointer" /> {t('join_session')} </span>
+        </ButtonLink>
       </div>
     );
   }


### PR DESCRIPTION
Public Recordings, when empty, had no button to return to the Join Room page.
![image](https://github.com/bigbluebutton/greenlight/assets/43917914/dcd170e8-0af7-435e-b396-9bdecdd3d1c6)

- Add Join Session button
- Fix typos in the text
