### PR TITLE
Add SMTP check for reset password link

### DIFF
--- a/app/controllers/api/v1/env_controller.rb
+++ b/app/controllers/api/v1/env_controller.rb
@@ -28,7 +28,8 @@ module Api
           OPENID_CONNECT: ENV['OPENID_CONNECT_ISSUER'].present?,
           HCAPTCHA_KEY: ENV.fetch('HCAPTCHA_SITE_KEY', nil),
           VERSION_TAG: ENV.fetch('VERSION_TAG', ''),
-          CURRENT_PROVIDER: current_provider
+          CURRENT_PROVIDER: current_provider,
+          SMTP_ENABLED: ENV.fetch('SMTP_SERVER', nil)
         }, status: :ok
       end
     end

--- a/app/javascript/components/users/authentication/forms/SigninForm.jsx
+++ b/app/javascript/components/users/authentication/forms/SigninForm.jsx
@@ -29,12 +29,14 @@ import useCreateSession from '../../../../hooks/mutations/sessions/useCreateSess
 import useSignInForm from '../../../../hooks/forms/users/authentication/useSignInForm';
 import HCaptcha from '../../../shared_components/utilities/HCaptcha';
 import FormCheckBox from '../../../shared_components/forms/controls/FormCheckBox';
+import useEnv from '../../../../hooks/queries/env/useEnv';
 
 export default function SigninForm() {
   const { t } = useTranslation();
   const { methods, fields } = useSignInForm();
   const createSessionAPI = useCreateSession();
   const captchaRef = useRef(null);
+  const { data: env } = useEnv();
 
   const handleSubmit = useCallback(async (session) => {
     const results = await captchaRef.current?.execute({ async: true });
@@ -52,7 +54,11 @@ export default function SigninForm() {
           <FormCheckBox field={fields.extend_session} />
         </Col>
         <Col>
-          <Link to="/forget_password" className="text-link float-end small"> {t('authentication.forgot_password')} </Link>
+          {
+            env?.SMTP_ENABLED && (
+              <Link to="/forget_password" className="text-link float-end small"> {t('authentication.forgot_password')} </Link>
+            )
+          }
         </Col>
       </Row>
       <HCaptcha ref={captchaRef} />

--- a/app/javascript/components/users/password_management/ForgetPassword.jsx
+++ b/app/javascript/components/users/password_management/ForgetPassword.jsx
@@ -16,13 +16,21 @@
 
 import React from 'react';
 import Card from 'react-bootstrap/Card';
-import { Link } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import ForgetPwdForm from './forms/ForgetPwdForm';
 import Logo from '../../shared_components/Logo';
+import useEnv from '../../../hooks/queries/env/useEnv';
 
 export default function ForgetPassword() {
   const { t } = useTranslation();
+  const { data: env, isLoading } = useEnv();
+
+  if (isLoading) return null;
+
+  if (!env?.SMTP_ENABLED) {
+    return <Navigate to="/" />;
+  }
 
   return (
     <div className="vertical-center">


### PR DESCRIPTION
Solves #5059 

The "Reset Password link on the sign in page should be removed if the SMTP server is not set up.
The `/forget_password` component should redirect to homepage if the SMTP server is not set up.

