### PR TITLE
Add restriction to update user role

### DIFF
--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -38,8 +38,8 @@ module Api
 
         # GET /api/v1/admin/users/user_roles.json
         # Returns the list of roles that the current user can assign to other users
-        # A user should not be able to assign a role to another user if the user does not have all the permissions that the role has
         def user_roles
+          # Returns the permissions that the current user role has
           current_user_permission_ids = current_user.role.role_permissions.where(value: 'true').pluck(:permission_id)
 
           # Returns the roles that have role permissions that the current user role does not have
@@ -49,6 +49,7 @@ module Api
                                                          .where.not(role_permissions: { permission_id: current_user_permission_ids })
                                                          .select(:role_id)
 
+          # Returns the roles that DO NOT have role permissions that the current user role DOES NOT have
           eligible_roles = Role.with_provider(current_provider)
                                .includes(:role_permissions)
                                .where.not(id: ineligible_role_permission_ids)

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -36,6 +36,26 @@ module Api
           end
         end
 
+        # GET /api/v1/admin/users/user_roles.json
+        # Returns the list of roles that the current user can assign to other users
+        # A user should not be able to assign a role to another user if the user does not have all the permissions that the role has
+        def user_roles
+          current_user_permission_ids = current_user.role.role_permissions.where(value: 'true').pluck(:permission_id)
+
+          # Returns the roles that have role permissions that the current user role does not have
+          ineligible_role_permission_ids = RolePermission.joins(:role)
+                                                         .where('role.provider': current_provider)
+                                                         .where(role_permissions: { value: 'true' })
+                                                         .where.not(role_permissions: { permission_id: current_user_permission_ids })
+                                                         .select(:role_id)
+
+          eligible_roles = Role.with_provider(current_provider)
+                               .includes(:role_permissions)
+                               .where.not(id: ineligible_role_permission_ids)
+
+          render_data data: eligible_roles, status: :ok
+        end
+
         # GET /api/v1/admin/users/pending.json
         # Fetches the list of all users in the pending state
         def pending

--- a/app/javascript/components/users/user/forms/UpdateUserForm.jsx
+++ b/app/javascript/components/users/user/forms/UpdateUserForm.jsx
@@ -40,9 +40,10 @@ export default function UpdateUserForm({ user }) {
   const { data: locales } = useLocales();
   const updateUserAPI = useUpdateUser(user?.id);
 
-  // User can update someone else role if:
-  // 1. They have the manage users permission
-  // 2. The user they are trying to update has a role that is lower than theirs
+  // User can update someone a user role if:
+  // 1. The user they are trying to update has a role that is not higher or equal to their own
+  // 2. The user has the manage users permission
+  // 3. The user is not trying to update themselves
   const canUpdateRole = roles?.some((role) => role.name === user.role.name)
     && user.role.name !== currentUser.role.name
     && PermissionChecker.hasManageUsers(currentUser)

--- a/app/javascript/hooks/queries/admin/manage_users/useUserRoles.jsx
+++ b/app/javascript/hooks/queries/admin/manage_users/useUserRoles.jsx
@@ -1,0 +1,27 @@
+// BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+//
+// Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+//
+// This program is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3.0 of the License, or (at your option) any later
+// version.
+//
+// Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along
+// with Greenlight; if not, see <http://www.gnu.org/licenses/>.
+
+import { useQuery } from 'react-query';
+import axios from '../../../../helpers/Axios';
+
+export default function useUserRoles() {
+  return useQuery(
+    'getUserRoles',
+    () => axios.get('/admin/users/user_roles.json').then((resp) => resp.data.data),
+    {
+    },
+  );
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,7 @@ Rails.application.routes.draw do
             get '/verified', to: 'users#verified'
             get '/pending', to: 'users#pending'
             get '/banned', to: 'users#banned'
+            get '/user_roles', to: 'users#user_roles'
             post '/:user_id/create_server_room', to: 'users#create_server_room'
           end
         end


### PR DESCRIPTION
Solves #5284 

**Potentially risky situation in which an administrator with lower-level privileges is able to assign higher-level administrative roles to other users**

Users with ManageUsers role permission should not be able to assign a role to another user if the role is higher in the hierarchy than its own role. By higher role, we mean if the updated role has permissions that the user role does not have.

Currently, the roles list for the update user form is being fetched from the admin roles controller. It would make sense that the roles list should instead be in the admin users controller as it is an operation on a user, not a role.

```
  User can update someone a user role if:
  1. The user they are trying to update has a role that is not higher or equal to their own
  2. The user has the manage users permission
  3. The user is not trying to update themselves
```

- Add new `user_roles` endpoint that returns the list of roles that the current user can assign to other users
- Add new hook
- TODO: Add specs



