### PR TITLE
Add force_path_style to storage.yml (#5296)

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -36,6 +36,7 @@ s3:
   secret_access_key: <%= ENV['S3_SECRET_ACCESS_KEY'] %>
   region: <%= ENV['S3_REGION'] %>
   bucket: <%= ENV['S3_BUCKET'] %>
+  force_path_style: <%= ENV.fetch("S3_FORCE_PATH_STYLE", false) %>
 
 # Remember not to checkin your GCS keyfile to a repository
 google:


### PR DESCRIPTION
Fixes #5296 

This variable allows user to use S3 servers configured to have the bucket name in urls in a `https://mys3server.com/my-bucket/` fashion rather than being forced to have it in the subdomain.

Adding the setting using an `ENV.fetch` makes sure that this doesn't brake any existing installation and it preserves the default `false` value which is probably the correct one for most users.