### PR TITLE
Improve ServerRooms & RunningMeetingChecker

### DIFF
--- a/app/controllers/api/v1/admin/server_rooms_controller.rb
+++ b/app/controllers/api/v1/admin/server_rooms_controller.rb
@@ -36,7 +36,7 @@ module Api
 
           pagy, paged_rooms = pagy(rooms)
 
-          RunningMeetingChecker.new(rooms: paged_rooms.select(&:online)).call
+          RunningMeetingChecker.new(rooms: paged_rooms.select(&:online)).call if paged_rooms.select(&:online).any?
 
           render_data data: paged_rooms, meta: pagy_metadata(pagy), serializer: ServerRoomSerializer, status: :ok
         end

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -51,7 +51,7 @@ module Api
           room.shared = true if room.user_id != current_user.id
         end
 
-        RunningMeetingChecker.new(rooms:).call
+        RunningMeetingChecker.new(rooms: rooms.select(&:online)).call if rooms.select(&:online).any?
 
         render_data data: rooms, status: :ok
       end

--- a/app/services/running_meeting_checker.rb
+++ b/app/services/running_meeting_checker.rb
@@ -16,14 +16,14 @@
 
 # frozen_string_literal: true
 
-# Pass the room(s) to the service and it will confirm if the meeting is online or not and will return the # of participants
+# Pass the online rooms to the service and it will confirm if the meeting is running or not and return the # of participants
 class RunningMeetingChecker
   def initialize(rooms:)
     @rooms = rooms
   end
 
   def call
-    @rooms.each do |room|
+    Array(@rooms).each do |room|
       next unless room.online
 
       begin
@@ -31,6 +31,7 @@ class RunningMeetingChecker
         room.participants = bbb_meeting[:participantCount]
       rescue BigBlueButton::BigBlueButtonException
         room.update(online: false)
+        next
       end
     end
   end

--- a/app/services/running_meeting_checker.rb
+++ b/app/services/running_meeting_checker.rb
@@ -23,14 +23,15 @@ class RunningMeetingChecker
   end
 
   def call
-    online_rooms = Array(@rooms).select { |room| room.online == true }
+    @rooms.each do |room|
+      next unless room.online
 
-    online_rooms.each do |online_room|
-      bbb_meeting = BigBlueButtonApi.new(provider: online_room.user.provider).get_meeting_info(meeting_id: online_room.meeting_id)
-      online_room.participants = bbb_meeting[:participantCount]
-    rescue BigBlueButton::BigBlueButtonException
-      online_room.update(online: false)
-      next
+      begin
+        bbb_meeting = BigBlueButtonApi.new(provider: room.user.provider).get_meeting_info(meeting_id: room.meeting_id)
+        room.participants = bbb_meeting[:participantCount]
+      rescue BigBlueButton::BigBlueButtonException
+        room.update(online: false)
+      end
     end
   end
 end

--- a/spec/controllers/admin/server_rooms_controller_spec.rb
+++ b/spec/controllers/admin/server_rooms_controller_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe Api::V1::Admin::ServerRoomsController, type: :controller do
       create_list(:room, 2, user_id: user_one.id)
       create_list(:room, 2, user_id: user_two.id)
 
-      allow_any_instance_of(BigBlueButtonApi).to receive(:active_meetings).and_return([])
       get :index
       expect(JSON.parse(response.body)['data'].pluck('friendly_id'))
         .to match_array(Room.all.pluck(:friendly_id))
@@ -56,37 +55,10 @@ RSpec.describe Api::V1::Admin::ServerRoomsController, type: :controller do
         create_list(:room, 2, user_id: user_one.id)
         create_list(:room, 2, user_id: user_two.id)
 
-        allow_any_instance_of(BigBlueButtonApi).to receive(:active_meetings).and_return([])
         get :index
         expect(JSON.parse(response.body)['data'].pluck('friendly_id'))
           .to match_array(Room.all.pluck(:friendly_id))
       end
-    end
-
-    it 'returns the server room status as online if the meeting has started' do
-      active_server_room = create(:room)
-      active_server_room.update(meeting_id: 'hulsdzwvitlk1dbekzxdprshsxmvycvar0jeaszc')
-
-      allow_any_instance_of(BigBlueButtonApi).to receive(:active_meetings).and_return(bbb_meetings)
-      get :index
-      expect(JSON.parse(response.body)['data'][0]['online']).to be(true)
-    end
-
-    it 'returns the number of participants in an online server room' do
-      active_server_room = create(:room)
-      active_server_room.update(meeting_id: 'hulsdzwvitlk1dbekzxdprshsxmvycvar0jeaszc')
-
-      allow_any_instance_of(BigBlueButtonApi).to receive(:active_meetings).and_return(bbb_meetings)
-      get :index
-      expect(JSON.parse(response.body)['data'][0]['participants']).to be(1)
-    end
-
-    it 'returns the server status as not running if BBB server does not return any online meetings' do
-      create(:room)
-
-      allow_any_instance_of(BigBlueButtonApi).to receive(:active_meetings).and_return([])
-      get :index
-      expect(JSON.parse(response.body)['data'][0]['online']).to be(false)
     end
 
     it 'excludes rooms whose owners have a different provider' do
@@ -95,8 +67,6 @@ RSpec.describe Api::V1::Admin::ServerRoomsController, type: :controller do
       user2 = create(:user, provider: 'test', role: role_with_provider_test)
       rooms = create_list(:room, 2, user: user1)
       create_list(:room, 2, user: user2)
-
-      allow_any_instance_of(BigBlueButtonApi).to receive(:active_meetings).and_return([])
 
       get :index
       expect(JSON.parse(response.body)['data'].pluck('id')).to match_array(rooms.pluck(:id))


### PR DESCRIPTION
This PR aims to solve the loading issue on the admin panel Server Rooms page.
The loading of the page on a server with thousands of rooms was very slow.
I think most of these slowdown are due to the fact that rooms did not initially have a `status` column.

A few things have been changed to optimize the performance:

- Use of pagy instead of pagy_array
- Iterating on only `status == online` rooms instead of all rooms
- Using the RunningMeetingChecker service only on online rooms

Also,

- Calling getMeetingInfo instead of getMeetings to get the number of participants