### PR TITLE
Fixing missing default room name for German

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -72,3 +72,5 @@ de:
       reset_password: Passwort zurücksetzen
       link_expires: Der Link wird in 1 Stunde ungültig.
       ignore_request: "Wenn du dein Passwort nicht ändern wolltest, dann ignoriere bitte diese E-Mail."
+  room:
+    new_room_name: "%{username}'s Raum"


### PR DESCRIPTION
This fixes a missing default room name for a new user when the default language is set to German.