### PR TITLE
fix: config.env not found

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source config.env
+source bin/config.env
 
 echo "Greenlight-v3 starting on port: $PORT"
 


### PR DESCRIPTION
`bin/start` should most likely read `bin/config.env` instead of `config.env` as the working directory is probably *not* `./bin` but `.`