### PR TITLE
fix logger, so it can log into default production.log

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -146,10 +146,9 @@ Rails.application.configure do
     require 'remote_syslog_logger'
     logger_program = ENV['RAILS_LOG_REMOTE_TAG'] || "greenlight-v3-#{ENV.fetch('RAILS_ENV', nil)}"
     logger = RemoteSyslogLogger.new(ENV['RAILS_LOG_REMOTE_NAME'], ENV['RAILS_LOG_REMOTE_PORT'], program: logger_program)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
-
-  logger.formatter = config.log_formatter
-  config.logger = ActiveSupport::TaggedLogging.new(logger)
 
   # Use Lograge for logging
   config.lograge.enabled = true


### PR DESCRIPTION
Hi,

I found out that if we not set up `RAILS_LOG_TO_STDOUT` and (`RAILS_LOG_REMOTE_NAME` or `RAILS_LOG_REMOTE_PORT`) env variable (e.q. we want to use default log to log into production.log file), Greenlight will raise error because the `logger` on  line 151 (`logger.formatter = config.log_formatter`) is not initialised.

So this PR basically to fix it. I just move it inside the if statement.

Best Regards,