### PR TITLE
Add hover tooltips for the copy-URL&delete buttons in room recording lists

### DIFF
--- a/app/javascript/components/recordings/RecordingRow.jsx
+++ b/app/javascript/components/recordings/RecordingRow.jsx
@@ -181,13 +181,14 @@ export default function RecordingRow({
                 <Button
                   variant="icon"
                   className="mt-1 me-3"
+                  title={t('recording.copy_recording_urls')}
                   onClick={() => copyRecordingUrl.mutate({ record_id: recording.record_id })}
                 >
                   <ClipboardDocumentIcon className="hi-s text-muted" />
                 </Button>
               )}
               <Modal
-                modalButton={<Dropdown.Item className="btn btn-icon"><TrashIcon className="hi-s me-2" /></Dropdown.Item>}
+                modalButton={<Dropdown.Item className="btn btn-icon"><TrashIcon className="hi-s me-2" title={t('delete')} /></Dropdown.Item>}
                 body={(
                   <DeleteRecordingForm
                     mutation={useDeleteAPI}

--- a/app/javascript/components/rooms/room/public_recordings/PublicRecordingRow.jsx
+++ b/app/javascript/components/rooms/room/public_recordings/PublicRecordingRow.jsx
@@ -73,6 +73,7 @@ export default function PublicRecordingRow({
           <Button
             variant="icon"
             className="mt-1 me-3"
+            title={t('recording.copy_recording_urls')}
             onClick={() => copyRecordingUrl.mutate({ record_id: recording.record_id })}
           >
             <ClipboardDocumentIcon className="hi-s text-muted" />


### PR DESCRIPTION
Adds the button texts from the admin recording list as tooltips for the buttons in the room recordings lists.

Fixes https://github.com/bigbluebutton/greenlight/issues/5457