### PR TITLE
Update changed recording URLs of already present formats instead of creating new format entries

### DIFF
--- a/app/services/recording_creator.rb
+++ b/app/services/recording_creator.rb
@@ -80,11 +80,11 @@ class RecordingCreator
   def create_formats(recording:, new_recording:)
     if recording[:playback][:format].is_a?(Array)
       recording[:playback][:format].each do |format|
-        Format.find_or_create_by(recording_id: new_recording.id, recording_type: format[:type], url: format[:url])
+        Format.find_or_create_by(recording_id: new_recording.id, recording_type: format[:type]).update(url: format[:url])
       end
     else
-      Format.find_or_create_by(recording_id: new_recording.id, recording_type: recording[:playback][:format][:type],
-                               url: recording[:playback][:format][:url])
+      Format.find_or_create_by(recording_id: new_recording.id,
+                               recording_type: recording[:playback][:format][:type]).update(url: recording[:playback][:format][:url])
     end
   end
 


### PR DESCRIPTION
Currently, a change in the format URL that is provided by BBB or SL (e.g. protected recordings!) leads to the addition of new format entries for formats that are already present with a different URL, whenever a recording resync or repeated recording ready notification happens. Instead of creating new entries, the URLs of present entries should be updated.

This PR implements that by using only the recording id & format name in the Format.find_or_create_by calls and then updates the recording URL afterwards on the found or created Format. 

Fixes https://github.com/bigbluebutton/greenlight/issues/5459