### PR TITLE
add whitespace after uses of shared_by string, remove the whitespace from english locale

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -110,7 +110,7 @@
     "delete_room": "Delete Room",
     "create_new_room": "Create New Room",
     "enter_room_name": "Enter the room name",
-    "shared_by": "shared by ",
+    "shared_by": "shared by",
     "last_session": "Last Session: {{ localizedTime }}",
     "no_last_session": "No previous session created",
     "search_not_found": "No Rooms Found",

--- a/app/javascript/components/rooms/RoomCard.jsx
+++ b/app/javascript/components/rooms/RoomCard.jsx
@@ -57,7 +57,7 @@ export default function RoomCard({ room }) {
         <Stack className="my-4">
           <Card.Title className="mb-0"> { room.name } </Card.Title>
           { room.shared_owner && (
-            <span className="text-muted">{ t('room.shared_by') } <strong>{ room.shared_owner }</strong></span>
+            <span className="text-muted">{ t('room.shared_by') } {' '} <strong>{ room.shared_owner }</strong></span>
           )}
           { room.last_session ? (
             <span className="text-muted"> { t('room.last_session', { localizedTime }) } </span>

--- a/app/javascript/components/rooms/room/SharedBadge.jsx
+++ b/app/javascript/components/rooms/room/SharedBadge.jsx
@@ -25,7 +25,7 @@ export default function SharedBadge({ ownerName }) {
   return (
     <div>
       <Badge className="rounded-pill shared-badge ms-2">
-        <span>{ t('room.shared_by')}
+        <span>{ t('room.shared_by')} {' '}
           <strong>{ ownerName }</strong>
         </span>
       </Badge>


### PR DESCRIPTION
Fixes https://github.com/bigbluebutton/greenlight/issues/5467 by adding the whitespace in the code and removing it from the english locale.