### PR TITLE
Support for Redis Sentinel

### DIFF
--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -45,7 +45,11 @@ class HealthChecksController < ApplicationController
   end
 
   def check_redis
-    Redis.new.ping
+    if Greenlight::Application.config.cache_store == :null_store
+      Redis.new.ping
+    else
+      Redis.new(Greenlight::Application.config.cache_store[1].except(:adapter, :channel_prefix)).ping
+    end
   rescue StandardError => e
     raise "Unable to connect to Redis - #{e}"
   end

--- a/bin/start
+++ b/bin/start
@@ -17,11 +17,13 @@ if [ "$RAILS_ENV" = "production" ]; then
     sleep 1
   done
 
-  while ! nc -zw3 $RDHOST $RDPORT
-  do
-    echo "Waiting for redis to start up ..."
-    sleep 1
-  done
+  if [ -z "$REDIS_SENTINEL" ]; then
+    while ! nc -zw3 $RDHOST $RDPORT
+    do
+      echo "Waiting for redis to start up ..."
+      sleep 1
+    done
+  fi
 fi
 
 rails assets:precompile

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -22,5 +22,9 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL", "") %>
+  url: <%= ENV.fetch("REDIS_URL", nil) || "redis://mymaster" %>
+  sentinels: <%= ENV.fetch("REDIS_SENTINEL", "") %>
+  name: mymaster
+  role: master
+  namespace: greenlight3
   channel_prefix: greenlight_production

--- a/sample.env
+++ b/sample.env
@@ -15,10 +15,13 @@ BIGBLUEBUTTON_SECRET=
 #   E.g. postgres://postgres:password@postgres:5432/greenlight-v3-production
 DATABASE_URL=
 
-### REDIS CACHE URL
-# Must be in the format redis://host:port
+### REDIS CACHE
+# REDIS_URL: Must be in the format redis://host:port
 #   E.g. redis://redis:6379
+# REDIS_SENTINEL: Must be an array of host, port pairs. In this case leave REDIS_URL blank or set it to e.g. redis://mymaster.
+#   E.g. [{host: 'host1', port: 26379}, {host: 'host2', port: 26379}, {host: 'host3', port: 26379}]
 REDIS_URL=
+REDIS_SENTINEL=
 
 ### OPTIONAL ENV VARS
 


### PR DESCRIPTION
This PR enables the use of Redis Sentinel Clusters with GL3. We are using this feature in production, but it was not developed with the goal to be merged upstream. However, I'd like to provide our development to the public for anyone in need of this and would be happy to help getting this ready for merging if there is interest.

This is the beginning of a series of similar PR submissions (Redis Sentinel, SAML integration, LDAP integration).

Details / How to use:
- See sample.env for some documention on configuration
- Provide Redis Sentinel hostnames & ports in the variable REDIS_SENTINEL
- If REDIS_SENTINEL is set, REDIS_URL will be redis://mymaster per default