### PR TITLE
Add env EXTERNAL_AUTH and replace checks for OPENID_CONNECT with checks for EXTERNAL_AUTH where applicable

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -89,7 +89,7 @@ module Api
         { sort_column => sort_direction }
       end
 
-      # Checks if external authentication is enabled
+      # Checks if external authentication is enabled (currently only OIDC is implemented)
       def external_authn_enabled?
         ENV['OPENID_CONNECT_ISSUER'].present?
       end

--- a/app/controllers/api/v1/env_controller.rb
+++ b/app/controllers/api/v1/env_controller.rb
@@ -25,7 +25,6 @@ module Api
       # Returns basic NON-CONFIDENTIAL information on the environment variables
       def index
         render_data data: {
-          OPENID_CONNECT: ENV['OPENID_CONNECT_ISSUER'].present?,
           EXTERNAL_AUTH: ENV['OPENID_CONNECT_ISSUER'].present?, # currently only OIDC is implemented
           HCAPTCHA_KEY: ENV.fetch('HCAPTCHA_SITE_KEY', nil),
           VERSION_TAG: ENV.fetch('VERSION_TAG', ''),

--- a/app/controllers/api/v1/env_controller.rb
+++ b/app/controllers/api/v1/env_controller.rb
@@ -26,6 +26,7 @@ module Api
       def index
         render_data data: {
           OPENID_CONNECT: ENV['OPENID_CONNECT_ISSUER'].present?,
+          EXTERNAL_AUTH: ENV['OPENID_CONNECT_ISSUER'].present?, # currently only OIDC is implemented
           HCAPTCHA_KEY: ENV.fetch('HCAPTCHA_SITE_KEY', nil),
           VERSION_TAG: ENV.fetch('VERSION_TAG', ''),
           CURRENT_PROVIDER: current_provider,

--- a/app/javascript/components/admin/manage_users/ManageUsers.jsx
+++ b/app/javascript/components/admin/manage_users/ManageUsers.jsx
@@ -81,7 +81,7 @@ export default function ManageUsers() {
                             />
                           )}
                         {
-                          (!envAPI.isLoading && !envAPI.data?.OPENID_CONNECT)
+                          (!envAPI.isLoading && !envAPI.data?.EXTERNAL_AUTH)
                           && (
                             <Modal
                               modalButton={

--- a/app/javascript/components/admin/site_settings/registration/Registration.jsx
+++ b/app/javascript/components/admin/site_settings/registration/Registration.jsx
@@ -52,7 +52,7 @@ export default function Registration() {
         </Dropdown.Item>
       </SettingSelect>
 
-      { env?.OPENID_CONNECT && (
+      { env?.EXTERNAL_AUTH && (
         <Row className="mb-3">
           <SettingsRow
             name="ResyncOnLogin"

--- a/app/javascript/components/home/AuthButtons.jsx
+++ b/app/javascript/components/home/AuthButtons.jsx
@@ -40,7 +40,7 @@ export default function AuthButtons({ direction }) {
     return registrationMethod !== 'invite' || !!inviteToken;
   }
 
-  if (env?.OPENID_CONNECT) {
+  if (env?.EXTERNAL_AUTH) {
     return (
       <Form action={process.env.OMNIAUTH_PATH} method="POST" data-turbo="false">
         <input type="hidden" name="authenticity_token" value={document.querySelector('meta[name="csrf-token"]').content} />

--- a/app/javascript/components/rooms/room/join/JoinCard.jsx
+++ b/app/javascript/components/rooms/room/join/JoinCard.jsx
@@ -252,7 +252,7 @@ export default function JoinCard() {
         </Row>
         <Row>
           {!currentUser?.signed_in && (
-            env?.OPENID_CONNECT ? (
+            env?.EXTERNAL_AUTH ? (
               <Stack direction="horizontal" className="d-flex justify-content-center text-muted mt-3"> {t('authentication.already_have_account')}
                 <RegularForm action={process.env.OMNIAUTH_PATH} method="POST" data-turbo="false">
                   <input type="hidden" name="authenticity_token" value={document.querySelector('meta[name="csrf-token"]').content} />

--- a/app/javascript/components/rooms/room/join/RequireAuthentication.jsx
+++ b/app/javascript/components/rooms/room/join/RequireAuthentication.jsx
@@ -38,7 +38,7 @@ export default function RequireAuthentication({ path }) {
         </Card.Body>
         <Card.Footer className="bg-white">
           {
-            env?.OPENID_CONNECT ? (
+            env?.EXTERNAL_AUTH ? (
               <Form action={process.env.OMNIAUTH_PATH} method="POST" data-turbo="false">
                 <input type="hidden" name="authenticity_token" value={document.querySelector('meta[name="csrf-token"]').content} />
                 <Button variant="brand-outline-color" className="btn btn-lg m-2" type="submit">{t('authentication.sign_up')}</Button>

--- a/app/javascript/components/users/authentication/Signup.jsx
+++ b/app/javascript/components/users/authentication/Signup.jsx
@@ -32,7 +32,7 @@ export default function Signup() {
   const envAPI = useEnv();
   const isLoading = envAPI.isLoading || registrationMethodSettingAPI.isLoading;
 
-  if (envAPI.data?.OPENID_CONNECT) {
+  if (envAPI.data?.EXTERNAL_AUTH) {
     return <Navigate to="/" replace />;
   }
 

--- a/esbuild.dev.mjs
+++ b/esbuild.dev.mjs
@@ -20,7 +20,7 @@ await esbuild.build({
   },
   define: {
     'process.env.RELATIVE_URL_ROOT': `"${relativeUrlRoot}"`,
-    'process.env.OMNIAUTH_PATH': `"${relativeUrlRoot}/auth/openid_connect"`,
+    'process.env.OMNIAUTH_PATH': `"${relativeUrlRoot}/auth/openid_connect"`, // currently, only OIDC is implemented
   },
 });
 

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -14,7 +14,7 @@ await esbuild.build({
   },
   define: {
     'process.env.RELATIVE_URL_ROOT': `"${relativeUrlRoot}"`,
-    'process.env.OMNIAUTH_PATH': `"${relativeUrlRoot}/auth/openid_connect"`,
+    'process.env.OMNIAUTH_PATH': `"${relativeUrlRoot}/auth/openid_connect"`, // currently, only OIDC is implemented
   },
 });
 


### PR DESCRIPTION
Since OIDC is currently the only implemented external authentication provider, in all the places where you would normally check for external auth usage there is instead a check for OIDC usage. This PR introduces a new env EXTERNAL_AUTH and replaces these checks with a check for EXTERNAL_AUTH. Also a few comments are left at places where additional providers would have to be "added".

This paves the way for addition of other external auth providers and, even if there are no plans to develop these from upstream side, makes it easier to develop and maintain extensions such as https://github.com/bigbluebutton/greenlight/pull/5476 . Also, it will not require any additional effort to maintain the changes made in this PR and it does not change the current behavior of GL3. 

If any changes have to be made to make this mergeable, I'm happy to work on them. Please let me know!