### PR TITLE
Add a new role permission for receiving an email on user signup

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -350,7 +350,8 @@
         "manage_site_settings": "Allow users with this role to manage site settings",
         "manage_roles": "Allow users with this role to edit other roles",
         "shared_list": "Include users with this role in the dropdown for sharing rooms",
-        "room_limit": "Room Limit"
+        "room_limit": "Room Limit",
+        "email_on_signup": "Receive an email when a new user signs up"
       }
     }
   },

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -76,6 +76,9 @@ module Api
             UserMailer.with(user:,
                             activation_url: activate_account_url(token), base_url: request.base_url,
                             provider: current_provider).activate_account_email.deliver_later
+
+            UserMailer.with(user:, admin_panel_url:, provider: current_provider)
+                      .new_user_signup_email.deliver_later
           end
 
           create_default_room(user)

--- a/app/javascript/components/admin/roles/forms/EditRoleForm.jsx
+++ b/app/javascript/components/admin/roles/forms/EditRoleForm.jsx
@@ -130,6 +130,13 @@ export default function EditRoleForm({ role }) {
                 defaultValue={rolePermissions?.SharedList === 'true'}
               />
 
+              <RolePermissionRow
+                permissionName="EmailOnSignup"
+                description={t('admin.roles.edit.email_on_signup')}
+                roleId={role?.id}
+                defaultValue={rolePermissions?.EmailOnSignup === 'true'}
+              />
+
               <Form methods={methodsLimit} onBlur={methodsLimit.handleSubmit(updatePermissionAPI.mutate)}>
                 <Stack direction="horizontal">
                   <div className="text-muted me-auto">

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -42,9 +42,18 @@ class UserMailer < ApplicationMailer
     @email = params[:email]
     @name = params[:name]
     @signup_url = params[:signup_url]
-    @email = params[:email]
 
     mail(to: @email, subject: t('email.invitation.invitation_to_join'))
+  end
+
+  def new_user_signup_email
+    @user = params[:user]
+    @admin_panel_url = params[:admin_panel_url]
+    emails = admin_emails
+
+    return if emails.blank? # Dont send anything if no-one has EmailOnSignup enabled
+
+    mail(to: emails, subject: t('email.new_user_signup.new_user'))
   end
 
   private
@@ -58,5 +67,15 @@ class UserMailer < ApplicationMailer
     branding_hash = SettingGetter.new(setting_name: %w[PrimaryColor BrandingImage], provider: @provider).call
     @brand_image = ActionController::Base.helpers.image_url(branding_hash['BrandingImage'], host: @base_url)
     @brand_color = branding_hash['PrimaryColor']
+  end
+
+  def admin_emails
+    # Find all the roles that have EmailOnSignup enabled
+    role_ids = Role.joins(role_permissions: :permission)
+                   .with_provider(@provider)
+                   .where(role_permissions: { value: 'true' }, permission: { name: 'EmailOnSignup' })
+                   .pluck(:id)
+
+    User.where(role_id: role_ids).pluck(:email)
   end
 end

--- a/app/views/user_mailer/new_user_signup_email.html.erb
+++ b/app/views/user_mailer/new_user_signup_email.html.erb
@@ -1,0 +1,30 @@
+<!--BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.-->
+
+<!--Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).-->
+
+<!--This program is free software; you can redistribute it and/or modify it under the-->
+<!--terms of the GNU Lesser General Public License as published by the Free Software-->
+<!--Foundation; either version 3.0 of the License, or (at your option) any later-->
+<!--version.-->
+
+<!--Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY-->
+<!--WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A-->
+<!--PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.-->
+
+<!--You should have received a copy of the GNU Lesser General Public License along-->
+<!--with Greenlight; if not, see <http://www.gnu.org/licenses/>.-->
+
+<div style="padding-left: 80px; padding-right: 80px;">
+  <p style="font-size: 40px; margin-bottom: 20px; font-weight: 600;"><%= t('email.new_user_signup.new_user') %></p>
+
+  <p style="font-size: 24px;"><%= t('email.new_user_signup.new_user_description') %></p>
+
+  <p style="font-size: 20px;"><%= t('email.new_user_signup.name', name: @user.name) %></p>
+  <p style="font-size: 20px;"><%= t('email.new_user_signup.email', email: @user.email) %></p>
+
+  <p style="font-size: 24px;"><%= t('email.new_user_signup.take_action') %></p>
+
+  <a href="<%= @signup_url %>" target="_blank" style="background-color: <%= @brand_color %>; border-radius: 8px; border: none; color: white; padding: 15px 32px; text-align: center; text-decoration: none; display: inline-block; font-size: 16px; font-weight: 600; margin-top: 16px; margin-bottom: 64px;">
+    <%= t('email.new_user_signup.admin_panel') %>
+  </a>
+</div>

--- a/app/views/user_mailer/new_user_signup_email.text.erb
+++ b/app/views/user_mailer/new_user_signup_email.text.erb
@@ -1,0 +1,25 @@
+<%#
+  BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+
+  Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+
+  This program is free software; you can redistribute it and/or modify it under the
+  terms of the GNU Lesser General Public License as published by the Free Software
+  Foundation; either version 3.0 of the License, or (at your option) any later
+  version.
+
+  Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License along
+  with Greenlight; if not, see http://www.gnu.org/licenses/.
+%>
+
+---
+<%= t('email.invitation.invitation_to_join') %>
+<%= t('email.invitation.you_have_been_invited', name: @name) %>
+<%= t('email.invitation.get_started') %>
+<%= @signup_url %>
+<%= t('email.invitation.valid_invitation') %>
+---

--- a/app/views/user_mailer/new_user_signup_email.text.erb
+++ b/app/views/user_mailer/new_user_signup_email.text.erb
@@ -17,9 +17,10 @@
 %>
 
 ---
-<%= t('email.invitation.invitation_to_join') %>
-<%= t('email.invitation.you_have_been_invited', name: @name) %>
-<%= t('email.invitation.get_started') %>
+<%= t('email.new_user_signup.new_user') %>
+<%= t('email.new_user_signup.new_user_description' %>
+<%= t('email.new_user_signup.name', name: @user.name) %>
+<%= t('email.new_user_signup.email', email: @user.email) %>
+<%= t('email.new_user_signup.take_action') %>
 <%= @signup_url %>
-<%= t('email.invitation.valid_invitation') %>
 ---

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,13 @@ en:
       get_started: To sign up, please click the button below and follow the steps.
       valid_invitation: The invitation is valid for 24 hours.
       sign_up: Sign Up
+    new_user_signup:
+      new_user: New User Signup
+      new_user_description: A new user has signed up to use BigBlueButton.
+      name: "Name: %{name}"
+      email: "Email: %{email}"
+      admin_panel: "Administrator Panel"
+      take_action: "To view the new user or to take the necessary action, visit the Administrator Panel"
     reset:
       password_reset: Reset Password
       password_reset_requested: A password reset has been requested for %{email}.

--- a/db/data/20231117151542_add_email_on_sign_up_permission.rb
+++ b/db/data/20231117151542_add_email_on_sign_up_permission.rb
@@ -16,25 +16,21 @@
 
 # frozen_string_literal: true
 
-module ClientRoutable
-  extend ActiveSupport::Concern
+class AddEmailOnSignUpPermission < ActiveRecord::Migration[7.1]
+  def up
+    email_permission = Permission.create!(name: 'EmailOnSignup')
+    admin = Role.find_by(name: 'Administrator')
 
-  # Generates a client side activate account url.
-  def activate_account_url(token)
-    "#{root_url}activate_account/#{token}"
+    values = [{ role: admin, permission: email_permission, value: 'true' }]
+
+    Role.where.not(name: 'Administrator').each do |role|
+      values.push({ role:, permission: email_permission, value: 'false' })
+    end
+
+    RolePermission.create! values
   end
 
-  # Generates a client side reset password url.
-  def reset_password_url(token)
-    "#{root_url}reset_password/#{token}"
-  end
-
-  # Generates a client side pending url.
-  def pending_path
-    "#{root_path}pending"
-  end
-
-  def admin_panel_url
-    "#{root_url}admin/users"
+  def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20231030185844)
+DataMigrate::Data.define(version: 20231117151542)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -66,6 +66,16 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         expect(User.find_by(email: user_params[:user][:email]).role.name).to eq('User')
       end
 
+      context 'EmailOnSignup' do
+        it 'emails all admins that a new user has signed up' do
+          post :create, params: user_params
+
+          expect(ActionMailer::MailDeliveryJob).to have_been_enqueued
+                                               .at(:no_wait).exactly(:once)
+                                               .with('UserMailer', 'new_user_signup_email', 'deliver_now', Hash)
+        end
+      end
+
       context 'User language' do
         it 'Persists the user language in the user record' do
           post :create, params: user_params

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
 
           expect(ActionMailer::MailDeliveryJob).to have_been_enqueued
                                                .at(:no_wait).exactly(:once)
-                                               .with('UserMailer', 'new_user_signup_email', 'deliver_now', Hash)
+            .with('UserMailer', 'new_user_signup_email', 'deliver_now', Hash)
         end
       end
 

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -38,4 +38,10 @@ class UserMailerPreview < ActionMailer::Preview
 
     UserMailer.with(user: fake_user.new('user', 'user@users'), invitation_url: 'https://example.com/invite').invitation_email
   end
+
+  def new_user_signup_email
+    fake_user = Struct.new(:name, :email)
+
+    UserMailer.with(user: fake_user.new('user', 'user@users')).new_user_signup_email
+  end
 end


### PR DESCRIPTION
fixes #5528, #5513, #5512, #5424,

Adds a new role permission for receiving an email when a user signs up.

By default, only Administrators will have it enabled

![image](https://github.com/bigbluebutton/greenlight/assets/35435341/6a6aaa61-3ce7-46cf-bb13-2feb4dd35229)
