### PR TITLE
added wording to explain default language a little more concisely

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -73,6 +73,7 @@ REDIS_URL=
 
 # Define the default locale language code (i.e. 'en' for English) from the following list:
 #  [en, ar, fr, es, fa_IR]
+# The DEFAULT_LOCALE setting specifies the default language, overriding the browser language which is always set.
 # More information: https://docs.bigbluebutton.org/greenlight/v3/install/#default-locale-setup
 #DEFAULT_LOCALE=en
 


### PR DESCRIPTION
in sample.env
fixes #5487 