### PR TITLE
Added ClamAV integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'aws-sdk-s3', require: false
 gem 'bcrypt', '~> 3.1.7'
 gem 'bigbluebutton-api-ruby', '1.9.1'
 gem 'bootsnap', require: false
+gem 'clamby', '~> 1.6.10'
 gem 'cssbundling-rails', '>= 1.3.3'
 gem 'data_migrate', '>= 9.2.0'
 gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,7 @@ GEM
     case_transform (0.2)
       activesupport
     childprocess (4.1.0)
+    clamby (1.6.10)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crack (0.4.5)
@@ -505,6 +506,7 @@ DEPENDENCIES
   bigbluebutton-api-ruby (= 1.9.1)
   bootsnap
   capybara
+  clamby (~> 1.6.10)
   cssbundling-rails (>= 1.3.3)
   data_migrate (>= 9.2.0)
   debug
@@ -545,9 +547,3 @@ DEPENDENCIES
   web-console (>= 4.2.1)
   webdrivers
   webmock
-
-RUBY VERSION
-   ruby 3.1.0p0
-
-BUNDLED WITH
-   2.3.9

--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -425,6 +425,7 @@
       "file_size_too_large": "The file size is too large.",
       "file_upload_error": "The file can't be uploaded.",
       "signin_required": "You must be signed in to access this page.",
+      "malware_detected": "Malware Detected! The file you uploaded may contain malware. Please check your file and try again.",
       "roles": {
         "role_assigned": "This role can't be deleted because it is assigned to at least one user."
       },

--- a/app/controllers/api/v1/admin/site_settings_controller.rb
+++ b/app/controllers/api/v1/admin/site_settings_controller.rb
@@ -51,10 +51,7 @@ module Api
                      site_setting.update(value: params[:site_setting][:value].to_s)
                    end
 
-          unless update
-            return render_error status: :bad_request,
-                                errors: Rails.configuration.custom_error_msgs[:record_invalid]
-          end
+          return render_error status: :bad_request, errors: site_setting.errors.to_a unless update
 
           render_data status: :ok
         end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -110,7 +110,7 @@ module Api
           create_default_room(user)
           render_data  status: :ok
         else
-          render_error errors: Rails.configuration.custom_error_msgs[:record_invalid]
+          render_error errors: user.errors.to_a
         end
       end
 

--- a/app/javascript/hooks/mutations/admin/site_settings/useUpdateSiteSetting.jsx
+++ b/app/javascript/hooks/mutations/admin/site_settings/useUpdateSiteSetting.jsx
@@ -74,7 +74,11 @@ export default function useUpdateSiteSetting(name) {
         handleSuccess();
       },
       onError: (error) => {
-        handleError(error, t, toast);
+        if (error.response.data.errors.includes('Image MalwareDetected')) {
+          toast.error(t('toast.error.malware_detected'));
+        } else {
+          handleError(error, t, toast);
+        }
       },
     },
   );

--- a/app/javascript/hooks/mutations/rooms/useUploadPresentation.jsx
+++ b/app/javascript/hooks/mutations/rooms/useUploadPresentation.jsx
@@ -41,7 +41,11 @@ export default function useUploadPresentation(friendlyId) {
       toast.success(t('toast.success.room.presentation_updated'));
     },
     onError: (error) => {
-      handleError(error, t, toast);
+      if (error.response.data.errors.includes('Presentation MalwareDetected')) {
+        toast.error(t('toast.error.malware_detected'));
+      } else {
+        handleError(error, t, toast);
+      }
     },
   });
 

--- a/app/javascript/hooks/mutations/users/useCreateAvatar.jsx
+++ b/app/javascript/hooks/mutations/users/useCreateAvatar.jsx
@@ -45,8 +45,12 @@ export default function useCreateAvatar(currentUser) {
         queryClient.invalidateQueries('getUser');
         toast.success(t('toast.success.user.avatar_updated'));
       },
-      onError: () => {
-        toast.error(t('toast.error.problem_completing_action'));
+      onError: (error) => {
+        if (error.response.data.errors.includes('Avatar MalwareDetected')) {
+          toast.error(t('toast.error.malware_detected'));
+        } else {
+          toast.error(t('toast.error.problem_completing_action'));
+        }
       },
     },
   );

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -19,4 +19,8 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
   self.implicit_order_column = 'created_at'
+
+  def virus_scan?
+    ENV.fetch('CLAMAV_SCANNING', 'false') == 'true'
+  end
 end

--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -16,34 +16,9 @@
 
 # frozen_string_literal: true
 
-class SiteSetting < ApplicationRecord
-  REGISTRATION_METHODS = {
-    open: 'open',
-    invite: 'invite',
-    approval: 'approval'
-  }.freeze
-
-  belongs_to :setting
-
-  has_one_attached :image
-
-  validates :provider, presence: true
-  validates :image,
-            content_type: Rails.configuration.uploads[:images][:formats],
-            size: { less_than: Rails.configuration.uploads[:images][:max_size] }
-
-  before_save :scan_image_for_virus
-
-  private
-
-  def scan_image_for_virus
-    return if !virus_scan? || !attachment_changes['image']
-
-    path = attachment_changes['image']&.attachable&.tempfile&.path
-
-    return true if Clamby.safe?(path)
-
-    errors.add(:image, 'MalwareDetected')
-    throw :abort
-  end
-end
+Clamby.configure({
+                   check: ENV.fetch('CLAMAV_SCANNING', 'false') == 'true',
+                   daemonize: ENV.fetch('CLAMAV_DAEMONIZE', 'true') == 'true',
+                   fdpass: ENV.fetch('CLAMAV_DAEMONIZE', 'true') == 'true',
+                   config_file: ENV.fetch('CLAMAV_CONFIG', nil)
+                 })

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_07_05_183747) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_18_154727) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/sample.env
+++ b/sample.env
@@ -90,3 +90,10 @@ LOG_LEVEL=info
 # RAILS_LOG_REMOTE_NAME=xxx.papertrailapp.com
 # RAILS_LOG_REMOTE_PORT=99999
 # RAILS_LOG_REMOTE_TAG=greenlight-v3
+
+## ClamAV Virus Scanning
+# If you have ClamAV installed on the same machine as your Greenlight deployment, you can enable automatic virus scanning
+# for presentations, avatars, and BrandingImage. If a malicious file is detected, the user will be informed and asked
+# to check their file.
+#CLAMAV_SCANNING=true
+#CLAMAV_DAEMONIZE=true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -352,4 +352,38 @@ RSpec.describe User, type: :model do
       expect(user.errors[:user_provider]).not_to be_empty
     end
   end
+
+  describe '#scan_avatar_for_virus' do
+    let(:user) { create(:user) }
+
+    before do
+      allow_any_instance_of(described_class).to receive(:virus_scan?).and_return(true)
+    end
+
+    it 'makes a call to ClamAV if CLAMAV_SCANNING=true' do
+      expect(Clamby).to receive(:safe?)
+
+      user.avatar.attach(fixture_file_upload(file_fixture('default-avatar.png'), 'image/png'))
+    end
+
+    it 'adds an error if the file is not safe' do
+      allow(Clamby).to receive(:safe?).and_return(false)
+      user.avatar.attach(fixture_file_upload(file_fixture('default-avatar.png'), 'image/png'))
+      expect(user.errors[:avatar]).to eq(['MalwareDetected'])
+    end
+
+    it 'does not makes a call to ClamAV if the image is not changing' do
+      expect(Clamby).not_to receive(:safe?)
+
+      user.update(name: 'New Name')
+    end
+
+    it 'does not makes a call to ClamAV if CLAMAV_SCANNING=false' do
+      allow_any_instance_of(described_class).to receive(:virus_scan?).and_return(false)
+
+      expect(Clamby).not_to receive(:safe?)
+
+      user.avatar.attach(fixture_file_upload(file_fixture('default-avatar.png'), 'image/png'))
+    end
+  end
 end


### PR DESCRIPTION
Disabled by default - adds ClamAV scanning (if configured on the Greenlight machine) for presentations, avatars and branding image

![image (12)](https://github.com/bigbluebutton/greenlight/assets/35435341/4b9948b6-b872-415b-9a5f-a7f62f292b39)
