### PR TITLE
fixed rails backend I18n translations and added fallbacks

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -108,6 +108,9 @@ module Api
 
         if user.update(update_user_params)
           create_default_room(user)
+          if params[:language] != @current_user.language
+            I18n.default_locale = params[:language].to_sym
+          end
           render_data  status: :ok
         else
           render_error errors: user.errors.to_a

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -108,9 +108,6 @@ module Api
 
         if user.update(update_user_params)
           create_default_room(user)
-          if params[:language] != @current_user.language
-            I18n.default_locale = params[:language].to_sym
-          end
           render_data  status: :ok
         else
           render_error errors: user.errors.to_a

--- a/app/services/meeting_starter.rb
+++ b/app/services/meeting_starter.rb
@@ -57,6 +57,7 @@ class MeetingStarter
 
   def computed_options(access_code:)
     room_url = "#{root_url(host: @base_url)}rooms/#{@room.friendly_id}/join"
+    I18n.default_locale = @current_user.language.to_sym
     moderator_message = "#{I18n.t('meeting.moderator_message')}<br>#{room_url}"
     moderator_message += "<br>#{I18n.t('meeting.access_code', code: access_code)}" if access_code.present?
     {

--- a/app/services/meeting_starter.rb
+++ b/app/services/meeting_starter.rb
@@ -57,8 +57,7 @@ class MeetingStarter
 
   def computed_options(access_code:)
     room_url = "#{root_url(host: @base_url)}rooms/#{@room.friendly_id}/join"
-    I18n.default_locale = @current_user.language.to_sym
-    moderator_message = "#{I18n.t('meeting.moderator_message')}<br>#{room_url}"
+    moderator_message = "#{I18n.t('meeting.moderator_message', locale: @current_user.language.to_sym)}<br>#{room_url}"
     moderator_message += "<br>#{I18n.t('meeting.access_code', code: access_code)}" if access_code.present?
     {
       moderatorOnlyMessage: moderator_message,

--- a/app/services/meeting_starter.rb
+++ b/app/services/meeting_starter.rb
@@ -58,7 +58,7 @@ class MeetingStarter
   def computed_options(access_code:)
     room_url = "#{root_url(host: @base_url)}rooms/#{@room.friendly_id}/join"
     moderator_message = "#{I18n.t('meeting.moderator_message', locale: @current_user.language.to_sym)}<br>#{room_url}"
-    moderator_message += "<br>#{I18n.t('meeting.access_code', code: access_code)}" if access_code.present?
+    moderator_message += "<br>#{I18n.t('meeting.access_code', code: access_code, locale: @current_user.language.to_sym)}" if access_code.present?
     {
       moderatorOnlyMessage: moderator_message,
       logoutURL: room_url,

--- a/config/application.rb
+++ b/config/application.rb
@@ -84,6 +84,6 @@ module Greenlight
     config.relative_url_root = '/' if config.relative_url_root.blank?
 
     I18n.load_path += Dir[Rails.root.join('config/locales/*.{rb,yml}').to_s]
-    config.i18n.fallbacks = %i[en fr de]
+    config.i18n.fallbacks = %i[en]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -84,5 +84,6 @@ module Greenlight
     config.relative_url_root = '/' if config.relative_url_root.blank?
 
     I18n.load_path += Dir[Rails.root.join('config/locales/*.{rb,yml}').to_s]
+    config.i18n.fallbacks = [:en, :fr, :de]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -84,6 +84,6 @@ module Greenlight
     config.relative_url_root = '/' if config.relative_url_root.blank?
 
     I18n.load_path += Dir[Rails.root.join('config/locales/*.{rb,yml}').to_s]
-    config.i18n.fallbacks = [:en, :fr, :de]
+    config.i18n.fallbacks = %i[en fr de]
   end
 end

--- a/spec/services/meeting_starter_spec.rb
+++ b/spec/services/meeting_starter_spec.rb
@@ -37,7 +37,7 @@ describe MeetingStarter, type: :service do
   let(:options) do
     url = File.join(base_url, '/rooms/', room.friendly_id, '/join')
     {
-      moderatorOnlyMessage: "To invite someone to the meeting, send them this link:<br>#{url}",
+      moderatorOnlyMessage: "#{I18n.t('meeting.moderator_message', locale: user.language.to_sym)}<br>#{url}",
       logoutURL: url,
       meta_endCallbackUrl: File.join(base_url, '/meeting_ended'),
       'meta_bbb-recording-ready-url': File.join(base_url, '/recording_ready'),


### PR DESCRIPTION
Fixes #5606 and #5583 
On meeting start setting I18n language for moderatorMessage to user language and fallback language of en in case of any missing translations.