### PR TITLE
Set path attribute in session cookie when relative url is set

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -17,7 +17,8 @@
 # frozen_string_literal: true
 
 if ENV['LOADBALANCER_ENDPOINT'].present?
-  Rails.application.config.session_store :cookie_store, key: '_greenlight-3_0_session', domain: ENV.fetch('SESSION_DOMAIN_NAME', nil), path: ENV.fetch('RELATIVE_URL_ROOT', '/')
+  Rails.application.config.session_store :cookie_store, key: '_greenlight-3_0_session', domain: ENV.fetch('SESSION_DOMAIN_NAME', nil),
+                                                        path: ENV.fetch('RELATIVE_URL_ROOT', '/')
 else
   Rails.application.config.session_store :cookie_store, key: '_greenlight-3_0_session', path: ENV.fetch('RELATIVE_URL_ROOT', '/')
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -17,7 +17,7 @@
 # frozen_string_literal: true
 
 if ENV['LOADBALANCER_ENDPOINT'].present?
-  Rails.application.config.session_store :cookie_store, key: '_greenlight-3_0_session', domain: ENV.fetch('SESSION_DOMAIN_NAME', nil)
+  Rails.application.config.session_store :cookie_store, key: '_greenlight-3_0_session', domain: ENV.fetch('SESSION_DOMAIN_NAME', nil), path: ENV.fetch('RELATIVE_URL_ROOT', '/')
 else
-  Rails.application.config.session_store :cookie_store, key: '_greenlight-3_0_session'
+  Rails.application.config.session_store :cookie_store, key: '_greenlight-3_0_session', path: ENV.fetch('RELATIVE_URL_ROOT', '/')
 end


### PR DESCRIPTION
This PR sets an explicit path to the session cookie which allows the use of multiple Greenlight instances on the same domain. 

Detailed description in issue #5650 