### PR TITLE
added checks for confirm terms and email notifications

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -286,7 +286,11 @@
         "allow_users_to_preupload_presentation": "Allow Users to Preupload Presentations",
         "allow_users_to_preupload_presentation_description": "Users can preupload a presentation to be used as the default presentation for that specific room",
         "default_visibility": "Default Recording Visibility",
-        "default_visibility_description": "All newly created recordings will have this visibility by default"
+        "default_visibility_description": "All newly created recordings will have this visibility by default",
+        "confirm_terms": "Confirm terms and conditions",
+        "confirm_terms_description": "Require users to confirm terms and conditions",
+        "disable": "Disable",
+        "enable": "Enable"
       },
       "registration": {
         "registration": "Registration",
@@ -401,7 +405,8 @@
         "brand_image_deleted": "The brand image has been deleted.",
         "privacy_policy_updated": "The privacy policy has been updated.",
         "helpcenter_updated": "The help center link has been updated.",
-        "terms_of_service_updated": "The terms of service have been updated."
+        "terms_of_service_updated": "The terms of service have been updated.",
+        "confirm_terms_updated": "The confirmation for terms of service have been updated."
       },
       "recording": {
         "recording_visibility_updated": "The recording visibility has been updated.",
@@ -460,6 +465,12 @@
     "resend_activation_link": "If you haven't received an activation email or if you are having a problem using it, click on the button below to request a new activation email.",
     "resend_btn_lbl": "Resend Verification"
   },
+  "confirm_terms_page": {
+    "title": "Confirm terms and conditions",
+    "account_unconfirmed": "Your account has not accepted the terms and conditions.",
+    "message": "Please accept the terms and conditions for Greenlight.",
+    "confirm_btn_lbl": "Confirm"
+  },
   "forms": {
     "validations": {
       "full_name": {
@@ -486,6 +497,9 @@
       "password_confirmation": {
         "required": "Please enter a password confirmation",
         "match": "The passwords do not match"
+      },
+      "confirm_terms": {
+        "required": "Please accept the terms and conditions"
       },
       "emails": {
         "required": "Please enter at least one valid email",
@@ -560,6 +574,12 @@
           "password_confirmation": {
             "label": "Confirm Password",
             "placeholder": "Confirm password"
+          },
+          "confirm_terms": {
+            "label": "I Accept the terms and conditions"
+          },
+          "email_notifs": {
+            "label": "I would like to receive email updates from Greenlight"
           }
         }
       },

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -27,6 +27,7 @@
 @import 'admin_panel';
 @import 'pagination';
 @import 'fonts';
+@import 'signup.scss';
 
 html,
 body {

--- a/app/assets/stylesheets/signup.scss
+++ b/app/assets/stylesheets/signup.scss
@@ -1,0 +1,39 @@
+// BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+//
+// Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+//
+// This program is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3.0 of the License, or (at your option) any later
+// version.
+//
+// Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along
+// with Greenlight; if not, see <http://www.gnu.org/licenses/>.
+
+// making it look like a normal checkbox removing FormControl Css
+input[type="checkbox"].form-control {
+  width: auto;
+  height: auto;
+  padding: 0;
+  margin: 0;
+  vertical-align: baseline;
+  position: static;
+  display: inline-block;
+  border: none;
+  background: none;
+  box-shadow: none;
+  outline: none;
+  opacity: 1;
+  -webkit-appearance: checkbox; /* for WebKit browsers */
+  -moz-appearance: checkbox;    /* for Firefox */
+  appearance: checkbox;   
+}
+
+// additional styling
+input[type="checkbox"].form-control {
+    margin-left: 0.5em;
+}

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -100,7 +100,6 @@ module Api
       # Updates the values of a user
       def update
         user = User.find(params[:id])
-
         # User can't change their own role
         if params[:user][:role_id].present? && current_user == user && params[:user][:role_id] != user.role_id
           return render_error errors: Rails.configuration.custom_error_msgs[:unauthorized], status: :forbidden
@@ -156,11 +155,13 @@ module Api
       private
 
       def create_user_params
-        @create_user_params ||= params.require(:user).permit(:name, :email, :password, :avatar, :language, :role_id, :invite_token)
+        @create_user_params ||= params.require(:user).permit(:name, :email, :password, :avatar, :language, :role_id,
+                                                             :confirm_terms, :email_notifs, :invite_token)
       end
 
       def update_user_params
-        @update_user_params ||= params.require(:user).permit(:name, :password, :avatar, :language, :role_id, :invite_token)
+        @update_user_params ||= params.require(:user).permit(:name, :password, :avatar, :language, :role_id,
+                                                             :confirm_terms, :email_notifs, :invite_token)
       end
 
       def change_password_params

--- a/app/javascript/components/admin/site_settings/settings/Settings.jsx
+++ b/app/javascript/components/admin/site_settings/settings/Settings.jsx
@@ -26,6 +26,7 @@ export default function Settings() {
   const { t } = useTranslation();
   const { data: siteSettings, isLoading } = useSiteSettings(['ShareRooms', 'PreuploadPresentation', 'DefaultRecordingVisibility']);
   const updateDefaultRecordingVisibility = useUpdateSiteSetting('DefaultRecordingVisibility');
+  const updateConfirmTerms = useUpdateSiteSetting('ConfirmTerms');
 
   if (isLoading) return null;
 
@@ -75,6 +76,19 @@ export default function Settings() {
         </Dropdown.Item>
         <Dropdown.Item key="Unpublished" value="Unpublished" onClick={() => updateDefaultRecordingVisibility.mutate({ value: 'Unpublished' })}>
           {t('recording.unpublished')}
+        </Dropdown.Item>
+      </SettingSelect>
+
+      <SettingSelect
+        defaultValue={siteSettings?.ConfirmTerms}
+        title={t('admin.site_settings.settings.confirm_terms')}
+        description={t('admin.site_settings.settings.confirm_terms_description')}
+      >
+        <Dropdown.Item key="false" value="false" onClick={() => updateConfirmTerms.mutate({ value: 'false' })}>
+          {t('admin.site_settings.settings.disable')}
+        </Dropdown.Item>
+        <Dropdown.Item key="true" value="true" onClick={() => updateConfirmTerms.mutate({ value: 'true' })}>
+          {t('admin.site_settings.settings.enable')}
         </Dropdown.Item>
       </SettingSelect>
     </>

--- a/app/javascript/components/users/account_activation/ConfirmTerms.jsx
+++ b/app/javascript/components/users/account_activation/ConfirmTerms.jsx
@@ -1,0 +1,96 @@
+// BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+//
+// Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+//
+// This program is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3.0 of the License, or (at your option) any later
+// version.
+//
+// Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along
+// with Greenlight; if not, see <http://www.gnu.org/licenses/>.
+
+import React, { useState } from 'react';
+import {
+  Button, Card, Stack,
+} from 'react-bootstrap';
+import { useTranslation } from 'react-i18next';
+import Spinner from '../../shared_components/utilities/Spinner';
+import Logo from '../../shared_components/Logo';
+import { useAuth } from '../../../contexts/auth/AuthProvider';
+import useUpdateUser from '../../../hooks/mutations/users/useUpdateUser';
+
+export default function ConfirmTerms() {
+  const { t } = useTranslation();
+
+  const currentUser = useAuth();
+  const updateUserAPI = useUpdateUser(currentUser?.id);
+  const [isCheckedTerms, setIsCheckedTerms] = useState(currentUser?.confirm_terms || false);
+  const [isCheckedEmails, setIsCheckedEmails] = useState(currentUser?.email_notifs || false);
+
+  // Update the user's confirm_terms value when the button is clicked
+  const handleConfirmTerms = () => {
+    updateUserAPI.mutate({
+      confirm_terms: isCheckedTerms,
+      email_notifs: isCheckedEmails,
+    });
+  };
+
+  return (
+    <div className="vertical-center">
+      <div className="text-center pb-4">
+        <Logo />
+      </div>
+      <Card className="col-md-4 mx-auto p-4 border-0 card-shadow">
+        <Stack direction="vertical" className="py-3">
+          <h3><strong>{ t('confirm_terms_page.title') }</strong></h3>
+          <h5 className="mb-3">{ t('confirm_terms_page.account_unconfirmed') }</h5>
+        </Stack>
+        <span className="mb-3">{ t('confirm_terms_page.message') }</span>
+
+        <Stack direction="horizontal">
+          <Stack>
+            {t('forms.user.signup.fields.confirm_terms.label')}
+          </Stack>
+          <div className="form-switch">
+            <input
+              className="form-check-input fs-5"
+              type="checkbox"
+              checked={isCheckedTerms}
+              onChange={() => setIsCheckedTerms(!isCheckedTerms)}
+            />
+          </div>
+        </Stack>
+
+        <Stack direction="horizontal">
+          <Stack>
+            {t('forms.user.signup.fields.email_notifs.label')}
+          </Stack>
+          <div className="form-switch">
+            <input
+              className="form-check-input fs-5"
+              type="checkbox"
+              checked={isCheckedEmails}
+              onChange={() => setIsCheckedEmails(!isCheckedEmails)}
+            />
+          </div>
+        </Stack>
+
+        <Button
+          variant="brand"
+          type="submit"
+          disabled={!isCheckedTerms || updateUserAPI.isLoading}
+          onClick={handleConfirmTerms}
+          className="mt-2"
+        >
+          { t('confirm_terms_page.confirm_btn_lbl') }
+          {updateUserAPI.isLoading && <Spinner className="me-2" />}
+        </Button>
+      </Card>
+    </div>
+  );
+}

--- a/app/javascript/components/users/authentication/forms/SignupForm.jsx
+++ b/app/javascript/components/users/authentication/forms/SignupForm.jsx
@@ -43,6 +43,10 @@ export default function SignupForm() {
       <FormControl field={fields.email} type="email" />
       <FormControl field={fields.password} type="password" />
       <FormControl field={fields.password_confirmation} type="password" />
+
+      <FormControl field={fields.confirm_terms} type="checkbox" />
+      <FormControl field={fields.email_notifs} type="checkbox" />
+
       <HCaptcha ref={captchaRef} />
       <Stack className="mt-1" gap={1}>
         <Button variant="brand" className="w-100 my-3 mt-1" type="submit" disabled={createUserAPI.isLoading}>

--- a/app/javascript/contexts/auth/AuthProvider.jsx
+++ b/app/javascript/contexts/auth/AuthProvider.jsx
@@ -46,6 +46,8 @@ export default function AuthProvider({ children }) {
     external_account: currentUser?.external_account,
     stateChanging: false,
     isSuperAdmin: currentUser?.super_admin,
+    confirm_terms: currentUser?.confirm_terms,
+    email_notifs: currentUser?.email_notifs,
   };
 
   const memoizedCurrentUser = useMemo(() => user, [user]);

--- a/app/javascript/hooks/forms/users/authentication/useSignUpForm.js
+++ b/app/javascript/hooks/forms/users/authentication/useSignUpForm.js
@@ -42,6 +42,8 @@ export function useSignUpFormValidation() {
       .test('oneSymbol', 'forms.validations.password.symbol', (pwd) => pwd.match(/[`@%~!#£$\\^&*()\][+={}/|:;"'<>\-,.?_ ]/)),
     password_confirmation: yup.string().required('forms.validations.password_confirmation.required')
       .oneOf([yup.ref('password')], 'forms.validations.password_confirmation.match'),
+
+    confirm_terms: yup.boolean().oneOf([true], 'forms.validations.confirm_terms.required'),
   })), []);
 }
 
@@ -87,6 +89,20 @@ export default function useSignUpForm({ defaultValues: _defaultValues, ..._confi
         },
       },
     },
+    confirm_terms: {
+      label: t('forms.user.signup.fields.confirm_terms.label'),
+      controlId: 'signupFormConfirmTerms',
+      hookForm: {
+        id: 'confirm_terms',
+      },
+    },
+    email_notifs: {
+      label: t('forms.user.signup.fields.email_notifs.label'),
+      controlId: 'signupFormEmailNotifs',
+      hookForm: {
+        id: 'email_notifs',
+      },
+    },
   }), [i18n.resolvedLanguage]);
 
   const validationSchema = useSignUpFormValidation();
@@ -101,6 +117,8 @@ export default function useSignUpForm({ defaultValues: _defaultValues, ..._confi
           email: '',
           password: '',
           password_confirmation: '',
+          confirm_terms: false,
+          email_notifs: false,
         },
         ..._defaultValues,
       },

--- a/app/javascript/hooks/mutations/admin/site_settings/useUpdateSiteSetting.jsx
+++ b/app/javascript/hooks/mutations/admin/site_settings/useUpdateSiteSetting.jsx
@@ -60,6 +60,9 @@ export default function useUpdateSiteSetting(name) {
       case 'TermsOfService':
         toast.success(t('toast.success.site_settings.terms_of_service_updated'));
         break;
+      case 'ConfirmTerms':
+        toast.success(t('toast.success.site_settings.confirm_terms_updated'));
+        break;
       default:
         toast.success(t('toast.success.site_settings.site_setting_updated'));
     }

--- a/app/javascript/routes/AuthenticatedOnly.jsx
+++ b/app/javascript/routes/AuthenticatedOnly.jsx
@@ -20,6 +20,8 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
 import { useAuth } from '../contexts/auth/AuthProvider';
 import useDeleteSession from '../hooks/mutations/sessions/useDeleteSession';
+import useSiteSetting from '../hooks/queries/site_settings/useSiteSetting';
+import ConfirmTerms from '../components/users/account_activation/ConfirmTerms';
 
 export default function AuthenticatedOnly() {
   const { t } = useTranslation();
@@ -27,6 +29,7 @@ export default function AuthenticatedOnly() {
   const roomsMatch = useMatch('/rooms/:friendlyId');
   const superAdminMatch = useMatch('/admin/*');
   const deleteSession = useDeleteSession({ showToast: false });
+  const { data: confirmTerms } = useSiteSetting('ConfirmTerms');
 
   // User is either pending or banned
   if (currentUser.signed_in && (currentUser.status !== 'active' || !currentUser.verified)) {
@@ -48,6 +51,10 @@ export default function AuthenticatedOnly() {
 
   if (currentUser.signed_in && currentUser.isSuperAdmin && !superAdminMatch) {
     return <Navigate to="/admin/users" />;
+  }
+
+  if (currentUser.signed_in && confirmTerms && !currentUser.confirm_terms) {
+    return <ConfirmTerms />;
   }
 
   if (!currentUser.signed_in) {

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -19,7 +19,7 @@
 class UserSerializer < ApplicationSerializer
   include Avatarable
 
-  attributes :id, :name, :email, :provider, :language, :avatar, :verified, :created_at
+  attributes :id, :name, :email, :provider, :language, :avatar, :verified, :confirm_terms, :email_notifs, :created_at
 
   belongs_to :role
 
@@ -30,4 +30,8 @@ class UserSerializer < ApplicationSerializer
   def avatar
     user_avatar(object)
   end
+
+  delegate :confirm_terms, to: :object
+
+  delegate :email_notifs, to: :object
 end

--- a/db/migrate/20240108202126_add_confirm_terms_to_site_settings.rb
+++ b/db/migrate/20240108202126_add_confirm_terms_to_site_settings.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddConfirmTermsToSiteSettings < ActiveRecord::Migration[7.1]
+  def change
+    Setting.create!(name: 'ConfirmTerms') unless Setting.exists?(name: 'ConfirmTerms')
+
+    return if SiteSetting.exists?(setting: Setting.find_by(name: 'ConfirmTerms'))
+
+    SiteSetting.create!(
+      setting: Setting.find_by(name: 'ConfirmTerms'),
+      value: false,
+      provider: 'greenlight'
+    )
+
+    change_table :users, bulk: true do |t|
+      t.boolean :confirm_terms, default: false
+      t.boolean :email_notifs, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_18_154727) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_08_202126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -193,13 +193,15 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_18_154727) do
     t.uuid "role_id"
     t.string "language", null: false
     t.string "reset_digest"
-    t.datetime "reset_sent_at", precision: nil
+    t.datetime "reset_sent_at"
     t.boolean "verified", default: false
     t.string "verification_digest"
-    t.datetime "verification_sent_at", precision: nil
+    t.datetime "verification_sent_at"
     t.string "session_token"
-    t.datetime "session_expiry", precision: nil
+    t.datetime "session_expiry"
     t.integer "status", default: 0
+    t.boolean "confirm_terms", default: false
+    t.boolean "email_notifs", default: false
     t.index ["email", "provider"], name: "index_users_on_email_and_provider", unique: true
     t.index ["reset_digest"], name: "index_users_on_reset_digest", unique: true
     t.index ["role_id"], name: "index_users_on_role_id"


### PR DESCRIPTION
Screenshots of new sign up page additions and page existing users that have not confirmed terms will see if the site setting is enabled

![image](https://github.com/bigbluebutton/greenlight/assets/28535207/395d5ebc-90a0-4d35-bcad-856f8247bf47)
![image](https://github.com/bigbluebutton/greenlight/assets/28535207/1be5d579-3d76-4e98-af25-f294ebef2980)
