### PR TITLE
Reimplementing flag meta_bbb-origin-server-name from Greenlight V2

### DIFF
--- a/app/services/meeting_starter.rb
+++ b/app/services/meeting_starter.rb
@@ -65,7 +65,8 @@ class MeetingStarter
       meta_endCallbackUrl: meeting_ended_url(host: @base_url),
       'meta_bbb-recording-ready-url': recording_ready_url(host: @base_url),
       'meta_bbb-origin-version': ENV.fetch('VERSION_TAG', 'v3'),
-      'meta_bbb-origin': 'greenlight'
+      'meta_bbb-origin': 'greenlight',
+      'meta_bbb-origin-server-name': @base_url.sub(/\A\w+:\/\/?/, '')
     }
   end
 


### PR DESCRIPTION
This pull request addresses the need for reintroducing the meta_bbb-origin-server-name flag, a feature originally present in Greenlight V2 but missing in versions > 3. 

The flag is crucial for monitoring systems to identify the origin server name at a single access point, allowing for the generation of statistical analyses based on the utilized graphical user interface.