### PR TITLE
fixed admin panel three dots dropdown not showing on iphone

### DIFF
--- a/app/assets/stylesheets/admin_panel.scss
+++ b/app/assets/stylesheets/admin_panel.scss
@@ -76,7 +76,7 @@
 }
 
 #manage-users-table {
-  @include media-breakpoint-down(xl) {
+  @include media-breakpoint-down(md) {
     td, tr {
       // Full name and creation date
       &:nth-child(1) {

--- a/app/assets/stylesheets/admin_panel.scss
+++ b/app/assets/stylesheets/admin_panel.scss
@@ -67,6 +67,12 @@
   .dropdown-toggle::after {
     display: none !important;
   }
+
+  @include media-breakpoint-down(md) {
+    .dropdown-menu {
+      transform: none !important;
+    }
+  }
 }
 
 #manage-users-table {


### PR DESCRIPTION
Fixes #5407 #5657 
fixed the three dots dropdown menu not showing on iphone for administrator panel menus. screenshot added for iphone.
could not reproduce presentation button not working on iphone worked fine in my testing.
same for after leaving a meeting, the Greenlight interface is blank could not reproduce on iphone or web.

Fixed issue on ipad where for manage user list scrolls off the page and are not visible at all, so no chance to delete or block a user. Screenshot attached for ipad.

![image](https://github.com/bigbluebutton/greenlight/assets/28535207/1e6d738a-da32-4ab2-8c46-8cfe7fecaf9b)

![image](https://github.com/bigbluebutton/greenlight/assets/28535207/1c76081d-19fd-4dfe-9460-9043a3beed74)
