### PR TITLE
relax length validation for rooms and users (#5534)

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -34,7 +34,7 @@ class Room < ApplicationRecord
             content_type: Rails.configuration.uploads[:presentations][:formats],
             size: { less_than: Rails.configuration.uploads[:presentations][:max_size] }
 
-  validates :name, length: { minimum: 2, maximum: 255 }
+  validates :name, length: { minimum: 1, maximum: 255 }
   validates :recordings_processing, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   before_validation :set_friendly_id, :set_meeting_id, on: :create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ApplicationRecord
   enum status: { active: 0, pending: 1, banned: 2 }
 
   validates :name, presence: true,
-                   length: { minimum: 2, maximum: 255 } # TODO: amir - Change into full_name or seperate first and last name.
+                   length: { minimum: 1, maximum: 255 } # TODO: amir - Change into full_name or seperate first and last name.
 
   validates :email,
             format: /\A[\w\-.+]+@[\w\-.]+\.[a-z]+\z/i,

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Room, type: :model do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to have_many(:recordings).dependent(:destroy) }
     it { is_expected.to validate_presence_of(:name) }
-    it { is_expected.to validate_length_of(:name).is_at_least(2).is_at_most(255) }
+    it { is_expected.to validate_length_of(:name).is_at_least(1).is_at_most(255) }
     it { is_expected.to validate_numericality_of(:recordings_processing).only_integer.is_greater_than_or_equal_to(0) }
 
     # Can't test validation on friendly_id and meeting_id due to before_validations

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_presence_of(:session_expiry) }
     it { is_expected.to validate_presence_of(:language) }
 
-    it { is_expected.to validate_length_of(:name).is_at_least(2).is_at_most(255) }
+    it { is_expected.to validate_length_of(:name).is_at_least(1).is_at_most(255) }
     it { is_expected.to validate_length_of(:email).is_at_least(5).is_at_most(255) }
 
     context 'password complexity' do


### PR DESCRIPTION
This allows to migrate users and room of length == 1 from Greenlight 2.x to Greenlight 3.

fixes #5534.