### PR TITLE
Add bbb-origin-server-name to metadata on meeting creation

### DIFF
--- a/app/services/meeting_starter.rb
+++ b/app/services/meeting_starter.rb
@@ -16,6 +16,8 @@
 
 # frozen_string_literal: true
 
+require 'uri'
+
 class MeetingStarter
   include Rails.application.routes.url_helpers
 
@@ -65,7 +67,8 @@ class MeetingStarter
       meta_endCallbackUrl: meeting_ended_url(host: @base_url),
       'meta_bbb-recording-ready-url': recording_ready_url(host: @base_url),
       'meta_bbb-origin-version': ENV.fetch('VERSION_TAG', 'v3'),
-      'meta_bbb-origin': 'greenlight'
+      'meta_bbb-origin': 'greenlight',
+      'meta_bbb-origin-server-name': URI(@base_url).host
     }
   end
 

--- a/spec/services/meeting_starter_spec.rb
+++ b/spec/services/meeting_starter_spec.rb
@@ -18,6 +18,7 @@
 
 require 'rails_helper'
 require 'bigbluebutton_api'
+require 'uri'
 
 describe MeetingStarter, type: :service do
   let(:user) { create(:user) }
@@ -43,6 +44,7 @@ describe MeetingStarter, type: :service do
       'meta_bbb-recording-ready-url': File.join(base_url, '/recording_ready'),
       'meta_bbb-origin-version': 'v3',
       'meta_bbb-origin': 'greenlight',
+      'meta_bbb-origin-server-name': URI(base_url).host,
       setting: 'value'
     }
   end


### PR DESCRIPTION
Many BBB frontends as well as GL2 (if I remember correctly) include the hostname from the base URL as 'bbb-origin-server-name' in the meeting metadata. This is useful in analytics / statistics to differentiate usage by different frontend deployments.

GL3 does not include the bbb-origin-server-name in metadata, it is only implicitly included in the callback-url. This PR makes GL3 include bbb-origin-server-name in the metadata on meeting creation.