### PR TITLE
Maintenance banner fixes

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -281,8 +281,8 @@
         "maintenance": "Maintenance Banner",
         "change_maintenance_text": "Change the maintenance banner text that appears in the header",
         "change_url": "Change URL",
-        "set_text": "Set text",
-        "clear_text": "Clear",
+        "set_text": "Set Text",
+        "clear_banner": "Clear Banner",
         "enter_link": "Enter link here"
       },
       "settings": {

--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -281,7 +281,8 @@
         "maintenance": "Maintenance Banner",
         "change_maintenance_text": "Change the maintenance banner text that appears in the header",
         "change_url": "Change URL",
-        "change_text": "Change text",
+        "set_text": "Set text",
+        "clear_text": "Clear",
         "enter_link": "Enter link here"
       },
       "settings": {

--- a/app/javascript/App.jsx
+++ b/app/javascript/App.jsx
@@ -52,7 +52,7 @@ export default function App() {
         className: 'text-center',
         onClose: () => localStorage.setItem('maintenanceClosedAt', new Date().toISOString()),
       });
-      localStorage.setItem('maintenanceBannerId', toastId)
+      localStorage.setItem('maintenanceBannerId', toastId);
     }
   }, [maintenanceBanner.data]);
 

--- a/app/javascript/App.jsx
+++ b/app/javascript/App.jsx
@@ -40,7 +40,7 @@ export default function App() {
     const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
 
     if (maintenanceBanner.data && (!maintenanceClosedAt || now.getTime() - new Date(maintenanceClosedAt).getTime() > oneDayInMilliseconds)) {
-      toast.info(maintenanceBanner.data, {
+      const toastId = toast.info(maintenanceBanner.data, {
         position: 'top-center',
         autoClose: false,
         hideProgressBar: true,
@@ -52,6 +52,7 @@ export default function App() {
         className: 'text-center',
         onClose: () => localStorage.setItem('maintenanceClosedAt', new Date().toISOString()),
       });
+      localStorage.setItem('maintenanceBannerId', toastId)
     }
   }, [maintenanceBanner.data]);
 

--- a/app/javascript/App.jsx
+++ b/app/javascript/App.jsx
@@ -34,7 +34,12 @@ export default function App() {
 
   // useEffect hook for running notify maintenance banner on page load
   useEffect(() => {
-    if (maintenanceBanner.data) {
+    // set a cookie for a day after maintenance banner dismissed
+    const maintenanceClosedAt = localStorage.getItem('maintenanceClosedAt');
+    const now = new Date();
+    const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
+
+    if (maintenanceBanner.data && (!maintenanceClosedAt || now.getTime() - new Date(maintenanceClosedAt).getTime() > oneDayInMilliseconds)) {
       toast.info(maintenanceBanner.data, {
         position: 'top-center',
         autoClose: false,
@@ -45,6 +50,7 @@ export default function App() {
         progress: undefined,
         theme: 'light',
         className: 'text-center',
+        onClose: () => localStorage.setItem('maintenanceClosedAt', new Date().toISOString()),
       });
     }
   }, [maintenanceBanner.data]);

--- a/app/javascript/components/admin/site_settings/administration/Administration.jsx
+++ b/app/javascript/components/admin/site_settings/administration/Administration.jsx
@@ -29,6 +29,15 @@ export default function Administration() {
   return (
     <>
       <Row>
+        <h6> { t('admin.site_settings.administration.maintenance') } </h6>
+        <p className="text-muted"> { t('admin.site_settings.administration.change_maintenance_text') } </p>
+        <TextForm
+          id="maintenanceForm"
+          mutation={() => useUpdateSiteSetting('Maintenance')}
+          value={siteSettings?.Maintenance}
+        />
+      </Row>
+      <Row>
         <h6> { t('admin.site_settings.administration.terms') } </h6>
         <p className="text-muted"> { t('admin.site_settings.administration.change_term_links') } </p>
         <LinksForm
@@ -53,15 +62,6 @@ export default function Administration() {
           id="helpForm"
           mutation={() => useUpdateSiteSetting('HelpCenter')}
           value={siteSettings?.HelpCenter}
-        />
-      </Row>
-      <Row>
-        <h6> { t('admin.site_settings.administration.maintenance') } </h6>
-        <p className="text-muted"> { t('admin.site_settings.administration.change_maintenance_text') } </p>
-        <TextForm
-          id="maintenanceForm"
-          mutation={() => useUpdateSiteSetting('Maintenance')}
-          value={siteSettings?.Maintenance}
         />
       </Row>
     </>

--- a/app/javascript/components/admin/site_settings/administration/TextForm.jsx
+++ b/app/javascript/components/admin/site_settings/administration/TextForm.jsx
@@ -22,6 +22,7 @@ import Form from '../../../shared_components/forms/Form';
 import Spinner from '../../../shared_components/utilities/Spinner';
 import FormControl from '../../../shared_components/forms/FormControl';
 import useTextForm from '../../../../hooks/forms/admin/site_settings/useTextForm';
+import { toast } from 'react-toastify';
 
 export default function TextForm({ id, value, mutation: useUpdateSiteSettingsAPI }) {
   const updateSiteSettingsAPI = useUpdateSiteSettingsAPI();
@@ -32,6 +33,8 @@ export default function TextForm({ id, value, mutation: useUpdateSiteSettingsAPI
   // Function to clear the form
   const clearForm = () => {
     methods.reset({ value: '' });
+    let maintenanceBannerId = localStorage.getItem('maintenanceBannerId')
+    toast.dismiss(maintenanceBannerId)
   };
 
   return (
@@ -44,7 +47,7 @@ export default function TextForm({ id, value, mutation: useUpdateSiteSettingsAPI
       />
       <Button id={`${id}-clear-btn`} className="mb-2 float-end" variant="brand" onClick={clearForm} disabled={updateSiteSettingsAPI.isLoading}>
         {updateSiteSettingsAPI.isLoading && <Spinner className="me-2" />}
-        { t('admin.site_settings.administration.clear_text') }
+        { t('admin.site_settings.administration.clear_banner') }
       </Button>
       <Button id={`${id}-submit-btn`} className="mb-2 float-end me-2" variant="brand" type="submit" disabled={updateSiteSettingsAPI.isLoading}>
         {updateSiteSettingsAPI.isLoading && <Spinner className="me-2" />}

--- a/app/javascript/components/admin/site_settings/administration/TextForm.jsx
+++ b/app/javascript/components/admin/site_settings/administration/TextForm.jsx
@@ -29,6 +29,11 @@ export default function TextForm({ id, value, mutation: useUpdateSiteSettingsAPI
 
   const { methods, fields } = useTextForm({ defaultValues: { value } });
 
+  // Function to clear the form
+  const clearForm = () => {
+    methods.reset({ value: '' });
+  };
+
   return (
     <Form id={id} methods={methods} onSubmit={updateSiteSettingsAPI.mutate}>
       <FormControl
@@ -37,9 +42,13 @@ export default function TextForm({ id, value, mutation: useUpdateSiteSettingsAPI
         type="text"
         noLabel
       />
-      <Button id={`${id}-submit-btn`} className="mb-2 float-end" variant="brand" type="submit" disabled={updateSiteSettingsAPI.isLoading}>
+      <Button id={`${id}-clear-btn`} className="mb-2 float-end" variant="brand" onClick={clearForm} disabled={updateSiteSettingsAPI.isLoading}>
         {updateSiteSettingsAPI.isLoading && <Spinner className="me-2" />}
-        { t('admin.site_settings.administration.change_text') }
+        { t('admin.site_settings.administration.clear_text') }
+      </Button>
+      <Button id={`${id}-submit-btn`} className="mb-2 float-end me-2" variant="brand" type="submit" disabled={updateSiteSettingsAPI.isLoading}>
+        {updateSiteSettingsAPI.isLoading && <Spinner className="me-2" />}
+        { t('admin.site_settings.administration.set_text') }
       </Button>
     </Form>
   );

--- a/app/javascript/components/admin/site_settings/administration/TextForm.jsx
+++ b/app/javascript/components/admin/site_settings/administration/TextForm.jsx
@@ -18,23 +18,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
 import Form from '../../../shared_components/forms/Form';
 import Spinner from '../../../shared_components/utilities/Spinner';
 import FormControl from '../../../shared_components/forms/FormControl';
 import useTextForm from '../../../../hooks/forms/admin/site_settings/useTextForm';
-import { toast } from 'react-toastify';
 
 export default function TextForm({ id, value, mutation: useUpdateSiteSettingsAPI }) {
   const updateSiteSettingsAPI = useUpdateSiteSettingsAPI();
   const { t } = useTranslation();
+  const maintenanceBannerId = localStorage.getItem('maintenanceBannerId');
 
   const { methods, fields } = useTextForm({ defaultValues: { value } });
 
   // Function to clear the form
   const clearForm = () => {
     methods.reset({ value: '' });
-    let maintenanceBannerId = localStorage.getItem('maintenanceBannerId')
-    toast.dismiss(maintenanceBannerId)
+    toast.dismiss(maintenanceBannerId);
   };
 
   return (


### PR DESCRIPTION
If the user clicks the x button on the banner, it will be hidden for 24 hours.
Clear banner button sets maintenance banner to be blank and dismisses it.
minors change of naming Set Text button instead of Change Text.