### PR TITLE
All users join moderator no longer allowing anyone to start meeting

### DIFF
--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -125,7 +125,7 @@ module Api
 
       def authorized_to_start_meeting?(settings, bbb_role)
         if settings['glAnyoneJoinAsModerator'] == 'true'
-          settings['glAnyoneCanStart'] == 'true' || @room.user_id == current_user&.id
+          settings['glAnyoneCanStart'] == 'true' || @room.user_id == current_user&.id || current_user&.shared_rooms&.include?(@room)
         else
           settings['glAnyoneCanStart'] == 'true' || bbb_role == 'Moderator'
         end

--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -124,7 +124,11 @@ module Api
       end
 
       def authorized_to_start_meeting?(settings, bbb_role)
-        settings['glAnyoneCanStart'] == 'true' || bbb_role == 'Moderator'
+        if(settings['glAnyoneJoinAsModerator'])
+          settings['glAnyoneCanStart'] == 'true' || @room.user_id == current_user&.id
+        else
+          settings['glAnyoneCanStart'] == 'true' || bbb_role == 'Moderator'
+        end
       end
 
       def unauthorized_access?(settings)

--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -67,7 +67,7 @@ module Api
         }
 
         # Starts meeting if meeting is not running and glAnyoneCanStart is enabled or user is a moderator
-        if !data[:status] && authorized_to_start_meeting?(settings, bbb_role)
+        if !data[:status] && authorized_to_start_meeting?(settings)
           begin
             MeetingStarter.new(room: @room, base_url: request.base_url, current_user:, provider: current_provider).call
           rescue BigBlueButton::BigBlueButtonException => e
@@ -123,7 +123,7 @@ module Api
           (anyone_join_as_mod && (access_code_validator(access_code: mod_code) || access_code_validator(access_code: viewer_code)))
       end
 
-      def authorized_to_start_meeting?(settings, bbb_role)
+      def authorized_to_start_meeting?(settings)
         settings['glAnyoneCanStart'] == 'true' || @room.user_id == current_user&.id || current_user&.shared_rooms&.include?(@room)
       end
 

--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -124,7 +124,7 @@ module Api
       end
 
       def authorized_to_start_meeting?(settings, bbb_role)
-        if (settings['glAnyoneJoinAsModerator'] == 'true')
+        if settings['glAnyoneJoinAsModerator'] == 'true'
           settings['glAnyoneCanStart'] == 'true' || @room.user_id == current_user&.id
         else
           settings['glAnyoneCanStart'] == 'true' || bbb_role == 'Moderator'

--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -124,7 +124,7 @@ module Api
       end
 
       def authorized_to_start_meeting?(settings, bbb_role)
-        if(settings['glAnyoneJoinAsModerator'])
+        if (settings['glAnyoneJoinAsModerator'] == 'true')
           settings['glAnyoneCanStart'] == 'true' || @room.user_id == current_user&.id
         else
           settings['glAnyoneCanStart'] == 'true' || bbb_role == 'Moderator'

--- a/app/controllers/api/v1/meetings_controller.rb
+++ b/app/controllers/api/v1/meetings_controller.rb
@@ -124,11 +124,7 @@ module Api
       end
 
       def authorized_to_start_meeting?(settings, bbb_role)
-        if settings['glAnyoneJoinAsModerator'] == 'true'
-          settings['glAnyoneCanStart'] == 'true' || @room.user_id == current_user&.id || current_user&.shared_rooms&.include?(@room)
-        else
-          settings['glAnyoneCanStart'] == 'true' || bbb_role == 'Moderator'
-        end
+        settings['glAnyoneCanStart'] == 'true' || @room.user_id == current_user&.id || current_user&.shared_rooms&.include?(@room)
       end
 
       def unauthorized_access?(settings)


### PR DESCRIPTION
Fixes #5714 
if glAnyoneJoinAsModerator is true then only the room owner can start the meeting or if glAnyoneCanStart is true anyone can
previously turning on glAnyoneJoinAsModerator allowed anyone to start the meeting