### PR TITLE
room setting for all moderators now hides approve users setting

### DIFF
--- a/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
+++ b/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
@@ -85,13 +85,15 @@ export default function RoomSettings() {
                 config={roomConfigs?.glRequireAuthentication}
                 description={t('room.settings.require_signed_in')}
               />
-              <RoomSettingsRow
-                settingName="guestPolicy"
-                updateMutation={updateMutationWrapper}
-                value={roomSetting?.data?.guestPolicy}
-                config={roomConfigs?.guestPolicy}
-                description={t('room.settings.require_mod_approval')}
-              />
+              { roomSetting?.data?.glAnyoneJoinAsModerator === 'false' && (
+                <RoomSettingsRow
+                  settingName="guestPolicy"
+                  updateMutation={updateMutationWrapper}
+                  value={roomSetting?.data?.guestPolicy}
+                  config={roomConfigs?.guestPolicy}
+                  description={t('room.settings.require_mod_approval')}
+                />
+              )}
               <RoomSettingsRow
                 settingName="glAnyoneCanStart"
                 updateMutation={updateMutationWrapper}

--- a/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
+++ b/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
@@ -85,15 +85,16 @@ export default function RoomSettings() {
                 config={roomConfigs?.glRequireAuthentication}
                 description={t('room.settings.require_signed_in')}
               />
-              { roomSetting?.data?.glAnyoneJoinAsModerator === 'false' && (
-                <RoomSettingsRow
-                  settingName="guestPolicy"
-                  updateMutation={updateMutationWrapper}
-                  value={roomSetting?.data?.guestPolicy}
-                  config={roomConfigs?.guestPolicy}
-                  description={t('room.settings.require_mod_approval')}
-                />
-              )}
+
+              <RoomSettingsRow
+                settingName="guestPolicy"
+                updateMutation={updateMutationWrapper}
+                value={roomSetting?.data?.guestPolicy}
+                config={roomConfigs?.guestPolicy}
+                description={t('room.settings.require_mod_approval')}
+                disabled={roomSetting?.data?.glAnyoneJoinAsModerator === 'true'}
+              />
+
               <RoomSettingsRow
                 settingName="glAnyoneCanStart"
                 updateMutation={updateMutationWrapper}

--- a/app/javascript/components/rooms/room/room_settings/RoomSettingsRow.jsx
+++ b/app/javascript/components/rooms/room/room_settings/RoomSettingsRow.jsx
@@ -18,7 +18,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 export default function RoomSettingsRow({
-  settingName, config, value, description, updateMutation: useUpdateAPI,
+  settingName, config, value, description, updateMutation: useUpdateAPI, disabled
 }) {
   const updateAPI = useUpdateAPI();
   const checkedValue = useMemo(() => {
@@ -49,7 +49,7 @@ export default function RoomSettingsRow({
           onChange={(event) => {
             updateAPI.mutate({ settingName, settingValue: event.target.checked });
           }}
-          disabled={updateAPI.isLoading || config === 'true'}
+          disabled={updateAPI.isLoading || config === 'true' || disabled}
         />
       </div>
     </div>

--- a/app/javascript/components/rooms/room/room_settings/RoomSettingsRow.jsx
+++ b/app/javascript/components/rooms/room/room_settings/RoomSettingsRow.jsx
@@ -18,7 +18,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 export default function RoomSettingsRow({
-  settingName, config, value, description, updateMutation: useUpdateAPI, disabled
+  settingName, config, value, description, updateMutation: useUpdateAPI, disabled,
 }) {
   const updateAPI = useUpdateAPI();
   const checkedValue = useMemo(() => {
@@ -59,6 +59,7 @@ export default function RoomSettingsRow({
 RoomSettingsRow.defaultProps = {
   value: '',
   config: 'false',
+  disabled: false,
 };
 
 RoomSettingsRow.propTypes = {
@@ -67,4 +68,5 @@ RoomSettingsRow.propTypes = {
   value: PropTypes.string,
   config: PropTypes.string,
   description: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
 };

--- a/lib/tasks/server_recordings_sync.rake
+++ b/lib/tasks/server_recordings_sync.rake
@@ -26,6 +26,8 @@ task :server_recordings_sync, %i[provider] => :environment do |_task, args|
 
     recordings = BigBlueButtonApi.new(provider: args[:provider]).get_recordings(meeting_ids:)
 
+    rooms.update_all(recordings_processing: 0) # rubocop:disable Rails/SkipsModelValidations
+
     next if recordings[:recordings].blank?
 
     # Skip the entire batch if the first and last recordings exist

--- a/lib/tasks/server_recordings_sync.rake
+++ b/lib/tasks/server_recordings_sync.rake
@@ -26,8 +26,6 @@ task :server_recordings_sync, %i[provider] => :environment do |_task, args|
 
     recordings = BigBlueButtonApi.new(provider: args[:provider]).get_recordings(meeting_ids:)
 
-    rooms.update_all(recordings_processing: 0) # rubocop:disable Rails/SkipsModelValidations
-
     next if recordings[:recordings].blank?
 
     # Skip the entire batch if the first and last recordings exist


### PR DESCRIPTION
Fixes #4286
when the room setting for "all users join as moderator" is active it will disable "Require moderator approval before joining" setting.