### PR TITLE
recordings sync rake task now sets recordings_processing back to 0

### DIFF
--- a/lib/tasks/server_recordings_sync.rake
+++ b/lib/tasks/server_recordings_sync.rake
@@ -26,6 +26,8 @@ task :server_recordings_sync, %i[provider] => :environment do |_task, args|
 
     recordings = BigBlueButtonApi.new(provider: args[:provider]).get_recordings(meeting_ids:)
 
+    rooms.update_all(recordings_processing: 0) # rubocop:disable Rails/SkipsModelValidations
+
     next if recordings[:recordings].blank?
 
     # Skip the entire batch if the first and last recordings exist


### PR DESCRIPTION
Fixes #5713 