### PR TITLE
fix(migrations): Set user password_digest only if it was received

### DIFF
--- a/app/controllers/api/v1/migrations/external_controller.rb
+++ b/app/controllers/api/v1/migrations/external_controller.rb
@@ -103,8 +103,13 @@ module Api
 
           return render_error(status: :bad_request, errors: user&.errors&.to_a) unless user.save
 
-          user.password_digest = user_hash[:provider] == 'greenlight' ? user_hash[:password_digest] : nil
-          user.save(validations: false)
+          if user_hash[:provider] != 'greenlight'
+            user.password_digest = nil
+            user.save(validations: false)
+          elsif user_hash[:password_digest]
+            user.password_digest = user_hash[:password_digest]
+            user.save(validations: false)
+          end
 
           render_data status: :created
         end


### PR DESCRIPTION
This fixes situations where after a migration from v2 due to a peculiar behavior, which refuses empty passwords but not empty password hashes, could end up with an empty password.