### PR TITLE
Host header

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,7 @@
 module ApplicationHelper
   def branding_image
     asset_path = SettingGetter.new(setting_name: 'BrandingImage', provider: current_provider).call
-    asset_url(asset_path, host: ENV.fetch('HOST', nil))
+    asset_url(asset_path, host: ENV.fetch('URL_HOST', nil))
   end
 
   def page_title

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,8 @@
 module ApplicationHelper
   def branding_image
     asset_path = SettingGetter.new(setting_name: 'BrandingImage', provider: current_provider).call
-    asset_url(asset_path)
+    puts "TESTING: #{ENV.fetch('HOST')}"
+    asset_url(asset_path, host: ENV.fetch('HOST', nil))
   end
 
   def page_title

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,6 @@
 module ApplicationHelper
   def branding_image
     asset_path = SettingGetter.new(setting_name: 'BrandingImage', provider: current_provider).call
-    puts "TESTING: #{ENV.fetch('HOST')}"
     asset_url(asset_path, host: ENV.fetch('HOST', nil))
   end
 

--- a/sample.env
+++ b/sample.env
@@ -71,6 +71,9 @@ REDIS_URL=
 #GCS_CLIENT_ID=
 #GCS_CLIENT_CERT=
 
+# Set this to explicitly specify base hostname
+#HOST=
+
 # Define the default locale language code (i.e. 'en' for English) from the following list:
 #  [en, ar, fr, es, fa_IR]
 # The DEFAULT_LOCALE setting specifies the default language, overriding the browser language which is always set.

--- a/sample.env
+++ b/sample.env
@@ -72,7 +72,7 @@ REDIS_URL=
 #GCS_CLIENT_CERT=
 
 # Set this to explicitly specify base hostname
-#HOST=
+#URL_HOST=
 
 # Define the default locale language code (i.e. 'en' for English) from the following list:
 #  [en, ar, fr, es, fa_IR]


### PR DESCRIPTION
Fixes #5625 
Added option to pass URL_HOST as an optional env variable which fixes the host-header issue. Below is a screenshot of the test with cmd `curl http://localhost:3000/ -H "X-Forwarded-Host: evil.com" | grep property` as the image shows the og:image no longer shows as content from evil.com as I had the URL_HOST var set to http://localhost:3000

![image](https://github.com/bigbluebutton/greenlight/assets/28535207/740f5b3a-eac3-476f-a13c-99e9512d3c63)

