### PR TITLE
Mail Notification when User Role is changed

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -56,6 +56,14 @@ class UserMailer < ApplicationMailer
     mail(to: emails, subject: t('email.new_user_signup.new_user'))
   end
 
+  def role_change_notification_email
+    
+    @user = params[:user]
+    @new_role = params[:role]
+  
+      mail(to: email_address_with_name(@user.email, @user.name), subject: t('email.role_change_notification.role_change'))
+  end
+
   private
 
   def preset

--- a/app/views/user_mailer/role_change_notification_email.html.erb
+++ b/app/views/user_mailer/role_change_notification_email.html.erb
@@ -1,0 +1,25 @@
+<!--BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.-->
+
+<!--Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).-->
+
+<!--This program is free software; you can redistribute it and/or modify it under the-->
+<!--terms of the GNU Lesser General Public License as published by the Free Software-->
+<!--Foundation; either version 3.0 of the License, or (at your option) any later-->
+<!--version.-->
+
+<!--Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY-->
+<!--WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A-->
+<!--PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.-->
+
+<!--You should have received a copy of the GNU Lesser General Public License along-->
+<!--with Greenlight; if not, see <http://www.gnu.org/licenses/>.-->
+
+<div style="padding-left: 80px; padding-right: 80px;">
+  <p style="font-size: 40px; margin-bottom: 20px; font-weight: 600;"><%= t('email.role_change_notification.role_change') %></p>
+
+  <p style="font-size: 24px;"><%= t('email.role_change_notification.role_change_description', new_role: @new_role) %></p>
+
+   <a href="<%= @base_url %>" target="_blank" style="background-color: <%= @brand_color %>; border-radius: 8px; border: none; color: white; padding: 15px 32px; text-align: center; text-decoration: none; display: inline-block; font-size: 16px; font-weight: 600; margin-top: 16px; margin-bottom: 64px;">
+    <%= t('email.role_change_notification.site') %>
+  </a>
+</div>

--- a/app/views/user_mailer/role_change_notification_email.text.erb
+++ b/app/views/user_mailer/role_change_notification_email.text.erb
@@ -1,0 +1,24 @@
+<%#
+  BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+
+  Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+
+  This program is free software; you can redistribute it and/or modify it under the
+  terms of the GNU Lesser General Public License as published by the Free Software
+  Foundation; either version 3.0 of the License, or (at your option) any later
+  version.
+
+  Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License along
+  with Greenlight; if not, see http://www.gnu.org/licenses/.
+%>
+
+---
+<%= t('email.role_change_notification.role_change') %>
+<%= t('email.role_change_notification.role_change_description', new_role: @new_role) %>
+<%= t('email.role_change_notification.site') %>
+<%= @base_url %>
+---

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -79,5 +79,9 @@ de:
       reset_password: Passwort zurücksetzen
       link_expires: Der Link wird in 1 Stunde ungültig.
       ignore_request: "Wenn du dein Passwort nicht ändern wolltest, dann ignoriere bitte diese E-Mail."
+    role_change_notification:
+      role_change: "Ihre Benutzer-Rolle wurde geändert"
+      role_change_description: "Ihr BigBlueButton-Konto hat die Rolle \"%{new_role}\" erhalten"
+      site: "In BigBlueButton einloggen"
   room:
     new_room_name: "Raum von %{username}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,5 +79,9 @@ en:
       reset_password: Reset Password
       link_expires: The link will expire in 1 hour.
       ignore_request: If you did not make a request to change your password, please ignore this email.
+    role_change_notification:
+      role_change: "Your user-role has been changed"
+      role_change_description: "Your BigBlueButton-user has been assigned to the role \"%{new_role}\""
+      site: "log in to BigBlueButton"
   room:
     new_room_name: "%{username}'s Room"


### PR DESCRIPTION
In Glv3 it is not as handy to map users to roles on behalf of ldap-attributes...
In our Use-Case everyone in our company has to be able to log in to our BigBlueButton-Server... (via KeyCloak) just not everyone should be authorized to create and start meetings... so we decided to instruct administratiors to promote users by hand if necessary when receiving "New User Sign Up" - Mails... This works well... but we want the users to get notfified via mail when their role gets promoted... The changes from this branch implements this "feature"