### PR TITLE
Do not require email for signup with invite

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -49,8 +49,19 @@ module Api
 
         registration_method = SettingGetter.new(setting_name: 'RegistrationMethod', provider: current_provider).call
 
-        if registration_method == SiteSetting::REGISTRATION_METHODS[:invite] && !valid_invite_token && !admin_create
-          return render_error errors: Rails.configuration.custom_error_msgs[:invite_token_invalid]
+        if registration_method == SiteSetting::REGISTRATION_METHODS[:invite] && !admin_create
+          if create_user_params[:invite_token].blank?
+            return render_error errors: Rails.configuration.custom_error_msgs[:invite_token_invalid]
+          end
+
+          invite = Invitation.find_by(provider: current_provider, token: create_user_params[:invite_token])
+          if !invite.present?
+            return render_error errors: Rails.configuration.custom_error_msgs[:invite_token_invalid]
+          end
+
+          create_user_params[:email] = invite.email
+
+          invite.destroy
         end
 
         # TODO: Add proper error logging for non-verified token hcaptcha
@@ -171,14 +182,6 @@ module Api
 
       def change_password_params
         params.require(:user).permit(:old_password, :new_password)
-      end
-
-      def valid_invite_token
-        return false if create_user_params[:invite_token].blank?
-
-        # Try to delete the invitation and return true if it succeeds
-        Invitation.destroy_by(email: create_user_params[:email].downcase, provider: current_provider,
-                              token: create_user_params[:invite_token]).present?
       end
     end
   end

--- a/app/javascript/components/users/authentication/Signup.jsx
+++ b/app/javascript/components/users/authentication/Signup.jsx
@@ -52,7 +52,7 @@ export default function Signup() {
       </div>
       <Card className="col-xl-5 col-lg-6 col-md-8 col-10 mx-auto p-4 border-0 card-shadow">
         <Card.Title className="text-center pb-2"> { t('authentication.create_an_account') } </Card.Title>
-        <SignupForm />
+        <SignupForm registrationMethod={registrationMethodSettingAPI.data} />
         <span className="text-center text-muted small"> { t('authentication.already_have_account') }
           <Link to="/signin" className="text-link"> { t('authentication.sign_in') } </Link>
         </span>

--- a/app/javascript/components/users/authentication/forms/SignupForm.jsx
+++ b/app/javascript/components/users/authentication/forms/SignupForm.jsx
@@ -24,9 +24,9 @@ import useCreateUser from '../../../../hooks/mutations/users/useCreateUser';
 import useSignUpForm from '../../../../hooks/forms/users/authentication/useSignUpForm';
 import HCaptcha from '../../../shared_components/utilities/HCaptcha';
 
-export default function SignupForm() {
+export default function SignupForm({registrationMethod}) {
   const { t } = useTranslation();
-  const { fields, methods } = useSignUpForm();
+  const { fields, methods } = useSignUpForm(registrationMethod);
   const createUserAPI = useCreateUser();
   const captchaRef = useRef(null);
 
@@ -40,7 +40,9 @@ export default function SignupForm() {
   return (
     <Form methods={methods} onSubmit={handleSubmit}>
       <FormControl field={fields.name} type="text" autoFocus />
+      { registrationMethod !== 'invite' && (
       <FormControl field={fields.email} type="email" />
+      )}
       <FormControl field={fields.password} type="password" />
       <FormControl field={fields.password_confirmation} type="password" />
       <HCaptcha ref={captchaRef} />

--- a/app/javascript/hooks/forms/users/authentication/useSignUpForm.js
+++ b/app/javascript/hooks/forms/users/authentication/useSignUpForm.js
@@ -20,15 +20,11 @@ import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
 import { useCallback, useMemo } from 'react';
 
-export function useSignUpFormValidation() {
-  return useMemo(() => (yup.object({
+export function useSignUpFormValidation(registrationMethod) {
+  const spec = {
     name: yup.string().required('forms.validations.full_name.required')
       .min(2, 'forms.validations.full_name.min')
       .max(255, 'forms.validations.full_name.max'),
-
-    email: yup.string().required('forms.validations.email.required').email('forms.validations.email.email')
-      .min(6, 'forms.validations.email.min')
-      .max(255, 'forms.validations.email.max'),
 
     password: yup.string().max(255, 'forms.validations.password.max')
       .matches(
@@ -42,10 +38,18 @@ export function useSignUpFormValidation() {
       .test('oneSymbol', 'forms.validations.password.symbol', (pwd) => pwd.match(/[`@%~!#£$\\^&*()\][+={}/|:;"'<>\-,.?_ ]/)),
     password_confirmation: yup.string().required('forms.validations.password_confirmation.required')
       .oneOf([yup.ref('password')], 'forms.validations.password_confirmation.match'),
-  })), []);
+  }
+
+  if (registrationMethod !== 'invite') {
+    spec.email = yup.string().required('forms.validations.email.required').email('forms.validations.email.email')
+      .min(6, 'forms.validations.email.min')
+      .max(255, 'forms.validations.email.max')
+  }
+
+  return useMemo(() => (yup.object(spec)), []);
 }
 
-export default function useSignUpForm({ defaultValues: _defaultValues, ..._config } = {}) {
+export default function useSignUpForm(registrationMethod, { defaultValues: _defaultValues, ..._config } = {}) {
   const { t, i18n } = useTranslation();
 
   const fields = useMemo(() => ({
@@ -89,7 +93,7 @@ export default function useSignUpForm({ defaultValues: _defaultValues, ..._confi
     },
   }), [i18n.resolvedLanguage]);
 
-  const validationSchema = useSignUpFormValidation();
+  const validationSchema = useSignUpFormValidation(registrationMethod);
 
   const config = useMemo(() => ({
     ...{


### PR DESCRIPTION
Currently, users must enter their email address when they sign up with an invitation. This email must match the email address for the invitation.
This pr changes that so that users do not have to enter their email address:
1. The email field is removed from the sign-up form when the registration method is invite.
2.  The user creation functions uses the email from the invite token.

Potential issue: The invite token is used as a unique index by itself. The documentations for has_secure_token states:
> Note that it’s still possible to generate a race condition in the database in the same way that validates_uniqueness_of can. You’re encouraged to add a unique index in the database to deal with this even more unlikely scenario.

I lack the understanding of active recording to judge, if this is the problem in this case.

