### PR TITLE
Admin can revoke user invites from Manage Users page

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -230,7 +230,7 @@
       "invited": {
         "time_sent": "Time Sent",
         "valid": "Valid",
-        "revoke_invite": "Revoke Invite"
+        "revoke": "Revoke"
       }
     },
     "server_rooms": {

--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -230,7 +230,8 @@
       "invited": {
         "time_sent": "Time Sent",
         "valid": "Valid"
-      }
+      },
+      "revoke_invite": "Revoke Invite"
     },
     "server_rooms": {
       "server_rooms": "Server Rooms",

--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -229,9 +229,9 @@
       "empty_invited_users_subtext": "When a user's status gets changed to invited, they will appear here.",
       "invited": {
         "time_sent": "Time Sent",
-        "valid": "Valid"
-      },
-      "revoke_invite": "Revoke Invite"
+        "valid": "Valid",
+        "revoke_invite": "Revoke Invite"
+      }
     },
     "server_rooms": {
       "server_rooms": "Server Rooms",
@@ -430,7 +430,8 @@
         "role_permission_updated": "The role permission has been updated."
       },
       "invitations": {
-        "invitation_sent": "An invitation has been sent."
+        "invitation_sent": "An invitation has been sent.",
+        "invitation_revoked": "An invitation has been revoked"
       }
     },
     "error": {

--- a/app/controllers/api/v1/admin/invitations_controller.rb
+++ b/app/controllers/api/v1/admin/invitations_controller.rb
@@ -63,11 +63,11 @@ module Api
 
         def destroy
           invitation = Invitation.find(params[:id])
-          invitation.destroy
-          render_data status: :ok
-        rescue StandardError => e
-          logger.error "Failed to revoke invite, error: #{e.message}"
-          render_error status: :bad_request
+          if invitation.destroy
+            render_data status: :ok
+          else
+            render_error status: :not_found
+          end
         end
       end
     end

--- a/app/controllers/api/v1/admin/invitations_controller.rb
+++ b/app/controllers/api/v1/admin/invitations_controller.rb
@@ -60,6 +60,15 @@ module Api
           logger.error "Failed to send invitations to #{params[:invitations][:emails]} - #{e}"
           render_error status: :bad_request
         end
+
+        def destroy
+          invitation = Invitation.find(params[:id])
+          invitation.destroy
+          render_data status: :ok
+        rescue StandardError => e
+          logger.error "Failed to revoke invite, error: #{e.message}"
+          render_error status: :bad_request
+        end
       end
     end
   end

--- a/app/javascript/components/admin/manage_users/InvitedUsersTable.jsx
+++ b/app/javascript/components/admin/manage_users/InvitedUsersTable.jsx
@@ -28,7 +28,6 @@ import EmptyUsersList from './EmptyUsersList';
 import { localizeDateTimeString } from '../../../helpers/DateTimeHelper';
 import { useAuth } from '../../../contexts/auth/AuthProvider';
 import ManageUsersInvitedRowPlaceHolder from './ManageUsersInvitedRowPlaceHolder';
-// import Modal from '../../shared_components/modals/Modal';
 import useRevokeUserInvite from '../../../hooks/mutations/admin/manage_users/useRevokeUserInvite';
 
 export default function InvitedUsersTable({ searchInput }) {
@@ -83,7 +82,7 @@ export default function InvitedUsersTable({ searchInput }) {
                               <Dropdown.Menu>
                                 <Dropdown.Item onClick={() => revokeUserInvite.mutate(invitation.id)}>
                                   <XCircleIcon className="hi-s me-2" />
-                                  {t('admin.manage_users.revoke_invite')}
+                                  {t('admin.manage_users.invited.revoke_invite')}
                                 </Dropdown.Item>
                               </Dropdown.Menu>
                             </Dropdown>

--- a/app/javascript/components/admin/manage_users/InvitedUsersTable.jsx
+++ b/app/javascript/components/admin/manage_users/InvitedUsersTable.jsx
@@ -18,7 +18,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Table, Dropdown } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
-import { CheckIcon, XMarkIcon, XCircleIcon } from '@heroicons/react/24/solid';
+import { CheckIcon, XMarkIcon, ArchiveBoxXMarkIcon } from '@heroicons/react/24/solid';
 import { EllipsisVerticalIcon } from '@heroicons/react/24/outline';
 import SortBy from '../../shared_components/search/SortBy';
 import useInvitations from '../../../hooks/queries/admin/manage_users/useInvitations';
@@ -81,8 +81,8 @@ export default function InvitedUsersTable({ searchInput }) {
                               <Dropdown.Toggle className="hi-s" as={EllipsisVerticalIcon} />
                               <Dropdown.Menu>
                                 <Dropdown.Item onClick={() => revokeUserInvite.mutate(invitation.id)}>
-                                  <XCircleIcon className="hi-s me-2" />
-                                  {t('admin.manage_users.invited.revoke_invite')}
+                                  <ArchiveBoxXMarkIcon className="hi-s me-2" />
+                                  {t('admin.manage_users.invited.revoke')}
                                 </Dropdown.Item>
                               </Dropdown.Menu>
                             </Dropdown>

--- a/app/javascript/components/admin/manage_users/InvitedUsersTable.jsx
+++ b/app/javascript/components/admin/manage_users/InvitedUsersTable.jsx
@@ -16,9 +16,10 @@
 
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Table } from 'react-bootstrap';
+import { Table, Dropdown } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
-import { CheckIcon, XMarkIcon } from '@heroicons/react/24/solid';
+import { CheckIcon, XMarkIcon, XCircleIcon } from '@heroicons/react/24/solid';
+import { EllipsisVerticalIcon } from '@heroicons/react/24/outline';
 import SortBy from '../../shared_components/search/SortBy';
 import useInvitations from '../../../hooks/queries/admin/manage_users/useInvitations';
 import Pagination from '../../shared_components/Pagination';
@@ -27,12 +28,15 @@ import EmptyUsersList from './EmptyUsersList';
 import { localizeDateTimeString } from '../../../helpers/DateTimeHelper';
 import { useAuth } from '../../../contexts/auth/AuthProvider';
 import ManageUsersInvitedRowPlaceHolder from './ManageUsersInvitedRowPlaceHolder';
+// import Modal from '../../shared_components/modals/Modal';
+import useRevokeUserInvite from '../../../hooks/mutations/admin/manage_users/useRevokeUserInvite';
 
 export default function InvitedUsersTable({ searchInput }) {
   const { t } = useTranslation();
   const [page, setPage] = useState();
   const { isLoading, data: invitations } = useInvitations(searchInput, page);
   const currentUser = useAuth();
+  const revokeUserInvite = useRevokeUserInvite();
 
   if (!searchInput && invitations?.data?.length === 0) {
     return <EmptyUsersList text={t('admin.manage_users.empty_invited_users')} subtext={t('admin.manage_users.empty_invited_users_subtext')} />;
@@ -72,6 +76,17 @@ export default function InvitedUsersTable({ searchInput }) {
                           <td className="text-dark border-0">{localizeDateTimeString(invitation.updated_at, currentUser?.language)}</td>
                           <td className="text-dark border-0">
                             { invitation.valid ? <CheckIcon className="text-success hi-s" /> : <XMarkIcon className="text-danger hi-s" />}
+                          </td>
+                          <td className="text-dark border-0">
+                            <Dropdown className="float-end cursor-pointer">
+                              <Dropdown.Toggle className="hi-s" as={EllipsisVerticalIcon} />
+                              <Dropdown.Menu>
+                                <Dropdown.Item onClick={() => revokeUserInvite.mutate(invitation.id)}>
+                                  <XCircleIcon className="hi-s me-2" />
+                                  {t('admin.manage_users.revoke_invite')}
+                                </Dropdown.Item>
+                              </Dropdown.Menu>
+                            </Dropdown>
                           </td>
                         </tr>
                       ))

--- a/app/javascript/hooks/mutations/admin/manage_users/useRevokeUserInvite.jsx
+++ b/app/javascript/hooks/mutations/admin/manage_users/useRevokeUserInvite.jsx
@@ -1,3 +1,19 @@
+// BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+//
+// Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+//
+// This program is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3.0 of the License, or (at your option) any later
+// version.
+//
+// Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along
+// with Greenlight; if not, see <http://www.gnu.org/licenses/>.
+
 import { useMutation, useQueryClient } from 'react-query';
 import { toast } from 'react-toastify';
 import { useTranslation } from 'react-i18next';

--- a/app/javascript/hooks/mutations/admin/manage_users/useRevokeUserInvite.jsx
+++ b/app/javascript/hooks/mutations/admin/manage_users/useRevokeUserInvite.jsx
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from 'react-query';
+import { toast } from 'react-toastify';
+import { useTranslation } from 'react-i18next';
+import axios from '../../../../helpers/Axios';
+
+export default function useRevokeUserInvite() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    (id) => axios.delete(`/admin/invitations/${id}.json`),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['getInvitations']);
+        toast.success(t('toast.success.invitations.invitation_revoked'));
+      },
+      onError: () => {
+        toast.error(t('toast.error.problem_completing_action'));
+      },
+    },
+  );
+}

--- a/app/serializers/invitation_serializer.rb
+++ b/app/serializers/invitation_serializer.rb
@@ -17,7 +17,7 @@
 # frozen_string_literal: true
 
 class InvitationSerializer < ApplicationSerializer
-  attributes :email, :updated_at, :valid
+  attributes :id, :email, :updated_at, :valid
 
   def valid
     object.updated_at.in(Invitation::INVITATION_VALIDITY_PERIOD)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,7 +106,7 @@ Rails.application.routes.draw do
         end
         resources :rooms_configurations, only: :update, param: :name
         resources :roles
-        resources :invitations, only: %i[index create]
+        resources :invitations, only: %i[index create destroy]
         resources :role_permissions, only: [:index] do
           collection do
             post '/', to: 'role_permissions#update'

--- a/spec/controllers/admin/invitations_controller_spec.rb
+++ b/spec/controllers/admin/invitations_controller_spec.rb
@@ -108,8 +108,8 @@ RSpec.describe Api::V1::Admin::InvitationsController do
 
   describe 'invitation#destroy' do
     it 'deletes the invitation' do
-      invitation = create(:invitation, email: 'faker@faker.com')
-      expect { delete :destroy, params: { id: invitation.id } }
+      invitation = create(:invitation)
+      expect { delete :destroy, params: { id: invitation.id } }.to change(Invitation, :count).by(-1)
       expect(response).to have_http_status(:ok)
     end
 

--- a/spec/controllers/admin/invitations_controller_spec.rb
+++ b/spec/controllers/admin/invitations_controller_spec.rb
@@ -18,7 +18,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V1::Admin::InvitationsController, type: :controller do
+RSpec.describe Api::V1::Admin::InvitationsController do
   let(:user) { create(:user) }
   let(:user_with_manage_users_permission) { create(:user, :with_manage_users_permission) }
 
@@ -103,6 +103,19 @@ RSpec.describe Api::V1::Admin::InvitationsController, type: :controller do
         expect { post :create, params: { invitations: valid_params } }.not_to change(Role, :count)
         expect(response).to have_http_status(:forbidden)
       end
+    end
+  end
+
+  describe 'invitation#destroy' do
+    it 'deletes the invitation' do
+      invitation = create(:invitation, email: 'faker@faker.com')
+      expect { delete :destroy, params: { id: invitation.id } }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'fails to delete the invitation if the id does not exist' do
+      expect { delete :destroy, params: { id: 'invalid-id' } }.not_to change(Invitation, :count)
+      expect(response).to have_http_status(:not_found)
     end
   end
 end


### PR DESCRIPTION
resolves #5385 

**Changes:** 
- Revoke Users Invite Mutation added and called from `InvitedUsersTable.jsx `
- Destroy route added to Invitations Controller 
- ID added to Invitation Serializer to allow invitations to be found by ID 
- Tests to be added in later commits 