### PR TITLE
Invitation expiration date changed to 7 days

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -17,7 +17,7 @@
 # frozen_string_literal: true
 
 class Invitation < ApplicationRecord
-  INVITATION_VALIDITY_PERIOD = 48.hours
+  INVITATION_VALIDITY_PERIOD = 7.days
 
   has_secure_token :token
 

--- a/app/serializers/invitation_serializer.rb
+++ b/app/serializers/invitation_serializer.rb
@@ -20,6 +20,8 @@ class InvitationSerializer < ApplicationSerializer
   attributes :id, :email, :updated_at, :valid
 
   def valid
-    object.updated_at.in(Invitation::INVITATION_VALIDITY_PERIOD)
+    expiration_time = object.updated_at + Invitation::INVITATION_VALIDITY_PERIOD
+
+    Time.current <= expiration_time
   end
 end

--- a/app/serializers/invitation_serializer.rb
+++ b/app/serializers/invitation_serializer.rb
@@ -20,8 +20,6 @@ class InvitationSerializer < ApplicationSerializer
   attributes :id, :email, :updated_at, :valid
 
   def valid
-    expiration_time = object.updated_at + Invitation::INVITATION_VALIDITY_PERIOD
-
-    Time.current <= expiration_time
+    object.updated_at < Invitation::INVITATION_VALIDITY_PERIOD.ago
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,7 +63,7 @@ en:
       invitation_to_join: BigBlueButton Invitation
       you_have_been_invited: You have been invited to create a BigBlueButton account by %{name}.
       get_started: To sign up, please click the button below and follow the steps.
-      valid_invitation: The invitation is valid for 24 hours.
+      valid_invitation: The invitation is valid for 7 days.
       sign_up: Sign Up
     new_user_signup:
       new_user: New BigBlueButton User Signup


### PR DESCRIPTION
resolves #5847 

- Invitation expiration date changed to 7 days. 
- Serializer updated to check for validity of invite.