### PR TITLE
Remove email fallback

### DIFF
--- a/app/controllers/external_controller.rb
+++ b/app/controllers/external_controller.rb
@@ -32,13 +32,6 @@ class ExternalController < ApplicationController
 
     user = User.find_by(external_id: credentials['uid'], provider:)
 
-    # Fallback mechanism to search by email
-    if user.blank?
-      user = User.find_by(email: credentials['info']['email'], provider:)
-      # Update the user's external id to the latest value to avoid using the fallback
-      user.update(external_id: credentials['uid']) if user.present? && credentials['uid'].present?
-    end
-
     new_user = user.blank?
 
     registration_method = SettingGetter.new(setting_name: 'RegistrationMethod', provider: current_provider).call


### PR DESCRIPTION
Don't fall back to email as identifier if no user with external_id found.

For more details see https://github.com/bigbluebutton/greenlight/issues/5872

## 

On top of this change, I introduced the following mechanism for our setup, to allow users to log in if they received an email that was previously owned by a different external account (which has previously logged into Greenlight). Without this code, Greenlight will not create the new user due to conflicting email addresses.
```
    # Replace any existing email with "dummy" value
    email_user = User.find_by(email: user_info[:email], provider:)
    if email_user.present? && user_info[:external_id].present? && email_user.external_id != user_info[:external_id]
      email_user.update(email: "#{email_user.id}@example.net")
    end
```
This changes the email associated with that other account to a dummy value, which does not cause issues and will be updated on the next login. The only alternative would be to completely delete the other account in Greenlight.

@farhatahmad Let me know if you want this code in GL, maybe behind a config flag.