### PR TITLE
Pass through user_id to BBB meeting

### DIFF
--- a/app/services/big_blue_button_api.rb
+++ b/app/services/big_blue_button_api.rb
@@ -44,12 +44,13 @@ class BigBlueButtonApi
     end
   end
 
-  def join_meeting(room:, role:, name: nil, avatar_url: nil)
+  def join_meeting(room:, role:, user_id:, name: nil, avatar_url: nil)
     bbb_server.join_meeting_url(
       room.meeting_id,
       name,
       '', # empty password -> use the role passed ing
       {
+        userId: user_id,
         role:,
         avatarURL: avatar_url,
         createTime: room.last_session&.to_datetime&.strftime('%Q')

--- a/app/services/meeting_starter.rb
+++ b/app/services/meeting_starter.rb
@@ -69,9 +69,11 @@ class MeetingStarter
       logoutURL: room_url,
       meta_endCallbackUrl: meeting_ended_url(host: @base_url),
       'meta_bbb-recording-ready-url': recording_ready_url(host: @base_url),
-      'meta_bbb-origin-version': ENV.fetch('VERSION_TAG', 'v3'),
       'meta_bbb-origin': 'greenlight',
-      'meta_bbb-origin-server-name': URI(@base_url).host
+      'meta_bbb-origin-server-name': URI(@base_url).host,
+      'meta_bbb-origin-version': ENV.fetch('VERSION_TAG', 'v3'),
+      'meta_bbb-context-name': @room.name,
+      'meta_bbb-context-id': @room.friendly_id
     }
   end
 

--- a/spec/services/meeting_starter_spec.rb
+++ b/spec/services/meeting_starter_spec.rb
@@ -46,6 +46,8 @@ describe MeetingStarter, type: :service do
       'meta_bbb-origin-version': 'v3',
       'meta_bbb-origin': 'greenlight',
       'meta_bbb-origin-server-name': URI(base_url).host,
+      'meta_bbb-context-name': room.name,
+      'meta_bbb-context-id': room.friendly_id,
       setting: 'value'
     }
   end


### PR DESCRIPTION
- if the user is logged in, pass through user id to BBB
- If the user is not logged in, set a cookie and pass that value (useful for banning in BBB)
- Update the meta data being passed to BBB to include the missing fields