### PR TITLE
Fix superfluous white space being passed in "required" server-tag meeting options

### DIFF
--- a/app/services/meeting_starter.rb
+++ b/app/services/meeting_starter.rb
@@ -85,7 +85,7 @@ class MeetingStarter
       tag_required = meeting_options.delete('serverTagRequired')
 
       if tag_names.key?(tag) && !(tag_roles.key?(tag) && tag_roles[tag].exclude?(@room.user.role_id))
-        tag_param = tag_required == 'true' ? "#{tag} !" : tag
+        tag_param = tag_required == 'true' ? "#{tag}!" : tag
         meeting_options.store('meta_server-tag', tag_param)
       end
     else


### PR DESCRIPTION
Fixes https://github.com/bigbluebutton/greenlight/issues/5935