### PR TITLE
Fixes to roles_controller update & delete action. Changes need to be reflected in SiteSetting DefaultRole setting.

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -452,7 +452,8 @@
       "signin_required": "You must be signed in to access this page.",
       "malware_detected": "Malware Detected! The file you uploaded may contain malware. Please check your file and try again.",
       "roles": {
-        "role_assigned": "This role can't be deleted because it is assigned to at least one user."
+        "role_assigned": "This role can't be deleted because it is assigned to at least one user.",
+        "role_set_as_default": "This role can't be deleted because it is set as Default Role in Site Setting."
       },
       "users": {
         "signup_error": "You can't be authenticated. Please contact your administrator.",

--- a/app/controllers/api/v1/admin/roles_controller.rb
+++ b/app/controllers/api/v1/admin/roles_controller.rb
@@ -66,7 +66,7 @@ module Api
         # Deletes a role
         def destroy
           undeletable_roles = %w[User Administrator Guest]
-          return render_error errors: @role.errors.to_a, status: :method_not_allowed if undeletable_roles.include?(@role.name)
+          return render_error errors: @role.errors.to_a, status: :method_not_allowed if undeletable_roles.include?(@role.name) || User.find_by(role_id: @role.id)
 
           @role.destroy!
 

--- a/app/controllers/api/v1/admin/roles_controller.rb
+++ b/app/controllers/api/v1/admin/roles_controller.rb
@@ -62,7 +62,7 @@ module Api
           return render_error errors: @role.errors.to_a, status: :bad_request unless @role.update role_params
 
           # update the 'DefaultRole' site setting value, if it used to be the current role.
-          default_role_site_setting = SiteSetting.joins(:setting).find_by(provider: current_provider, setting: { name: 'DefaultRole'})
+          default_role_site_setting = SiteSetting.joins(:setting).find_by(provider: current_provider, setting: { name: 'DefaultRole' })
 
           default_role_site_setting.update(value: @role.name) if default_role_site_setting.value == old_role_name
 
@@ -73,12 +73,16 @@ module Api
         # Deletes a role
         def destroy
           undeletable_roles = %w[User Administrator Guest]
-          return render_error errors: @role.errors.to_a, status: :method_not_allowed if undeletable_roles.include?(@role.name) || User.find_by(role_id: @role.id)
+          if undeletable_roles.include?(@role.name) || User.find_by(role_id: @role.id)
+            return render_error errors: @role.errors.to_a,
+                                status: :method_not_allowed
+          end
 
           # prevent role from being deleted if its the default role in site setting
-          default_role_site_setting = SiteSetting.joins(:setting).find_by(provider: current_provider, setting: { name: 'DefaultRole'})
+          default_role_site_setting = SiteSetting.joins(:setting).find_by(provider: current_provider, setting: { name: 'DefaultRole' })
 
           return render_error status: :forbidden if default_role_site_setting.value == @role.name
+
           @role.destroy!
 
           render_data status: :ok

--- a/app/controllers/api/v1/admin/roles_controller.rb
+++ b/app/controllers/api/v1/admin/roles_controller.rb
@@ -57,7 +57,14 @@ module Api
         # POST /api/v1/:id/roles.json
         # Updates a role
         def update
+          old_role_name = @role.name
+
           return render_error errors: @role.errors.to_a, status: :bad_request unless @role.update role_params
+
+          # update the 'DefaultRole' site setting value, if it used to be the current role.
+          default_role_site_setting = SiteSetting.joins(:setting).find_by(provider: current_provider, setting: { name: 'DefaultRole'})
+
+          default_role_site_setting.update(value: @role.name) if default_role_site_setting.value == old_role_name
 
           render_data status: :ok
         end
@@ -68,6 +75,10 @@ module Api
           undeletable_roles = %w[User Administrator Guest]
           return render_error errors: @role.errors.to_a, status: :method_not_allowed if undeletable_roles.include?(@role.name) || User.find_by(role_id: @role.id)
 
+          # prevent role from being deleted if its the default role in site setting
+          default_role_site_setting = SiteSetting.joins(:setting).find_by(provider: current_provider, setting: { name: 'DefaultRole'})
+
+          return render_error status: :forbidden if default_role_site_setting.value == @role.name
           @role.destroy!
 
           render_data status: :ok

--- a/app/javascript/hooks/mutations/admin/roles/useDeleteRole.jsx
+++ b/app/javascript/hooks/mutations/admin/roles/useDeleteRole.jsx
@@ -31,6 +31,8 @@ export default function useDeleteRole({ role, onSettled }) {
       onError: (error) => {
         if (error.response?.status === 405) {
           toast.error(t('toast.error.roles.role_assigned'));
+        } else if (error.response?.status === 403) {
+          toast.error(t('toast.error.roles.role_set_as_default'));
         } else {
           toast.error(t('toast.error.problem_completing_action'));
         }


### PR DESCRIPTION

### First Commit - Extended return condition to render error if Users are associated with role.

- I have tried to modify return condition for error status :method_not_allowed by adding additional OR condition which checks if any User is associated with the role because if we don't manually do it here we get a Internal Server Error from Postgres stating foreign key constraint violation which is correct at its place.

- But at UI we get "The action cant be completed" in the toast message. This don't align with our requirements. So i have manually added the OR condition check.

- This way I eliminate Internal Server Error stuff which is a good practice. Also the toast shows the proper message as already stated in useDeleteRole hook. The same message gets displayed when we try to delete the pre defined roles.

**PFA Screenshot of the issue :** 

Suppose I have a user with Role as : test-role

Now when i try to delete test-role i get toast as : 

![image](https://github.com/user-attachments/assets/ae86be4d-bc06-4db1-ab00-0daeb05dac98)

and in my terminal i get : 

![image](https://github.com/user-attachments/assets/7bb25d67-d74f-4a10-a9f9-887974c5a70a)
![image](https://github.com/user-attachments/assets/55832ca0-5e15-480b-8dd9-5a4de8cf2e81)

After Fixing the issue : 

Toast I get : 

![image](https://github.com/user-attachments/assets/f8592526-4c55-4b4f-b2f0-4c2c12fe8962)

And on terminal i get : 

![image](https://github.com/user-attachments/assets/98b9851d-6d7c-4fe0-af54-20adc0487a15)

********************************************************************************************************

### Second Commit - Modified update and destroy action route for roles_controller. Added further error handler to useDeleteRole.jsx

- In update action we chain the name update to SiteSetting DefaultRole. This ensures consistency.

- We avoid the delete action for the role that is assigned as DefaultRole in SiteSetting. If we don't do this we don't have any side effects as this case is already handled by setting fallback to User role, in case the DefaultRole is not present. But I think this should be handled properly by giving a correct error message. We return status: :forbidden in that case and the same is handled in the useDeleteRole hook.

- What I observe is that if the update and delete action is not aligned with SiteSetting Default Role then the drop-down appearing for the setting in the UI is left empty without any valid selection. This isn't good practice.

**PFA Screenshot of the issue :** 

Suppose I have a Role as : test-role. This i set as default role in site setting

![image](https://github.com/user-attachments/assets/3ef8a0de-b02f-4296-88ec-e04c4a4b3b22)

Now when i update the test-role to test-role-update, it gets successfully updated while in the UI the dropdown selection gets empty.

![image](https://github.com/user-attachments/assets/212b0f63-5ef5-40fa-89eb-6f24cf1b7e5d)

Same situation happens when we try to delete this test-role. Deletion happens successfully.

Note : We can delete only if no users are associated to that role. Here I am considering no users are associated and then when we delete

After Fixing the issue : 

On Update  : 

![image](https://github.com/user-attachments/assets/1aec2ef2-c1b3-41aa-a8c9-db25cd3b5f80)

On Delete the toast i get :

![image](https://github.com/user-attachments/assets/2b8a55fd-0708-4b5a-8b1e-df8cf92d8157)

On terminal output shows as  :

![image](https://github.com/user-attachments/assets/b3f5c1d9-e8c8-4550-be3a-1d3c79285cae)

