### PR TITLE
Return unauthorized if recording ready call fails

### DIFF
--- a/app/controllers/external_controller.rb
+++ b/app/controllers/external_controller.rb
@@ -113,6 +113,8 @@ class ExternalController < ApplicationController
     RecordingCreator.new(recording:, first_creation: true).call
 
     render json: {}, status: :ok
+  rescue JWT::DecodeError
+    render json: {}, status: :unauthorized
   end
 
   # GET /meeting_ended


### PR DESCRIPTION
https://github.com/blindsidenetworks/scalelite/pull/1129

This functionality is added to work with the retry mechanism added to Scalelite to fix the issues with the recording_ready notifier when using multiple secrets