### PR TITLE
update keycloak to 26.0

### DIFF
--- a/docker-compose.kc.yml
+++ b/docker-compose.kc.yml
@@ -1,7 +1,7 @@
 
   keycloak:
     command: start
-    image: quay.io/keycloak/keycloak:20.0
+    image: quay.io/keycloak/keycloak:26.0
     container_name: keycloak
     restart: unless-stopped
     environment:
@@ -12,9 +12,10 @@
       - KC_DB_USERNAME=postgres
       - KC_DB_URL_DATABASE=keycloakdb
       - KC_DB_PASSWORD=
-      - KC_HOSTNAME_STRICT=false
+      - KC_HTTP_ENABLED=true
       - KC_HTTP_RELATIVE_PATH=/keycloak
-      - KC_PROXY=edge
+      - KC_HOSTNAME_STRICT=false
+      - KC_PROXY_HEADERS=xforwarded
     ports:
       - 127.0.0.1:5151:8080
     logging:


### PR DESCRIPTION
Instead of keycloak 20.0 the recent version 26.0 should be used

Appropriate to the [Upgrading Guide](https://www.keycloak.org/docs/latest/upgrading/#deprecated-proxy-option) the environment variables need to be adapted to `KC_PROXY_HEADERS=xforwarded` and `KC_HTTP_ENABLED=true` instead of `KC_PROXY=edge`. 