### PR TITLE
Fix Dockerfile to prevent build issues since Ruby 3.3 Docker was updated to 3.3.7 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3-alpine3.20 AS base
+FROM ruby:3.3.6-alpine3.20 AS base
 
 ARG RAILS_ROOT=/usr/src/app
 ENV RAILS_ROOT=${RAILS_ROOT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,7 @@ RUN apk update \
     && yarn cache clean
 COPY . ./
 RUN apk update \
-    && apk upgrade \
-    && update-ca-certificates
+    && apk upgrade
 
 EXPOSE ${PORT}
 ENTRYPOINT [ "./bin/start" ]


### PR DESCRIPTION
Since upstream Ruby 3.3 changed to 3.3.7, I've encountered issues with some gem, preventing the GL container to build from the `Dockerfile`. I'd suggest pinning to Ruby 3.3.6 for the moment, which is done in this PR.