### PR TITLE
Added avatar support when passed through Keycloak

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,7 +73,7 @@ Metrics/ClassLength:
 # A calculated magnitude based on number of assignments,
 # branches, and conditions.
 Metrics/AbcSize:
-  Max: 95
+  Max: 105
 
 Metrics/ParameterLists:
   CountKeywordArgs: false

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -35,7 +35,6 @@ module Api
         render_data data: user, status: :ok
       end
 
-      # rubocop:disable Metrics/AbcSize
       # POST /api/v1/users.json
       # Creates and saves a new user record in the database with the provided parameters
       def create
@@ -97,7 +96,6 @@ module Api
           render_error errors: Rails.configuration.custom_error_msgs[:record_invalid], status: :bad_request
         end
       end
-      # rubocop:enable Metrics/AbcSize
 
       # PATCH /api/v1/users/:id.json
       # Updates the values of a user

--- a/app/controllers/external_controller.rb
+++ b/app/controllers/external_controller.rb
@@ -54,6 +54,7 @@ class ExternalController < ApplicationController
     # Create the user if they don't exist
     if new_user
       user = UserCreator.new(user_params: user_info, provider: current_provider, role: default_role).call
+      handle_avatar(user, credentials['info']['image'])
       user.save!
       create_default_room(user)
 
@@ -64,8 +65,9 @@ class ExternalController < ApplicationController
       end
     end
 
-    if SettingGetter.new(setting_name: 'ResyncOnLogin', provider:).call
+    if !new_user && SettingGetter.new(setting_name: 'ResyncOnLogin', provider:).call
       user.assign_attributes(user_info.except(:language)) # Don't reset the user's language
+      handle_avatar(user, credentials['info']['image'])
       user.save! if user.changed?
     end
 
@@ -175,6 +177,24 @@ class ExternalController < ApplicationController
       external_id: credentials['uid'],
       verified: true
     }
+  end
+
+  # Downloads the image and correctly attaches it to the user
+  def handle_avatar(user, image)
+    return if image.blank? || !user.valid? # return if no image passed or user isnt valid
+
+    profile_file = URI.parse(image)
+
+    filename = File.basename(profile_file.path)
+    return if user.avatar&.filename&.to_s == filename # return if the filename is the same
+
+    file = profile_file.open
+    user.avatar.attach(
+      io: file, filename:, content_type: file.content_type
+    )
+  rescue StandardError => e
+    Rails.logger.error("Failed to upload avatar for #{user.id}: #{e}")
+    nil
   end
 
   def valid_domain?(email)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ApplicationRecord
             on: %i[create update], if: :password_digest_changed?, unless: :external_id?
 
   validates :avatar,
-            dimension: { width: 300, height: 300 },
+            dimension: { width: { in: 1..300 }, height: { in: 1..300 } },
             content_type: Rails.configuration.uploads[:images][:formats],
             size: { less_than: Rails.configuration.uploads[:images][:max_size] }
 

--- a/spec/controllers/external_controller_spec.rb
+++ b/spec/controllers/external_controller_spec.rb
@@ -437,6 +437,65 @@ RSpec.describe ExternalController do
         expect(User.find_by(email: OmniAuth.config.mock_auth[:openid_connect][:info][:email]).role).to eq(role1)
       end
     end
+
+    context 'avatar' do
+      before do
+        OmniAuth.config.mock_auth[:openid_connect] = OmniAuth::AuthHash.new(
+          uid: Faker::Internet.uuid,
+          info: {
+            email: Faker::Internet.email,
+            name: Faker::Name.name,
+            image: Faker::Avatar.image
+          }
+        )
+
+        request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
+        stub_request(:get, OmniAuth.config.mock_auth[:openid_connect][:info][:image])
+          .to_return(body: file_fixture('default-avatar.png'), headers: { 'Content-Type' => 'image/jpeg' }, status: 200)
+      end
+
+      it 'attaches the avatar to the user' do
+        get :create_user, params: { provider: 'openid_connect' }
+
+        expect(User.find_by(email: OmniAuth.config.mock_auth[:openid_connect][:info][:email]).avatar).to be_attached
+      end
+
+      it 'does not re-attach the avatar if it hasnt changed' do
+        reg_method = instance_double(SettingGetter)
+        allow(SettingGetter).to receive(:new).with(setting_name: 'ResyncOnLogin', provider: 'greenlight').and_return(reg_method)
+        allow(reg_method).to receive(:call).and_return(true)
+
+        profile_file = URI.parse(OmniAuth.config.mock_auth[:openid_connect][:info][:image])
+        filename = File.basename(profile_file.path)
+
+        user = create(:user, email: OmniAuth.config.mock_auth[:openid_connect][:info][:email])
+        user.avatar.attach(io: fixture_file_upload('default-avatar.png'), filename:, content_type: 'image/png')
+
+        expect(User.find_by(email: OmniAuth.config.mock_auth[:openid_connect][:info][:email]).avatar).not_to receive(:attach)
+        get :create_user, params: { provider: 'openid_connect' }
+      end
+
+      it 'does not prevent the user from being created if the avatar attaching fails' do
+        allow(OmniAuth.config.mock_auth[:openid_connect][:info][:image]).to receive(:blank?).and_raise(StandardError, 'Some error')
+
+        expect { get :create_user, params: { provider: 'openid_connect' } }.not_to raise_error
+        expect(User.find_by(email: OmniAuth.config.mock_auth[:openid_connect][:info][:email])).to be_present
+      end
+
+      it 'does not try to attach the avatar if no image is passed' do
+        OmniAuth.config.mock_auth[:openid_connect][:info][:image] = nil
+
+        get :create_user, params: { provider: 'openid_connect' }
+
+        expect(User.find_by(email: OmniAuth.config.mock_auth[:openid_connect][:info][:email]).avatar).not_to be_attached
+      end
+
+      it 'does not try to attach the avatar if the user is invalid' do
+        allow_any_instance_of(User).to receive(:valid?).and_return(false)
+        expect_any_instance_of(User).not_to receive(:avatar)
+        get :create_user, params: { provider: 'openid_connect' }
+      end
+    end
   end
 
   describe '#recording_ready' do


### PR DESCRIPTION
Added support for avatars that are passed through under the `image` key

For keycloak, there's some mapping changes that will need to be made to add support (atleast for Google, likely for others as well)

fixes #5987 