### PR TITLE
[Improvement] : Added disabled option to input element in RolePermissionRow.jsx

### DIFF
--- a/app/javascript/components/admin/roles/RolePermissionRow.jsx
+++ b/app/javascript/components/admin/roles/RolePermissionRow.jsx
@@ -34,6 +34,7 @@ export default function RolePermissionRow({
           className="form-check-input fs-5"
           type="checkbox"
           defaultChecked={defaultValue}
+          disabled={updateAPI.isLoading}
           onClick={(event) => {
             updateAPI.mutate({ role_id: roleId, name: permissionName, value: event.target.checked });
           }}


### PR DESCRIPTION
This will prevent piling of multiple POST request to update role permission api simultaneously. We will disable the button when the api is in loading state.

This makes sense mostly for the CreateRoom Permission. Because at backend, once this option is enabled not only it performs the update action but also it has chained operation of creating rooms for user. This might take some time in completion and then returning success message, if there are large chunks of users for whom this needs to be done. So consecutive request needs to be handled well. 

```
def create_default_room
	return unless role_params[:name] == 'CreateRoom' && role_params[:value] == true
        User.includes(:rooms)
              .with_provider(current_provider)
              .where(role_id: role_params[:role_id])
              .where(rooms: { id: nil }).find_in_batches do |group|
            group.each do |user|
              Room.create(name: t('room.new_room_name', username: user.name, locale: user.language), user_id: user.id)
            end
          end
  end
```