### PR TITLE
[Minor fix] : Reversed if else condition. More general toast error message should be placed in else block

### DIFF
--- a/app/javascript/hooks/mutations/rooms/useStartMeeting.jsx
+++ b/app/javascript/hooks/mutations/rooms/useStartMeeting.jsx
@@ -29,10 +29,10 @@ export default function useStartMeeting(friendlyId) {
         window.location.href = joinUrl;
       },
       onError: (error) => {
-        if (error.response.data.errors !== 'serverTagUnavailable') {
-          toast.error(t('toast.error.problem_completing_action'));
-        } else {
+        if (error.response.data.errors === 'serverTagUnavailable') {
           toast.error(t('toast.error.server_type_unavailable'));
+        } else {
+          toast.error(t('toast.error.problem_completing_action'));
         }
       },
     },


### PR DESCRIPTION
Tried to follow the design as used in other hooks. Most general error toast should be in else block. While serverTagUnavailable stuff should be in if block handling. This will help us having scope to add further error handling cases in future