### PR TITLE
Manually Verify Users in Unverified Tab

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -208,6 +208,7 @@
       "ban": "Ban",
       "unban": "Unban",
       "unverified": "Unverified",
+      "verify": "Verify",
       "deleted": "Deleted",
       "invited_tab": "Invited",
       "invite_user": "Invite User",
@@ -231,6 +232,8 @@
       "empty_pending_users_subtext": "When a user's status gets changed to pending, they will appear here.",
       "empty_banned_users": "There are no banned users on this server yet!",
       "empty_banned_users_subtext": "When a user's status gets changed to banned, they will appear here.",
+      "empty_unverified_users": "There are no unverified users on this server yet!",
+      "empty_unverified_users_subtext": "When a user's status gets changed to unverified, they will appear here.",
       "empty_invited_users": "There are no invited users on this server yet!",
       "empty_invited_users_subtext": "When a user's status gets changed to invited, they will appear here.",
       "invited": {

--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -207,6 +207,7 @@
       "banned": "Banned",
       "ban": "Ban",
       "unban": "Unban",
+      "unverified": "Unverified",
       "deleted": "Deleted",
       "invited_tab": "Invited",
       "invite_user": "Invite User",

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -51,13 +51,13 @@ module Api
         end
 
         # GET /api/v1/admin/users/verified.json
-        # Fetches all active users
+        # Fetches all verified users
         def verified
           sort_config = config_sorting(allowed_columns: %w[name roles.name])
 
           users = User.includes(:role)
                       .with_provider(current_provider)
-                      .where(status: 'active')
+                      .where(verified: true)
                       .with_attached_avatar
                       .order(sort_config, created_at: :desc)&.search(params[:search])
 

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -99,7 +99,7 @@ module Api
         private
 
         def user_params
-          params.require(:user).permit(:status)
+          params.require(:user).permit(:status, :verified)
         end
       end
     end

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -66,6 +66,22 @@ module Api
           render_data data: users, meta: pagy_metadata(pagy), serializer: UserSerializer, status: :ok
         end
 
+        # GET /api/v1/admin/users/unverified.json
+        # Fetches all unverified users
+        def unverified
+          sort_config = config_sorting(allowed_columns: %w[name roles.name])
+
+          users = User.includes(:role)
+                      .with_provider(current_provider)
+                      .where(verified: false)
+                      .with_attached_avatar
+                      .order(sort_config, created_at: :desc)&.search(params[:search])
+
+          pagy, users = pagy(users)
+
+          render_data data: users, meta: pagy_metadata(pagy), serializer: UserSerializer, status: :ok
+        end
+
         # GET /api/v1/admin/users/banned.json
         # Fetches all banned users
         def banned

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -57,7 +57,7 @@ module Api
 
           users = User.includes(:role)
                       .with_provider(current_provider)
-                      .where(verified: true)
+                      .where(status: 'active', verified: true)
                       .with_attached_avatar
                       .order(sort_config, created_at: :desc)&.search(params[:search])
 

--- a/app/javascript/components/admin/manage_users/BannedPendingRow.jsx
+++ b/app/javascript/components/admin/manage_users/BannedPendingRow.jsx
@@ -26,16 +26,50 @@ import {
   EllipsisVerticalIcon,
   XCircleIcon,
 } from '@heroicons/react/24/outline';
+import { render } from 'react-dom';
 import Avatar from '../../users/user/Avatar';
 import useUpdateUserStatus from '../../../hooks/mutations/admin/manage_users/useUpdateUserStatus';
 import { localizeDateTimeString } from '../../../helpers/DateTimeHelper';
 import { useAuth } from '../../../contexts/auth/AuthProvider';
 
-export default function BannedPendingRow({ user, pendingTable }) {
+export default function BannedPendingRow({ user, tableType }) {
   const { t } = useTranslation();
   const updateUserStatus = useUpdateUserStatus();
   const currentUser = useAuth();
   const localizedTime = localizeDateTimeString(user?.created_at, currentUser?.language);
+
+  const renderDropdownItems = () => {
+    if (tableType === 'pending') {
+      return (
+        <>
+          <Dropdown.Item onClick={() => updateUserStatus.mutate({ id: user.id, status: 'active' })}>
+            <CheckCircleIcon className="hi-s me-2" />
+            {t('admin.manage_users.approve')}
+          </Dropdown.Item>
+          <Dropdown.Item onClick={() => updateUserStatus.mutate({ id: user.id, status: 'banned' })}>
+            <XCircleIcon className="hi-s me-2" />
+            {t('admin.manage_users.decline')}
+          </Dropdown.Item>
+        </>
+      );
+    }
+    if (tableType === 'banned') {
+      return (
+        <Dropdown.Item onClick={() => updateUserStatus.mutate({ id: user.id, status: 'active' })}>
+          <CheckIcon className="hi-s me-2" />
+          {t('admin.manage_users.unban')}
+        </Dropdown.Item>
+      );
+    }
+    if (tableType === 'unverified') {
+      return (
+        <Dropdown.Item onClick={() => updateUserStatus.mutate({ id: user.id, verified: true })}>
+          <CheckIcon className="hi-s me-2" />
+          {t('admin.manage_users.verify')}
+        </Dropdown.Item>
+      );
+    }
+  };
 
   return (
     <tr key={user.id} className="align-middle text-muted border border-2">
@@ -56,23 +90,7 @@ export default function BannedPendingRow({ user, pendingTable }) {
         <Dropdown className="float-end cursor-pointer">
           <Dropdown.Toggle className="hi-s" as={EllipsisVerticalIcon} />
           <Dropdown.Menu>
-            {pendingTable ? (
-              <>
-                <Dropdown.Item onClick={() => updateUserStatus.mutate({ id: user.id, status: 'active' })}>
-                  <CheckCircleIcon className="hi-s me-2" />
-                  {t('admin.manage_users.approve')}
-                </Dropdown.Item>
-                <Dropdown.Item onClick={() => updateUserStatus.mutate({ id: user.id, status: 'banned' })}>
-                  <XCircleIcon className="hi-s me-2" />
-                  {t('admin.manage_users.decline')}
-                </Dropdown.Item>
-              </>
-            ) : (
-              <Dropdown.Item onClick={() => updateUserStatus.mutate({ id: user.id, status: 'active' })}>
-                <CheckIcon className="hi-s me-2" />
-                {t('admin.manage_users.unban')}
-              </Dropdown.Item>
-            )}
+            {renderDropdownItems()}
           </Dropdown.Menu>
         </Dropdown>
       </td>
@@ -89,5 +107,5 @@ BannedPendingRow.propTypes = {
     created_at: PropTypes.string.isRequired,
     language: PropTypes.string.isRequired,
   }).isRequired,
-  pendingTable: PropTypes.bool.isRequired,
+  tableType: PropTypes.string.isRequired
 };

--- a/app/javascript/components/admin/manage_users/BannedPendingRow.jsx
+++ b/app/javascript/components/admin/manage_users/BannedPendingRow.jsx
@@ -30,10 +30,12 @@ import Avatar from '../../users/user/Avatar';
 import useUpdateUserStatus from '../../../hooks/mutations/admin/manage_users/useUpdateUserStatus';
 import { localizeDateTimeString } from '../../../helpers/DateTimeHelper';
 import { useAuth } from '../../../contexts/auth/AuthProvider';
+import useUpdateUserVerification from "../../../hooks/mutations/admin/manage_users/useUpdateUserVerification";
 
 export default function BannedPendingRow({ user, tableType }) {
   const { t } = useTranslation();
   const updateUserStatus = useUpdateUserStatus();
+  const updateUserVerification = useUpdateUserVerification();
   const currentUser = useAuth();
   const localizedTime = localizeDateTimeString(user?.created_at, currentUser?.language);
 
@@ -62,7 +64,7 @@ export default function BannedPendingRow({ user, tableType }) {
     }
     if (tableType === 'unverified') {
       return (
-        <Dropdown.Item onClick={() => updateUserStatus.mutate({ id: user.id, verified: true })}>
+        <Dropdown.Item onClick={() => updateUserVerification.mutate({ id: user.id, verified: true })}>
           <CheckIcon className="hi-s me-2" />
           {t('admin.manage_users.verify')}
         </Dropdown.Item>

--- a/app/javascript/components/admin/manage_users/BannedPendingRow.jsx
+++ b/app/javascript/components/admin/manage_users/BannedPendingRow.jsx
@@ -30,7 +30,7 @@ import Avatar from '../../users/user/Avatar';
 import useUpdateUserStatus from '../../../hooks/mutations/admin/manage_users/useUpdateUserStatus';
 import { localizeDateTimeString } from '../../../helpers/DateTimeHelper';
 import { useAuth } from '../../../contexts/auth/AuthProvider';
-import useUpdateUserVerification from "../../../hooks/mutations/admin/manage_users/useUpdateUserVerification";
+import useUpdateUserVerification from '../../../hooks/mutations/admin/manage_users/useUpdateUserVerification';
 
 export default function BannedPendingRow({ user, tableType }) {
   const { t } = useTranslation();
@@ -70,6 +70,7 @@ export default function BannedPendingRow({ user, tableType }) {
         </Dropdown.Item>
       );
     }
+    return null;
   };
 
   return (

--- a/app/javascript/components/admin/manage_users/BannedPendingRow.jsx
+++ b/app/javascript/components/admin/manage_users/BannedPendingRow.jsx
@@ -26,7 +26,6 @@ import {
   EllipsisVerticalIcon,
   XCircleIcon,
 } from '@heroicons/react/24/outline';
-import { render } from 'react-dom';
 import Avatar from '../../users/user/Avatar';
 import useUpdateUserStatus from '../../../hooks/mutations/admin/manage_users/useUpdateUserStatus';
 import { localizeDateTimeString } from '../../../helpers/DateTimeHelper';
@@ -107,5 +106,5 @@ BannedPendingRow.propTypes = {
     created_at: PropTypes.string.isRequired,
     language: PropTypes.string.isRequired,
   }).isRequired,
-  tableType: PropTypes.string.isRequired
+  tableType: PropTypes.string.isRequired,
 };

--- a/app/javascript/components/admin/manage_users/BannedPendingRow.jsx
+++ b/app/javascript/components/admin/manage_users/BannedPendingRow.jsx
@@ -53,16 +53,14 @@ export default function BannedPendingRow({ user, tableType }) {
           </Dropdown.Item>
         </>
       );
-    }
-    if (tableType === 'banned') {
+    } if (tableType === 'banned') {
       return (
         <Dropdown.Item onClick={() => updateUserStatus.mutate({ id: user.id, status: 'active' })}>
           <CheckIcon className="hi-s me-2" />
           {t('admin.manage_users.unban')}
         </Dropdown.Item>
       );
-    }
-    if (tableType === 'unverified') {
+    } if (tableType === 'unverified') {
       return (
         <Dropdown.Item onClick={() => updateUserVerification.mutate({ id: user.id, verified: true })}>
           <CheckIcon className="hi-s me-2" />

--- a/app/javascript/components/admin/manage_users/BannedPendingUsersTable.jsx
+++ b/app/javascript/components/admin/manage_users/BannedPendingUsersTable.jsx
@@ -28,12 +28,6 @@ export default function BannedPendingUsersTable({
 }) {
   const { t } = useTranslation();
 
-  // if (!isLoading && users.length === 0) {
-  //   if (pendingTable) {
-  //     return <EmptyUsersList text={t('admin.manage_users.empty_pending_users')} subtext={t('admin.manage_users.empty_pending_users_subtext')} />;
-  //   }
-  //   return <EmptyUsersList text={t('admin.manage_users.empty_banned_users')} subtext={t('admin.manage_users.empty_banned_users_subtext')} />;
-  // }
   if (!isLoading && users.length === 0) {
     if (tableType === 'pending') {
       return <EmptyUsersList text={t('admin.manage_users.empty_pending_users')} subtext={t('admin.manage_users.empty_pending_users_subtext')} />;

--- a/app/javascript/components/admin/manage_users/BannedPendingUsersTable.jsx
+++ b/app/javascript/components/admin/manage_users/BannedPendingUsersTable.jsx
@@ -23,17 +23,26 @@ import EmptyUsersList from './EmptyUsersList';
 import ManageUsersPendingBannedRowPlaceHolder from './ManageUsersPendingBannedRowPlaceHolder';
 import Pagination from '../../shared_components/Pagination';
 
-// pendingTable prop is true when table is being used for pending data, false when table is being used for banned data
 export default function BannedPendingUsersTable({
-  users, pendingTable, isLoading, pagination, setPage,
+  users, tableType, isLoading, pagination, setPage,
 }) {
   const { t } = useTranslation();
 
+  // if (!isLoading && users.length === 0) {
+  //   if (pendingTable) {
+  //     return <EmptyUsersList text={t('admin.manage_users.empty_pending_users')} subtext={t('admin.manage_users.empty_pending_users_subtext')} />;
+  //   }
+  //   return <EmptyUsersList text={t('admin.manage_users.empty_banned_users')} subtext={t('admin.manage_users.empty_banned_users_subtext')} />;
+  // }
   if (!isLoading && users.length === 0) {
-    if (pendingTable) {
+    if (tableType === 'pending') {
       return <EmptyUsersList text={t('admin.manage_users.empty_pending_users')} subtext={t('admin.manage_users.empty_pending_users_subtext')} />;
     }
-    return <EmptyUsersList text={t('admin.manage_users.empty_banned_users')} subtext={t('admin.manage_users.empty_banned_users_subtext')} />;
+    if (tableType === 'unverified') {
+      return <EmptyUsersList text={t('admin.manage_users.empty_pending_users')} subtext={t('admin.manage_users.empty_unverified_users_subtext')} />;
+    }
+
+    return <EmptyUsersList text={t('admin.manage_users.empty_pending_users')} subtext={t('admin.manage_users.empty_banned_users_subtext')} />;
   }
 
   return (
@@ -56,7 +65,7 @@ export default function BannedPendingUsersTable({
                 users?.length
                 && (
                   users?.map((user) => (
-                    <BannedPendingRow key={user.id} user={user} pendingTable={pendingTable} />
+                    <BannedPendingRow key={user.id} user={user} tableType={tableType} />
                   ))
                 )
               )
@@ -95,7 +104,7 @@ BannedPendingUsersTable.propTypes = {
     avatar: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
   })),
-  pendingTable: PropTypes.bool.isRequired,
+  tableType: PropTypes.string.isRequired,
   isLoading: PropTypes.bool.isRequired,
   pagination: PropTypes.shape({
     page: PropTypes.number.isRequired,

--- a/app/javascript/components/admin/manage_users/BannedUsers.jsx
+++ b/app/javascript/components/admin/manage_users/BannedUsers.jsx
@@ -25,6 +25,7 @@ export default function BannedUsers({ searchInput }) {
   const [page, setPage] = useState();
   const { isLoading, data: bannedUsers } = useBannedUsers(searchInput, page);
   const { t } = useTranslation();
+  const tableType = 'banned';
 
   return (
     <div>
@@ -37,7 +38,7 @@ export default function BannedUsers({ searchInput }) {
         ) : (
           <BannedPendingUsersTable
             users={bannedUsers?.data}
-            pendingTable={false}
+            tableType={tableType}
             isLoading={isLoading}
             pagination={bannedUsers?.meta}
             setPage={setPage}

--- a/app/javascript/components/admin/manage_users/ManageUsers.jsx
+++ b/app/javascript/components/admin/manage_users/ManageUsers.jsx
@@ -34,6 +34,7 @@ import PendingUsers from './PendingUsers';
 import BannedUsers from './BannedUsers';
 import { useAuth } from '../../../contexts/auth/AuthProvider';
 import useEnv from '../../../hooks/queries/env/useEnv';
+import UnverifiedUsers from "./UnverifiedUsers";
 
 export default function ManageUsers() {
   const { t } = useTranslation();
@@ -98,6 +99,9 @@ export default function ManageUsers() {
                     <Tabs defaultActiveKey="active" unmountOnExit>
                       <Tab eventKey="active" title={t('admin.manage_users.active')}>
                         <VerifiedUsers searchInput={searchInput} />
+                      </Tab>
+                      <Tab eventKey="unverified" title={t('admin.manage_users.unverified')} >
+                        <UnverifiedUsers searchInput={searchInput} />
                       </Tab>
                       {registrationMethod === 'approval'
                         && (

--- a/app/javascript/components/admin/manage_users/ManageUsers.jsx
+++ b/app/javascript/components/admin/manage_users/ManageUsers.jsx
@@ -100,7 +100,7 @@ export default function ManageUsers() {
                       <Tab eventKey="active" title={t('admin.manage_users.active')}>
                         <VerifiedUsers searchInput={searchInput} />
                       </Tab>
-                      <Tab eventKey="unverified" title="Test Tab">
+                      <Tab eventKey="unverified" title={t('admin.manage_users.unverified')}>
                         <UnverifiedUsers searchInput={searchInput} />
                       </Tab>
                       {registrationMethod === 'approval'

--- a/app/javascript/components/admin/manage_users/ManageUsers.jsx
+++ b/app/javascript/components/admin/manage_users/ManageUsers.jsx
@@ -34,7 +34,7 @@ import PendingUsers from './PendingUsers';
 import BannedUsers from './BannedUsers';
 import { useAuth } from '../../../contexts/auth/AuthProvider';
 import useEnv from '../../../hooks/queries/env/useEnv';
-import UnverifiedUsers from "./UnverifiedUsers";
+import UnverifiedUsers from './UnverifiedUsers';
 
 export default function ManageUsers() {
   const { t } = useTranslation();
@@ -100,7 +100,7 @@ export default function ManageUsers() {
                       <Tab eventKey="active" title={t('admin.manage_users.active')}>
                         <VerifiedUsers searchInput={searchInput} />
                       </Tab>
-                      <Tab eventKey="unverified" title={t('admin.manage_users.unverified')} >
+                      <Tab eventKey="unverified" title="Test Tab">
                         <UnverifiedUsers searchInput={searchInput} />
                       </Tab>
                       {registrationMethod === 'approval'

--- a/app/javascript/components/admin/manage_users/PendingUsers.jsx
+++ b/app/javascript/components/admin/manage_users/PendingUsers.jsx
@@ -25,6 +25,7 @@ export default function PendingUsers({ searchInput }) {
   const [page, setPage] = useState();
   const { isLoading, data: users } = usePendingUsers(searchInput, page);
   const { t } = useTranslation();
+  const tableType = 'pending';
 
   return (
     <div>
@@ -35,7 +36,7 @@ export default function PendingUsers({ searchInput }) {
             <NoSearchResults text={t('user.search_not_found')} searchInput={searchInput} />
           </div>
         ) : (
-          <BannedPendingUsersTable users={users?.data} pendingTable isLoading={isLoading} pagination={users?.meta} setPage={setPage} />
+          <BannedPendingUsersTable users={users?.data} tableType={tableType} isLoading={isLoading} pagination={users?.meta} setPage={setPage} />
         )
       }
     </div>

--- a/app/javascript/components/admin/manage_users/UnverifiedUsers.jsx
+++ b/app/javascript/components/admin/manage_users/UnverifiedUsers.jsx
@@ -17,15 +17,16 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
-import useUnverifiedUsers from "../../../hooks/queries/admin/manage_users/useUnverifiedUsers";
+import useUnverifiedUsers from '../../../hooks/queries/admin/manage_users/useUnverifiedUsers';
 import ManageUsersTable from './ManageUsersTable';
 import NoSearchResults from '../../shared_components/search/NoSearchResults';
+import BannedPendingUsersTable from "./BannedPendingUsersTable";
 
-// TODO create a useUnverifiedUsers query & change all verified instances in this file to unverified
 export default function UnverifiedUsers({ searchInput }) {
   const [page, setPage] = useState();
   const { isLoading, data: unverifiedUsers } = useUnverifiedUsers(searchInput, page);
   const { t } = useTranslation();
+  const tableType = 'unverified';
 
   return (
     <div>
@@ -36,7 +37,8 @@ export default function UnverifiedUsers({ searchInput }) {
               <NoSearchResults text={t('user.search_not_found')} searchInput={searchInput} />
             </div>
           ) : (
-            <ManageUsersTable users={unverifiedUsers?.data} isLoading={isLoading} pagination={unverifiedUsers?.meta} setPage={setPage} />
+            // <ManageUsersTable users={unverifiedUsers?.data} isLoading={isLoading} pagination={unverifiedUsers?.meta} setPage={setPage} />
+          <BannedPendingUsersTable users={unverifiedUsers?.data} tableType={tableType} isLoading={isLoading} pagination={unverifiedUsers?.meta} setPage={setPage}/>
           )
       }
     </div>

--- a/app/javascript/components/admin/manage_users/UnverifiedUsers.jsx
+++ b/app/javascript/components/admin/manage_users/UnverifiedUsers.jsx
@@ -18,9 +18,8 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import useUnverifiedUsers from '../../../hooks/queries/admin/manage_users/useUnverifiedUsers';
-import ManageUsersTable from './ManageUsersTable';
 import NoSearchResults from '../../shared_components/search/NoSearchResults';
-import BannedPendingUsersTable from "./BannedPendingUsersTable";
+import BannedPendingUsersTable from './BannedPendingUsersTable';
 
 export default function UnverifiedUsers({ searchInput }) {
   const [page, setPage] = useState();
@@ -37,8 +36,13 @@ export default function UnverifiedUsers({ searchInput }) {
               <NoSearchResults text={t('user.search_not_found')} searchInput={searchInput} />
             </div>
           ) : (
-            // <ManageUsersTable users={unverifiedUsers?.data} isLoading={isLoading} pagination={unverifiedUsers?.meta} setPage={setPage} />
-          <BannedPendingUsersTable users={unverifiedUsers?.data} tableType={tableType} isLoading={isLoading} pagination={unverifiedUsers?.meta} setPage={setPage}/>
+            <BannedPendingUsersTable
+              users={unverifiedUsers?.data}
+              tableType={tableType}
+              isLoading={isLoading}
+              pagination={unverifiedUsers?.meta}
+              setPage={setPage}
+            />
           )
       }
     </div>

--- a/app/javascript/components/admin/manage_users/UnverifiedUsers.jsx
+++ b/app/javascript/components/admin/manage_users/UnverifiedUsers.jsx
@@ -1,0 +1,52 @@
+// BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+//
+// Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+//
+// This program is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3.0 of the License, or (at your option) any later
+// version.
+//
+// Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along
+// with Greenlight; if not, see <http://www.gnu.org/licenses/>.
+
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+import useUnverifiedUsers from "../../../hooks/queries/admin/manage_users/useUnverifiedUsers";
+import ManageUsersTable from './ManageUsersTable';
+import NoSearchResults from '../../shared_components/search/NoSearchResults';
+
+// TODO create a useUnverifiedUsers query & change all verified instances in this file to unverified
+export default function UnverifiedUsers({ searchInput }) {
+  const [page, setPage] = useState();
+  const { isLoading, data: unverifiedUsers } = useUnverifiedUsers(searchInput, page);
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      {
+        (searchInput && unverifiedUsers?.data.length === 0)
+          ? (
+            <div className="mt-5">
+              <NoSearchResults text={t('user.search_not_found')} searchInput={searchInput} />
+            </div>
+          ) : (
+            <ManageUsersTable users={unverifiedUsers?.data} isLoading={isLoading} pagination={unverifiedUsers?.meta} setPage={setPage} />
+          )
+      }
+    </div>
+  );
+}
+
+UnverifiedUsers.propTypes = {
+  searchInput: PropTypes.string,
+};
+
+UnverifiedUsers.defaultProps = {
+  searchInput: '',
+};

--- a/app/javascript/hooks/mutations/admin/manage_users/useUpdateUserVerification.jsx
+++ b/app/javascript/hooks/mutations/admin/manage_users/useUpdateUserVerification.jsx
@@ -27,9 +27,8 @@ export default function useUpdateUserVerification() {
     (data) => axios.patch(`/admin/users/${data.id}.json`, { user: { verified: data.verified } }),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(['getPendingUsers']);
-        queryClient.invalidateQueries(['getBannedUsers']);
         queryClient.invalidateQueries(['getAdminUsers']);
+        queryClient.invalidateQueries(['getUnverifiedUsers']);
 
         toast.success(t('toast.success.user.user_updated'));
       },

--- a/app/javascript/hooks/mutations/admin/manage_users/useUpdateUserVerification.jsx
+++ b/app/javascript/hooks/mutations/admin/manage_users/useUpdateUserVerification.jsx
@@ -1,0 +1,41 @@
+// BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+//
+// Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+//
+// This program is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3.0 of the License, or (at your option) any later
+// version.
+//
+// Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along
+// with Greenlight; if not, see <http://www.gnu.org/licenses/>.
+
+import { useMutation, useQueryClient } from 'react-query';
+import { toast } from 'react-toastify';
+import { useTranslation } from 'react-i18next';
+import axios from '../../../../helpers/Axios';
+
+export default function useUpdateUserVerification() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    (data) => axios.patch(`/admin/users/${data.id}.json`, { user: { verified: data.verified } }),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['getPendingUsers']);
+        queryClient.invalidateQueries(['getBannedUsers']);
+        queryClient.invalidateQueries(['getAdminUsers']);
+
+        toast.success(t('toast.success.user.user_updated'));
+      },
+      onError: () => {
+        toast.error(t('toast.error.problem_completing_action'));
+      },
+    },
+  );
+}

--- a/app/javascript/hooks/queries/admin/manage_users/useUnverifiedUsers.jsx
+++ b/app/javascript/hooks/queries/admin/manage_users/useUnverifiedUsers.jsx
@@ -1,0 +1,38 @@
+// BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+//
+// Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+//
+// This program is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3.0 of the License, or (at your option) any later
+// version.
+//
+// Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along
+// with Greenlight; if not, see <http://www.gnu.org/licenses/>.
+
+import { useQuery } from 'react-query';
+import { useSearchParams } from 'react-router-dom';
+import axios from '../../../../helpers/Axios';
+
+export default function useUnverifiedUsers(input, page) {
+  const [searchParams] = useSearchParams();
+
+  const params = {
+    'sort[column]': searchParams.get('sort[column]'),
+    'sort[direction]': searchParams.get('sort[direction]'),
+    search: input,
+    page,
+  };
+
+  return useQuery(
+    ['getAdminUsers', { ...params }],
+    () => axios.get('/admin/users/unverified.json', { params }).then((resp) => resp.data),
+    {
+      keepPreviousData: true,
+    },
+  );
+}

--- a/app/javascript/hooks/queries/admin/manage_users/useUnverifiedUsers.jsx
+++ b/app/javascript/hooks/queries/admin/manage_users/useUnverifiedUsers.jsx
@@ -29,7 +29,7 @@ export default function useUnverifiedUsers(input, page) {
   };
 
   return useQuery(
-    ['getAdminUsers', { ...params }],
+    ['getUnverifiedUsers', { ...params }],
     () => axios.get('/admin/users/unverified.json', { params }).then((resp) => resp.data),
     {
       keepPreviousData: true,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
         resources :users, only: %i[update] do
           collection do
             get '/verified', to: 'users#verified'
+            get '/unverified', to: 'users#unverified'
             get '/pending', to: 'users#pending'
             get '/banned', to: 'users#banned'
             post '/:user_id/create_server_room', to: 'users#create_server_room'

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Api::V1::Admin::UsersController, type: :controller do
   end
 
   describe '#verified_users' do
-    it 'returns the list of verified users' do
-      users = create_list(:user, 3, verified: true) + [user, user_with_manage_users_permission]
+    it 'returns the list of active users' do
+      users = create_list(:user, 3, status: 'active') + [user, user_with_manage_users_permission]
       get :verified
       expect(response).to have_http_status(:ok)
       response_user_ids = response.parsed_body['data'].pluck('id')
@@ -115,8 +115,8 @@ RSpec.describe Api::V1::Admin::UsersController, type: :controller do
         sign_in_user(super_admin)
       end
 
-      it 'returns the list of verified users' do
-        users = create_list(:user, 3, verified: true) + [user, user_with_manage_users_permission]
+      it 'returns the list of active users' do
+        users = create_list(:user, 3, status: 'active') + [user, user_with_manage_users_permission]
         get :verified
         expect(response).to have_http_status(:ok)
         response_user_ids = response.parsed_body['data'].pluck('id')


### PR DESCRIPTION
This feature is to allow admins to view any unverified users in its own 'Unverified' Tab under Manage Users, and manually verify the user

[Screencast from 2025-04-15 05:41:50 PM.webm](https://github.com/user-attachments/assets/5ca563aa-3e92-4be3-9bf8-85fb3b5e0240)

