### PR TITLE
Add logout logic when using external login

### DIFF
--- a/app/controllers/external_controller.rb
+++ b/app/controllers/external_controller.rb
@@ -28,8 +28,6 @@ class ExternalController < ApplicationController
 
     credentials = request.env['omniauth.auth']
 
-    session[:oidc_id_token] = credentials.dig('credentials', 'id_token')
-
     user_info = build_user_info(credentials)
 
     user = User.find_by(external_id: credentials['uid'], provider:)
@@ -85,6 +83,7 @@ class ExternalController < ApplicationController
     handle_session_timeout(session_timeout.to_i, user) if session_timeout
 
     session[:session_token] = user.session_token
+    session[:oidc_id_token] = credentials.dig('credentials', 'id_token')
 
     # TODO: - Ahmad: deal with errors
 

--- a/app/controllers/external_controller.rb
+++ b/app/controllers/external_controller.rb
@@ -28,6 +28,8 @@ class ExternalController < ApplicationController
 
     credentials = request.env['omniauth.auth']
 
+    session[:oidc_id_token] = credentials.dig('credentials', 'id_token')
+
     user_info = build_user_info(credentials)
 
     user = User.find_by(external_id: credentials['uid'], provider:)

--- a/app/javascript/components/home/HomePage.jsx
+++ b/app/javascript/components/home/HomePage.jsx
@@ -35,6 +35,7 @@ export default function HomePage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const error = searchParams.get('error');
+  const success = searchParams.get('success');
   const { data: recordValue } = useRoomConfigValue('record');
   const { data: env } = useEnv();
 
@@ -50,6 +51,16 @@ export default function HomePage() {
     },
     [currentUser.signed_in],
   );
+
+  useEffect(() => {
+    switch (success) {
+      case 'LogoutSuccessful':
+        toast.success(t('toast.success.session.signed_out'));
+        break;
+      default:
+    }
+    if (success) { setSearchParams(searchParams.delete('success')); }
+  }, [success]);
 
   useEffect(() => {
     switch (error) {

--- a/app/javascript/hooks/mutations/sessions/useDeleteSession.jsx
+++ b/app/javascript/hooks/mutations/sessions/useDeleteSession.jsx
@@ -30,12 +30,19 @@ export default function useDeleteSession({ showToast = true }) {
   return useMutation(
     () => axios.delete('/sessions/signout.json'),
     {
-      onSuccess: async () => {
-        setStateChanging(true);
-        queryClient.refetchQueries('useSessions');
-        await navigate('/');
-        if (showToast) { toast.success(t('toast.success.session.signed_out')); }
-        setStateChanging(false);
+      onSuccess: async ({ data }) => {
+        const logoutUrl = data?.data;
+
+        if (typeof logoutUrl === 'string') {
+          window.location.href = logoutUrl;
+        } else {
+          setStateChanging(true);
+          queryClient.refetchQueries('useSessions');
+
+          await navigate('/');
+          if (showToast) { toast.success(t('toast.success.session.signed_out')); }
+          setStateChanging(false);
+        }
       },
       onError: () => {
         toast.error(t('toast.error.problem_completing_action'));

--- a/spec/controllers/external_controller_spec.rb
+++ b/spec/controllers/external_controller_spec.rb
@@ -30,6 +30,9 @@ RSpec.describe ExternalController do
         info: {
           email: Faker::Internet.email,
           name: Faker::Name.name
+        },
+        credentials: {
+          id_token: 'sample_id_token'
         }
       )
 
@@ -53,7 +56,6 @@ RSpec.describe ExternalController do
 
       get :create_user, params: { provider: 'openid_connect' }
 
-      expect(session[:session_token]).to eq(User.find_by(email: OmniAuth.config.mock_auth[:openid_connect][:info][:email]).session_token)
       expect(response).to redirect_to(root_path)
     end
 
@@ -91,6 +93,15 @@ RSpec.describe ExternalController do
       expect do
         get :create_user, params: { provider: 'openid_connect' }
       end.not_to change(User, :count)
+    end
+
+    it 'sets the correct session variables' do
+      request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
+
+      get :create_user, params: { provider: 'openid_connect' }
+
+      expect(session[:session_token]).to eq(User.find_by(email: OmniAuth.config.mock_auth[:openid_connect][:info][:email]).session_token)
+      expect(session[:oidc_id_token]).to eq(OmniAuth.config.mock_auth[:openid_connect][:credentials][:id_token])
     end
 
     context 'redirect' do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -162,6 +162,10 @@ RSpec.describe Api::V1::SessionsController, type: :controller do
         ENV['OPENID_CONNECT_ISSUER'] = 'https://openid.example'
       end
 
+      after do
+        ENV['OPENID_CONNECT_ISSUER'] = nil
+      end
+
       it 'returns the OIDC logout url' do
         delete :destroy
 
@@ -185,6 +189,10 @@ RSpec.describe Api::V1::SessionsController, type: :controller do
           sign_in_user(mt_user)
           ENV['LOADBALANCER_ENDPOINT'] = 'http://test.com/'
           allow(controller).to receive(:current_provider).and_return('test-provider')
+        end
+
+        after do
+          ENV['LOADBALANCER_ENDPOINT'] = nil
         end
 
         it 'returns the OIDC logout url' do


### PR DESCRIPTION
fixes #6019 #5211 

This PR adds an explicit call to the openid_connect logout endpoint to ensure the user is logged out when clicking the log out button. 

Behaviour for a local logout is unchanged