### PR TITLE
Switch Mute On Start to be default enabled for all new rooms

### DIFF
--- a/app/services/tenant_setup.rb
+++ b/app/services/tenant_setup.rb
@@ -65,7 +65,7 @@ class TenantSetup
   def create_rooms_configs_options
     RoomsConfiguration.create! [
       { meeting_option: MeetingOption.find_by(name: 'record'), value: 'default_enabled', provider: @provider },
-      { meeting_option: MeetingOption.find_by(name: 'muteOnStart'), value: 'optional', provider: @provider },
+      { meeting_option: MeetingOption.find_by(name: 'muteOnStart'), value: 'default_enabled', provider: @provider },
       { meeting_option: MeetingOption.find_by(name: 'guestPolicy'), value: 'optional', provider: @provider },
       { meeting_option: MeetingOption.find_by(name: 'glAnyoneCanStart'), value: 'optional', provider: @provider },
       { meeting_option: MeetingOption.find_by(name: 'glAnyoneJoinAsModerator'), value: 'optional', provider: @provider },

--- a/db/data/20250501185954_update_mute_on_start_to_enabled.rb
+++ b/db/data/20250501185954_update_mute_on_start_to_enabled.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class UpdateMuteOnStartToEnabled < ActiveRecord::Migration[7.2]
+  def up
+    meeting_option = MeetingOption.find_by(name: 'muteOnStart')
+
+    RoomsConfiguration.find_by(meeting_option:, value: 'optional', provider: 'greenlight').update(value: 'default_enabled')
+
+    Tenant.find_each do |tenant|
+      RoomsConfiguration.find_by(meeting_option:, value: 'optional', provider: tenant.name).update(value: 'default_enabled')
+    end
+  end
+
+  def down
+    meeting_option = MeetingOption.find_by(name: 'muteOnStart')
+
+    RoomsConfiguration.find_by(meeting_option:, value: 'default_enabled', provider: 'greenlight').update(value: 'optional')
+
+    Tenant.find_each do |tenant|
+      RoomsConfiguration.find_by(meeting_option:, value: 'default_enabled', provider: tenant.name).update(value: 'optional')
+    end
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20250130160334)
+DataMigrate::Data.define(version: 20250501185954)


### PR DESCRIPTION
With the upcoming changes to BBB 3.1 and Livekit, the BBB Dev team has asked to change the default value of MuteOnStart to be enabled by default. There are noticeable performance improvements for changing this. This change will only apply to newly created rooms (old rooms will stay as set before)