### PR TITLE
[Minor Fix] : missing table sort params added to useBannedUsers and usePendingUsers hook

### DIFF
--- a/app/javascript/hooks/queries/admin/manage_users/useBannedUsers.jsx
+++ b/app/javascript/hooks/queries/admin/manage_users/useBannedUsers.jsx
@@ -20,7 +20,7 @@ import axios from '../../../../helpers/Axios';
 
 export default function useBannedUsers(input, page) {
   const [searchParams] = useSearchParams();
-  
+
   const params = {
     'sort[column]': searchParams.get('sort[column]'),
     'sort[direction]': searchParams.get('sort[direction]'),

--- a/app/javascript/hooks/queries/admin/manage_users/useBannedUsers.jsx
+++ b/app/javascript/hooks/queries/admin/manage_users/useBannedUsers.jsx
@@ -15,10 +15,15 @@
 // with Greenlight; if not, see <http://www.gnu.org/licenses/>.
 
 import { useQuery } from 'react-query';
+import { useSearchParams } from 'react-router-dom';
 import axios from '../../../../helpers/Axios';
 
 export default function useBannedUsers(input, page) {
+  const [searchParams] = useSearchParams();
+  
   const params = {
+    'sort[column]': searchParams.get('sort[column]'),
+    'sort[direction]': searchParams.get('sort[direction]'),
     search: input,
     page,
   };

--- a/app/javascript/hooks/queries/admin/manage_users/usePendingUsers.jsx
+++ b/app/javascript/hooks/queries/admin/manage_users/usePendingUsers.jsx
@@ -15,10 +15,15 @@
 // with Greenlight; if not, see <http://www.gnu.org/licenses/>.
 
 import { useQuery } from 'react-query';
+import { useSearchParams } from 'react-router-dom';
 import axios from '../../../../helpers/Axios';
 
 export default function usePendingUsers(input, page) {
+  const [searchParams] = useSearchParams();
+  
   const params = {
+    'sort[column]': searchParams.get('sort[column]'),
+    'sort[direction]': searchParams.get('sort[direction]'),
     search: input,
     page,
   };

--- a/app/javascript/hooks/queries/admin/manage_users/usePendingUsers.jsx
+++ b/app/javascript/hooks/queries/admin/manage_users/usePendingUsers.jsx
@@ -20,7 +20,7 @@ import axios from '../../../../helpers/Axios';
 
 export default function usePendingUsers(input, page) {
   const [searchParams] = useSearchParams();
-  
+
   const params = {
     'sort[column]': searchParams.get('sort[column]'),
     'sort[direction]': searchParams.get('sort[direction]'),


### PR DESCRIPTION
Sort params were missing in both the hooks. This enables table sorting based on allowed columns