### PR TITLE
Manage Users UI changes

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -233,7 +233,7 @@
       "empty_banned_users": "There are no banned users on this server yet!",
       "empty_banned_users_subtext": "When a user's status gets changed to banned, they will appear here.",
       "empty_unverified_users": "There are no unverified users on this server yet!",
-      "empty_unverified_users_subtext": "When a user's status gets changed to unverified, they will appear here.",
+      "empty_unverified_users_subtext": "Any unverified users will appear here.",
       "empty_invited_users": "There are no invited users on this server yet!",
       "empty_invited_users_subtext": "When a user's status gets changed to invited, they will appear here.",
       "invited": {

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -74,7 +74,6 @@ module Api
           users = User.includes(:role)
                       .with_provider(current_provider)
                       .where(verified: false)
-                      .with_attached_avatar
                       .order(sort_config, created_at: :desc)&.search(params[:search])
 
           pagy, users = pagy(users)

--- a/app/javascript/components/admin/manage_users/BannedPendingUsersTable.jsx
+++ b/app/javascript/components/admin/manage_users/BannedPendingUsersTable.jsx
@@ -33,10 +33,10 @@ export default function BannedPendingUsersTable({
       return <EmptyUsersList text={t('admin.manage_users.empty_pending_users')} subtext={t('admin.manage_users.empty_pending_users_subtext')} />;
     }
     if (tableType === 'unverified') {
-      return <EmptyUsersList text={t('admin.manage_users.empty_pending_users')} subtext={t('admin.manage_users.empty_unverified_users_subtext')} />;
+      return <EmptyUsersList text={t('admin.manage_users.empty_unverified_users')} subtext={t('admin.manage_users.empty_unverified_users_subtext')} />;
     }
 
-    return <EmptyUsersList text={t('admin.manage_users.empty_pending_users')} subtext={t('admin.manage_users.empty_banned_users_subtext')} />;
+    return <EmptyUsersList text={t('admin.manage_users.empty_banned_users')} subtext={t('admin.manage_users.empty_banned_users_subtext')} />;
   }
 
   return (

--- a/app/javascript/components/admin/manage_users/BannedPendingUsersTable.jsx
+++ b/app/javascript/components/admin/manage_users/BannedPendingUsersTable.jsx
@@ -33,7 +33,12 @@ export default function BannedPendingUsersTable({
       return <EmptyUsersList text={t('admin.manage_users.empty_pending_users')} subtext={t('admin.manage_users.empty_pending_users_subtext')} />;
     }
     if (tableType === 'unverified') {
-      return <EmptyUsersList text={t('admin.manage_users.empty_unverified_users')} subtext={t('admin.manage_users.empty_unverified_users_subtext')} />;
+      return (
+        <EmptyUsersList
+          text={t('admin.manage_users.empty_unverified_users')}
+          subtext={t('admin.manage_users.empty_unverified_users_subtext')}
+        />
+      );
     }
 
     return <EmptyUsersList text={t('admin.manage_users.empty_banned_users')} subtext={t('admin.manage_users.empty_banned_users_subtext')} />;


### PR DESCRIPTION
- changed the subtext for the unverified users `EmptyUsersList` and changed the banned users list to use its corresponding one
- `unverified` method in `admin/users_controller` doesn't check for an avatar

![image](https://github.com/user-attachments/assets/f7324ee1-5d0b-443e-a490-bb7ca30cc900)

![image](https://github.com/user-attachments/assets/058b91e8-0e01-4f67-992f-ae7ea74fe9f9)
