### PR TITLE
fix: NoMethodError in muteOnStart migration if room configuration was changed from default

### DIFF
--- a/db/data/20250501185954_update_mute_on_start_to_enabled.rb
+++ b/db/data/20250501185954_update_mute_on_start_to_enabled.rb
@@ -4,20 +4,20 @@ class UpdateMuteOnStartToEnabled < ActiveRecord::Migration[7.2]
   def up
     meeting_option = MeetingOption.find_by(name: 'muteOnStart')
 
-    RoomsConfiguration.find_by(meeting_option:, value: 'optional', provider: 'greenlight').update(value: 'default_enabled')
+    RoomsConfiguration.find_by(meeting_option:, value: 'optional', provider: 'greenlight')&.update(value: 'default_enabled')
 
     Tenant.find_each do |tenant|
-      RoomsConfiguration.find_by(meeting_option:, value: 'optional', provider: tenant.name).update(value: 'default_enabled')
+      RoomsConfiguration.find_by(meeting_option:, value: 'optional', provider: tenant.name)&.update(value: 'default_enabled')
     end
   end
 
   def down
     meeting_option = MeetingOption.find_by(name: 'muteOnStart')
 
-    RoomsConfiguration.find_by(meeting_option:, value: 'default_enabled', provider: 'greenlight').update(value: 'optional')
+    RoomsConfiguration.find_by(meeting_option:, value: 'default_enabled', provider: 'greenlight')&.update(value: 'optional')
 
     Tenant.find_each do |tenant|
-      RoomsConfiguration.find_by(meeting_option:, value: 'default_enabled', provider: tenant.name).update(value: 'optional')
+      RoomsConfiguration.find_by(meeting_option:, value: 'default_enabled', provider: tenant.name)&.update(value: 'optional')
     end
   end
 end


### PR DESCRIPTION
If the muteOnStart room configuration was set to something else than "default off" ("optional" in DB), the migration to "default on" would fail with a NoMethodError, because update method was called on nil.

This PR makes the change to safe navigation operators to avoid the error (and still make no update in these cases, which I think is intended).

Fixes https://github.com/bigbluebutton/greenlight/issues/6080