### PR TITLE
Fix boot loop with Puma

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,4 @@ services:
     depends_on:
       - postgres
       - redis
+    command: bash -c "rm -f /usr/src/app/tmp/pids/server.pid && bundle exec puma -C config/puma.rb"


### PR DESCRIPTION
Fix a boot loop that caused a 502 Bad Gateway error.

`[1/4] Resolving packages... success Already up-to-date. Done in 0.59s. yarn run v1.22.19 $ node esbuild.mjs watch build finished Done in 0.62s. Database 'greenlight-v3-production' already exists => Booting Puma => Rails 7.1.4.1 application starting in production => Run `bin/rails server --help` for more startup options A server is already running. Check /usr/src/app/tmp/pids/server.pid. Exiting Greenlight-v3 starting on port: 3000 Postgres host: postgres Postgres port: 5432 Redis host: redis Redis port: 6379 yarn install v1.22.19 warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json. [1/4] Resolving packages... success Already up-to-date. Done in 0.61s. yarn run v1.22.19 $ sass ./app/assets/stylesheets/application.bootstrap.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules --style compressed Done in 3.77s. yarn install v1.22.19 warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json. [1/4] Resolving packages... success Already up-to-date. Done in 0.58s. yarn run v1.22.19 $ node esbuild.mjs watch build finished Done in 0.65s. Database 'greenlight-v3-production' already exists => Booting Puma => Rails 7.1.4.1 application starting in production => Run `bin/rails server --help` for more startup options A server is already running. Check /usr/src/app/tmp/pids/server.pid. Exiting Greenlight-v3 starting on port: 3000 Postgres host: postgres Postgres port: 5432 Redis host: redis Redis port: 6379 yarn install v1.22.19 warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.`