### PR TITLE
Minor Bug Fixes - typo in getAdminUsers | Invalidating user session when state changed to banned | Redirect to room join page | Error toast for Invalid HCAPTCHA

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -466,7 +466,8 @@
         "email_exists": "An account under this email already exists. Please try again with another email.",
         "old_password": "The password you have entered is incorrect.",
         "pending": "Your registration is pending approval from the administrator. Please try again later.",
-        "banned": "You do not have access to this application. Please contact your administrator if you believe this is a mistake."
+        "banned": "You do not have access to this application. Please contact your administrator if you believe this is a mistake.",
+        "hcaptcha_invalid": "The CAPTCHA verification failed. Please try again."
       },
       "rooms": {
         "room_limit": "The room can't be created due to reaching the room limit."

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -31,7 +31,7 @@ module Api
           initial_status = user.status
 
           if user.update(user_params)
-            user.generate_session_token! if (user.status == 'banned' && initial_status == 'active')
+            user.generate_session_token! if user.status == 'banned' && initial_status == 'active'
             render_data status: :ok
           else
             render_error errors: user.errors.to_a

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -28,8 +28,10 @@ module Api
         # Updates the specified user's status
         def update
           user = User.find(params[:id])
+          initial_status = user.status
 
           if user.update(user_params)
+            user.generate_session_token! if (user.status == 'banned' && initial_status == 'active')
             render_data status: :ok
           else
             render_error errors: user.errors.to_a

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -33,8 +33,7 @@ module Api
       # POST /api/v1/sessions
       # Signs a user in and updates the session cookie
       def create
-        # TODO: Add proper error logging for non-verified token hcaptcha
-        return render_error if hcaptcha_enabled? && !verify_hcaptcha(response: params[:token])
+        return render_error errors: Rails.configuration.custom_error_msgs[:hcaptcha_invalid] if hcaptcha_enabled? && !verify_hcaptcha(response: params[:token])
 
         # Search for a user within the current provider and, if not found, search for a super admin within bn provider
         user = User.find_by(email: session_params[:email].downcase, provider: current_provider) ||
@@ -52,7 +51,6 @@ module Api
           return render_error data: token, errors: 'PasswordNotSet'
         end
 
-        # TODO: Add proper error logging for non-verified token hcaptcha
         if user.authenticate(session_params[:password])
           return render_error data: user.id, errors: Rails.configuration.custom_error_msgs[:unverified_user] unless user.verified?
           return render_error errors: Rails.configuration.custom_error_msgs[:pending_user] if user.pending?

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -33,7 +33,9 @@ module Api
       # POST /api/v1/sessions
       # Signs a user in and updates the session cookie
       def create
-        return render_error errors: Rails.configuration.custom_error_msgs[:hcaptcha_invalid] if hcaptcha_enabled? && !verify_hcaptcha(response: params[:token])
+        if hcaptcha_enabled? && !verify_hcaptcha(response: params[:token])
+          return render_error errors: Rails.configuration.custom_error_msgs[:hcaptcha_invalid]
+        end
 
         # Search for a user within the current provider and, if not found, search for a super admin within bn provider
         user = User.find_by(email: session_params[:email].downcase, provider: current_provider) ||

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -52,7 +52,6 @@ module Api
           return render_error errors: Rails.configuration.custom_error_msgs[:invite_token_invalid]
         end
 
-        # TODO: Add proper error logging for non-verified token hcaptcha
         if !admin_create && hcaptcha_enabled? && !verify_hcaptcha(response: params[:token])
           return render_error errors: Rails.configuration.custom_error_msgs[:hcaptcha_invalid]
         end

--- a/app/javascript/components/rooms/room/join/JoinCard.jsx
+++ b/app/javascript/components/rooms/room/join/JoinCard.jsx
@@ -62,11 +62,12 @@ export default function JoinCard() {
   const { data: signInOnRoomJoin } = useSiteSetting('SignInOnRoomJoin');
 
   const { methods, fields } = useRoomJoinForm();
-
-  const path = encodeURIComponent(document.location.pathname);
-
+  
   // get queryParams for JoinFormName
   const location = useLocation();
+
+  const path = encodeURIComponent(location.pathname);
+
   const queryParams = new URLSearchParams(location.search);
   const joinFormName = queryParams.get('joinFormName');
   const viewerCode = queryParams.get('viewerCode');

--- a/app/javascript/components/rooms/room/join/JoinCard.jsx
+++ b/app/javascript/components/rooms/room/join/JoinCard.jsx
@@ -62,7 +62,7 @@ export default function JoinCard() {
   const { data: signInOnRoomJoin } = useSiteSetting('SignInOnRoomJoin');
 
   const { methods, fields } = useRoomJoinForm();
-  
+
   // get queryParams for JoinFormName
   const location = useLocation();
 

--- a/app/javascript/hooks/mutations/admin/manage_users/useAdminCreateUser.jsx
+++ b/app/javascript/hooks/mutations/admin/manage_users/useAdminCreateUser.jsx
@@ -27,7 +27,7 @@ export default function useAdminCreateUser({ onSettled }) {
     (user) => axios.post('/users.json', { user }),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries('getAdminUsers');
+        queryClient.invalidateQueries('getVerifiedUsers');
         toast.success(t('toast.success.user.user_created'));
       },
       onError: (err) => {

--- a/app/javascript/hooks/mutations/admin/manage_users/useDeleteUser.jsx
+++ b/app/javascript/hooks/mutations/admin/manage_users/useDeleteUser.jsx
@@ -27,7 +27,7 @@ export default function useDeleteUser(userId) {
     (data) => axios.delete(`/users/${userId}.json`, data),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries('getAdminUsers');
+        queryClient.invalidateQueries('getVerifiedUsers');
         toast.success(t('toast.success.user.user_deleted'));
       },
       onError: () => {

--- a/app/javascript/hooks/mutations/admin/manage_users/useUpdateUserStatus.jsx
+++ b/app/javascript/hooks/mutations/admin/manage_users/useUpdateUserStatus.jsx
@@ -29,7 +29,7 @@ export default function useUpdateUserStatus() {
       onSuccess: () => {
         queryClient.invalidateQueries(['getPendingUsers']);
         queryClient.invalidateQueries(['getBannedUsers']);
-        queryClient.invalidateQueries(['getAdminUsers']);
+        queryClient.invalidateQueries(['getVerifiedUsers']);
 
         toast.success(t('toast.success.user.user_updated'));
       },

--- a/app/javascript/hooks/mutations/admin/manage_users/useUpdateUserVerification.jsx
+++ b/app/javascript/hooks/mutations/admin/manage_users/useUpdateUserVerification.jsx
@@ -27,7 +27,7 @@ export default function useUpdateUserVerification() {
     (data) => axios.patch(`/admin/users/${data.id}.json`, { user: { verified: data.verified } }),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(['getAdminUsers']);
+        queryClient.invalidateQueries(['getVerifiedUsers']);
         queryClient.invalidateQueries(['getUnverifiedUsers']);
 
         toast.success(t('toast.success.user.user_updated'));

--- a/app/javascript/hooks/mutations/sessions/useCreateSession.jsx
+++ b/app/javascript/hooks/mutations/sessions/useCreateSession.jsx
@@ -55,6 +55,8 @@ export default function useCreateSession() {
           navigate(`/verify?id=${err.response.data.data}`);
         } else if (err.response.data.errors === 'PasswordNotSet') {
           navigate(`/reset_password/${err.response.data.data}`);
+        } else if (err.response.data.errors === 'HCaptchaInvalid') {
+          toast.error(t('toast.error.users.hcaptcha_invalid'));
         } else {
           toast.error(t('toast.error.session.invalid_credentials'));
         }

--- a/app/javascript/hooks/mutations/users/useCreateUser.jsx
+++ b/app/javascript/hooks/mutations/users/useCreateUser.jsx
@@ -53,6 +53,8 @@ export default function useCreateUser() {
           toast.error(t('toast.error.users.email_exists'));
         } else if (err.response.data.errors === 'BannedUser') {
           toast.error(t('toast.error.users.banned'));
+        } else if (err.response.data.errors === 'HCaptchaInvalid') {
+          toast.error(t('toast.error.users.hcaptcha_invalid'));
         } else {
           toast.error(t('toast.error.problem_completing_action'));
         }

--- a/app/javascript/hooks/queries/admin/manage_users/useVerifiedUsers.jsx
+++ b/app/javascript/hooks/queries/admin/manage_users/useVerifiedUsers.jsx
@@ -29,7 +29,7 @@ export default function useVerifiedUsers(input, page) {
   };
 
   return useQuery(
-    ['getAdminUsers', { ...params }],
+    ['getVerifiedUsers', { ...params }],
     () => axios.get('/admin/users/verified.json', { params }).then((resp) => resp.data),
     {
       keepPreviousData: true,


### PR DESCRIPTION
1. getAdminUsers renamed to getverifiedUsers. This makes more sense. It seems there was typo

2. Invalidating user session in case he is sent to banned state from active. 
    Server side crash is observed otherwise, in case the user has active login session and admin ban him. 
    Same is observed in Browser window, it gets stucked.
    On careful examination i found that we need to invalidate the session_token for user. 
    Doing this minimum work will logout the user.

3. Add proper error logging for non-verified token hcaptcha. 
    Toast message shown to client.
    Updated translation file.

![Screenshot from 2025-07-06 21-59-54](https://github.com/user-attachments/assets/81f17278-c874-49a9-bcc2-1f20d685d172)

4. Fixes #6014 

Redirect after signin to room join page was creating an issue. The redirect url was having two times  RELATIVE_URL_ROOT appended.
`document.location.pathname` returns `/RELATIVE_URL_ROOT/rooms/ROOM_FRIENDLY_ID/join`

Replaced the above with 
```
const location = useLocation();
const path = encodeURIComponent(location.pathname);
```

`location.pathname` returns `/rooms/ROOM_FRIENDLY_ID/join`. 

And after this, navigate works cool 

https://github.com/bigbluebutton/greenlight/blob/251c307b8bb71c1a9bc86144500e8eade2c66238/app/javascript/hooks/mutations/sessions/useCreateSession.jsx#L41
