### PR TITLE
Security fix: remove role id from permitted params

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -163,7 +163,7 @@ module Api
       private
 
       def create_user_params
-        @create_user_params ||= params.require(:user).permit(:name, :email, :password, :avatar, :language, :role_id, :invite_token)
+        @create_user_params ||= params.require(:user).permit(:name, :email, :password, :avatar, :language, :invite_token)
       end
 
       def update_user_params


### PR DESCRIPTION
- removed role id from the permitted params in `create_user_params` in the `users_controller`. preventing the `role_id` injection highlighted in the security issue raised