### PR TITLE
Add transfer room ownership feature

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -14,7 +14,7 @@
   "report": "Report",
   "share": "Share",
   "cancel": "Cancel",
-  "reset":   "Reset",
+  "reset": "Reset",
   "close": "Close",
   "delete": "Delete",
   "copy": "Copy Join Link",
@@ -143,7 +143,10 @@
       "add_some_users": "Time to add some users!",
       "add_some_users_description": "To add new users, click the button below and search or select the users you want to share this room with.",
       "delete_shared_access": "Delete Shared Access",
-      "are_you_sure_delete_shared_access": "Are you sure you want to delete this Shared Access?"
+      "are_you_sure_delete_shared_access": "Are you sure you want to delete this Shared Access?",
+      "transfer_ownership": "Transfer Ownership",
+      "transfer_room_ownership": "Transfer Room Ownership",
+      "transfer_ownership_warning": "Warning: You will permanently lose ownership of this room and all management rights. This action cannot be undone."
     },
     "settings": {
       "settings": "Settings",
@@ -329,14 +332,14 @@
         "default_role_description": "The default role to be assigned to newly created users",
         "registration_method": "Registration Method",
         "registration_method_description": "Change the way that users register to the website",
-        "registration_methods" : {
+        "registration_methods": {
           "open": "Open Registration",
           "invite": "Join by Invitation",
           "approval": "Approve/Decline"
         },
         "allowed_domains": "Allowed Email Domains",
         "allowed_domains_signup_description": "Allow specific email domains to sign up. Format must be: @test.com,domain.com",
-        "enter_allowed_domains_rule" : "Enter the allowed domains"
+        "enter_allowed_domains_rule": "Enter the allowed domains"
       }
     },
     "room_configuration": {
@@ -427,7 +430,8 @@
         "access_code_deleted": "The access code has been deleted.",
         "copied_meeting_url": "The meeting URL has been copied. The link can be used to join the meeting.",
         "copied_viewer_code": "The viewer access code has been copied.",
-        "copied_moderator_code": "The moderator access code has been copied."
+        "copied_moderator_code": "The moderator access code has been copied.",
+        "ownership_transferred": "Room ownership has been transferred."
       },
       "site_settings": {
         "site_setting_updated": "The site setting has been updated.",
@@ -575,8 +579,8 @@
     "room_join": {
       "fields": {
         "name": {
-            "label": "Name",
-            "placeholder": "Enter your name"
+          "label": "Name",
+          "placeholder": "Enter your name"
         },
         "access_code": {
           "label": "Access Code",

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -21,7 +21,7 @@ module Api
     class RoomsController < ApiController
       skip_before_action :ensure_authenticated, only: %i[public_show public_recordings]
 
-      before_action :find_room, only: %i[show update destroy recordings recordings_processing purge_presentation public_show public_recordings]
+      before_action :find_room, only: %i[show update destroy recordings recordings_processing purge_presentation public_show public_recordings transfer_ownership]
 
       before_action only: %i[create] do
         ensure_authorized('CreateRoom')
@@ -32,7 +32,7 @@ module Api
       before_action only: %i[show update recordings recordings_processing purge_presentation] do
         ensure_authorized(%w[ManageRooms SharedRoom], friendly_id: params[:friendly_id])
       end
-      before_action only: %i[destroy] do
+      before_action only: %i[destroy transfer_ownership] do
         ensure_authorized('ManageRooms', friendly_id: params[:friendly_id])
       end
 
@@ -151,6 +151,20 @@ module Api
       # Returns the total number of processing recordings for a specific room
       def recordings_processing
         render_data data: @room.recordings_processing, status: :ok
+      end
+
+      # POST /api/v1/rooms/:friendly_id/transfer_ownership.json
+      # Transfers room ownership to a different user
+      def transfer_ownership
+        new_owner = User.with_provider(current_provider).find_by(id: params[:new_owner_id])
+        return render_error status: :not_found unless new_owner
+        return render_error status: :unprocessable_entity if new_owner.id == @room.user_id
+
+        if @room.update(user_id: new_owner.id)
+          render_data status: :ok
+        else
+          render_error errors: @room.errors.to_a, status: :bad_request
+        end
       end
 
       private

--- a/app/controllers/api/v1/shared_accesses_controller.rb
+++ b/app/controllers/api/v1/shared_accesses_controller.rb
@@ -21,7 +21,7 @@ module Api
     class SharedAccessesController < ApiController
       before_action :find_room
 
-      before_action only: %i[create destroy shareable_users] do
+      before_action only: %i[create destroy shareable_users transferable_users] do
         ensure_authorized('ManageRooms', friendly_id: params[:friendly_id])
       end
       before_action only: %i[show unshare_room] do
@@ -80,6 +80,18 @@ module Api
                               .where(role_id: [role_ids])
                               .shared_access_search(params[:search])
         render_data data: shareable_users, serializer: SharedAccessSerializer, status: :ok
+      end
+
+      # GET /api/v1/shared_accesses/friendly_id/transferable_users.json
+      # Returns a list of users who can receive room ownership
+      def transferable_users
+        return render_data data: [], status: :ok unless params[:search].present? && params[:search].length >= 3
+
+        users = User.with_attached_avatar
+                    .with_provider(current_provider)
+                    .where.not(id: @room.user_id)
+                    .shared_access_search(params[:search])
+        render_data data: users, serializer: SharedAccessSerializer, status: :ok
       end
 
       private

--- a/app/controllers/api/v1/shared_accesses_controller.rb
+++ b/app/controllers/api/v1/shared_accesses_controller.rb
@@ -68,33 +68,38 @@ module Api
       # GET /api/v1/shared_accesses/friendly_id/shareable_users.json
       # Returns a list of users with whom a room can be shared with (based on role permissions)
       def shareable_users
-        return render_data data: [], status: :ok unless params[:search].present? && params[:search].length >= 3
+        return render_data data: [], status: :ok unless search_valid?
 
         # role_id of roles that have SharedList permission set to true
         role_ids = RolePermission.joins(:permission).where(permission: { name: 'SharedList' }).where(value: 'true').pluck(:role_id)
 
         # Can't share the room if it's already shared or it's the room owner
-        shareable_users = User.with_attached_avatar
-                              .with_provider(current_provider)
-                              .where.not(id: [@room.shared_users.pluck(:id) << @room.user_id])
-                              .where(role_id: [role_ids])
-                              .shared_access_search(params[:search])
+        shareable_users = search_users
+                          .where.not(id: @room.shared_users.pluck(:id) + [@room.user_id])
+                          .where(role_id: role_ids)
         render_data data: shareable_users, serializer: SharedAccessSerializer, status: :ok
       end
 
       # GET /api/v1/shared_accesses/friendly_id/transferable_users.json
       # Returns a list of users who can receive room ownership
       def transferable_users
-        return render_data data: [], status: :ok unless params[:search].present? && params[:search].length >= 3
+        return render_data data: [], status: :ok unless search_valid?
 
-        users = User.with_attached_avatar
-                    .with_provider(current_provider)
-                    .where.not(id: @room.user_id)
-                    .shared_access_search(params[:search])
+        users = search_users.where.not(id: @room.user_id)
         render_data data: users, serializer: SharedAccessSerializer, status: :ok
       end
 
       private
+
+      def search_valid?
+        params[:search].present? && params[:search].length >= 3
+      end
+
+      def search_users
+        User.with_attached_avatar
+            .with_provider(current_provider)
+            .shared_access_search(params[:search])
+      end
 
       def find_room
         @room = Room.find_by(friendly_id: params[:friendly_id])

--- a/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
+++ b/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
@@ -26,6 +26,7 @@ import useDeleteRoom from '../../../../hooks/mutations/rooms/useDeleteRoom';
 import RoomSettingsRow from './RoomSettingsRow';
 import Modal from '../../../shared_components/modals/Modal';
 import DeleteRoomForm from '../forms/DeleteRoomForm';
+import TransferOwnershipForm from '../shared_access/forms/TransferOwnershipForm';
 import useRoomConfigs from '../../../../hooks/queries/rooms/useRoomConfigs';
 import AccessCodeRow from './AccessCodeRow';
 import useUpdateRoomSetting from '../../../../hooks/mutations/room_settings/useUpdateRoomSetting';
@@ -151,16 +152,31 @@ export default function RoomSettings() {
                   {
                     (!room.shared || currentUser?.permissions?.ManageRooms === 'true')
                       && (
-                        <Modal
-                          modalButton={(
-                            <Button
-                              variant="delete"
-                              className="mt-1 mx-2 float-end"
-                            >{t('room.delete_room')}
-                            </Button>
-                          )}
-                          body={<DeleteRoomForm mutation={deleteMutationWrapper} />}
-                        />
+                        <>
+                          <Modal
+                            modalButton={(
+                              <Button
+                                variant="brand-outline"
+                                className="mt-1 mx-2 float-end"
+                              >{t('room.shared_access.transfer_ownership')}
+                              </Button>
+                            )}
+                            title={t('room.shared_access.transfer_room_ownership')}
+                            body={<TransferOwnershipForm />}
+                            size="lg"
+                            id="transfer-ownership-modal"
+                          />
+                          <Modal
+                            modalButton={(
+                              <Button
+                                variant="delete"
+                                className="mt-1 mx-2 float-end"
+                              >{t('room.delete_room')}
+                              </Button>
+                            )}
+                            body={<DeleteRoomForm mutation={deleteMutationWrapper} />}
+                          />
+                        </>
                       )
                   }
                 </Stack>

--- a/app/javascript/components/rooms/room/shared_access/SharedAccess.jsx
+++ b/app/javascript/components/rooms/room/shared_access/SharedAccess.jsx
@@ -56,7 +56,7 @@ export default function SharedAccess() {
                   className="ms-auto"
                 >{t('room.shared_access.add_share_access')}
                 </Button>
-)}
+              )}
               title={t('room.shared_access.share_room_access')}
               body={<SharedAccessForm />}
               size="lg"

--- a/app/javascript/components/rooms/room/shared_access/forms/SharedAccessForm.jsx
+++ b/app/javascript/components/rooms/room/shared_access/forms/SharedAccessForm.jsx
@@ -18,15 +18,15 @@
 
 import React, { useState } from 'react';
 import {
-  Button, Form, Stack, Table,
+  Button, Form, Stack,
 } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import useShareAccess from '../../../../../hooks/mutations/shared_accesses/useShareAccess';
-import Avatar from '../../../../users/user/Avatar';
 import SearchBar from '../../../../shared_components/search/SearchBar';
 import useShareableUsers from '../../../../../hooks/queries/shared_accesses/useShareableUsers';
+import UserSearchTable from './UserSearchTable';
 
 export default function SharedAccessForm({ handleClose }) {
   const { t } = useTranslation();
@@ -55,50 +55,13 @@ export default function SharedAccessForm({ handleClose }) {
     <div id="shared-access-form">
       <SearchBar searchInput={searchInput} setSearchInput={setSearchInput} />
       <Form onSubmit={onSubmit}>
-        <div className="table-scrollbar-wrapper">
-          <Table hover responsive className="text-secondary my-3">
-            <thead>
-              <tr className="text-muted small">
-                <th className="fw-normal">{ t('user.name') }</th>
-              </tr>
-            </thead>
-            <tbody className="border-top-0">
-              {
-                (() => {
-                  if (searchInput?.length >= 3 && shareableUsers?.length) {
-                    return (
-                      shareableUsers.map((user) => (
-                        <tr
-                          key={user.id}
-                          className="align-middle"
-                        >
-                          <td>
-                            <Stack direction="horizontal" className="py-2">
-                              <Form.Label className="w-100 mb-0 text-brand">
-                                <Form.Check
-                                  id={`${user.id}-checkbox`}
-                                  type="checkbox"
-                                  value={user.id}
-                                  className="d-inline-block"
-                                  checked={selectedUsers.includes(user.id)}
-                                  onChange={() => toggleUserSelection(user.id)}
-                                />
-                                <Avatar avatar={user.avatar} size="small" className="d-inline-block px-3" />
-                                {user.name}
-                              </Form.Label>
-                            </Stack>
-                          </td>
-                        </tr>
-                      )));
-                  } if (searchInput?.length >= 3) {
-                    return (<tr className="fw-bold"><td>{ t('user.no_user_found') }</td><td /></tr>);
-                  }
-                  return (<tr className="fw-bold"><td colSpan="2">{ t('user.type_three_characters') }</td></tr>);
-                })()
-              }
-            </tbody>
-          </Table>
-        </div>
+        <UserSearchTable
+          users={shareableUsers}
+          searchInput={searchInput}
+          inputType="checkbox"
+          isChecked={(userId) => selectedUsers.includes(userId)}
+          onChange={toggleUserSelection}
+        />
         <Stack id="shared-access-modal-buttons" className="mt-3" direction="horizontal" gap={1}>
           <Button variant="neutral" className="ms-auto" onClick={handleClose}>
             { t('close') }

--- a/app/javascript/components/rooms/room/shared_access/forms/TransferOwnershipForm.jsx
+++ b/app/javascript/components/rooms/room/shared_access/forms/TransferOwnershipForm.jsx
@@ -1,0 +1,118 @@
+// BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+//
+// Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+//
+// This program is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3.0 of the License, or (at your option) any later
+// version.
+//
+// Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along
+// with Greenlight; if not, see <http://www.gnu.org/licenses/>.
+
+/* eslint-disable react/jsx-props-no-spreading */
+
+import React, { useState } from 'react';
+import {
+  Alert, Button, Form, Stack, Table,
+} from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import useTransferOwnership from '../../../../../hooks/mutations/rooms/useTransferOwnership';
+import Avatar from '../../../../users/user/Avatar';
+import SearchBar from '../../../../shared_components/search/SearchBar';
+import useTransferableUsers from '../../../../../hooks/queries/shared_accesses/useTransferableUsers';
+
+export default function TransferOwnershipForm({ handleClose }) {
+  const { t } = useTranslation();
+  const { friendlyId } = useParams();
+  const transferOwnership = useTransferOwnership({ friendlyId, closeModal: handleClose });
+  const [searchInput, setSearchInput] = useState();
+  const [selectedUserId, setSelectedUserId] = useState(null);
+  const { data: transferableUsers } = useTransferableUsers(friendlyId, searchInput);
+
+  const onSubmit = (event) => {
+    event.preventDefault();
+    if (!selectedUserId) return;
+    transferOwnership.mutate({ new_owner_id: selectedUserId });
+  };
+
+  return (
+    <div id="transfer-ownership-form">
+      <Alert variant="danger" className="d-flex align-items-start gap-2">
+        <ExclamationTriangleIcon className="hi-s flex-shrink-0 mt-1" />
+        <span>{t('room.shared_access.transfer_ownership_warning')}</span>
+      </Alert>
+      <SearchBar searchInput={searchInput} setSearchInput={setSearchInput} />
+      <Form onSubmit={onSubmit}>
+        <div className="table-scrollbar-wrapper">
+          <Table hover responsive className="text-secondary my-3">
+            <thead>
+              <tr className="text-muted small">
+                <th className="fw-normal">{ t('user.name') }</th>
+              </tr>
+            </thead>
+            <tbody className="border-top-0">
+              {
+                (() => {
+                  if (searchInput?.length >= 3 && transferableUsers?.length) {
+                    return (
+                      transferableUsers.map((user) => (
+                        <tr
+                          key={user.id}
+                          className="align-middle"
+                        >
+                          <td>
+                            <Stack direction="horizontal" className="py-2">
+                              <Form.Label className="w-100 mb-0 text-brand">
+                                <Form.Check
+                                  id={`${user.id}-radio`}
+                                  type="radio"
+                                  name="transfer-owner"
+                                  value={user.id}
+                                  className="d-inline-block"
+                                  checked={selectedUserId === user.id}
+                                  onChange={() => setSelectedUserId(user.id)}
+                                />
+                                <Avatar avatar={user.avatar} size="small" className="d-inline-block px-3" />
+                                {user.name}
+                              </Form.Label>
+                            </Stack>
+                          </td>
+                        </tr>
+                      )));
+                  } if (searchInput?.length >= 3) {
+                    return (<tr className="fw-bold"><td>{ t('user.no_user_found') }</td><td /></tr>);
+                  }
+                  return (<tr className="fw-bold"><td colSpan="2">{ t('user.type_three_characters') }</td></tr>);
+                })()
+              }
+            </tbody>
+          </Table>
+        </div>
+        <Stack id="transfer-ownership-modal-buttons" className="mt-3" direction="horizontal" gap={1}>
+          <Button variant="neutral" className="ms-auto" onClick={handleClose}>
+            { t('close') }
+          </Button>
+          <Button variant="danger" type="submit" disabled={!selectedUserId}>
+            { t('room.shared_access.transfer_ownership') }
+          </Button>
+        </Stack>
+      </Form>
+    </div>
+  );
+}
+
+TransferOwnershipForm.propTypes = {
+  handleClose: PropTypes.func,
+};
+
+TransferOwnershipForm.defaultProps = {
+  handleClose: () => { },
+};

--- a/app/javascript/components/rooms/room/shared_access/forms/TransferOwnershipForm.jsx
+++ b/app/javascript/components/rooms/room/shared_access/forms/TransferOwnershipForm.jsx
@@ -18,16 +18,16 @@
 
 import React, { useState } from 'react';
 import {
-  Alert, Button, Form, Stack, Table,
+  Alert, Button, Form, Stack,
 } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import useTransferOwnership from '../../../../../hooks/mutations/rooms/useTransferOwnership';
-import Avatar from '../../../../users/user/Avatar';
 import SearchBar from '../../../../shared_components/search/SearchBar';
 import useTransferableUsers from '../../../../../hooks/queries/shared_accesses/useTransferableUsers';
+import UserSearchTable from './UserSearchTable';
 
 export default function TransferOwnershipForm({ handleClose }) {
   const { t } = useTranslation();
@@ -51,51 +51,14 @@ export default function TransferOwnershipForm({ handleClose }) {
       </Alert>
       <SearchBar searchInput={searchInput} setSearchInput={setSearchInput} />
       <Form onSubmit={onSubmit}>
-        <div className="table-scrollbar-wrapper">
-          <Table hover responsive className="text-secondary my-3">
-            <thead>
-              <tr className="text-muted small">
-                <th className="fw-normal">{ t('user.name') }</th>
-              </tr>
-            </thead>
-            <tbody className="border-top-0">
-              {
-                (() => {
-                  if (searchInput?.length >= 3 && transferableUsers?.length) {
-                    return (
-                      transferableUsers.map((user) => (
-                        <tr
-                          key={user.id}
-                          className="align-middle"
-                        >
-                          <td>
-                            <Stack direction="horizontal" className="py-2">
-                              <Form.Label className="w-100 mb-0 text-brand">
-                                <Form.Check
-                                  id={`${user.id}-radio`}
-                                  type="radio"
-                                  name="transfer-owner"
-                                  value={user.id}
-                                  className="d-inline-block"
-                                  checked={selectedUserId === user.id}
-                                  onChange={() => setSelectedUserId(user.id)}
-                                />
-                                <Avatar avatar={user.avatar} size="small" className="d-inline-block px-3" />
-                                {user.name}
-                              </Form.Label>
-                            </Stack>
-                          </td>
-                        </tr>
-                      )));
-                  } if (searchInput?.length >= 3) {
-                    return (<tr className="fw-bold"><td>{ t('user.no_user_found') }</td><td /></tr>);
-                  }
-                  return (<tr className="fw-bold"><td colSpan="2">{ t('user.type_three_characters') }</td></tr>);
-                })()
-              }
-            </tbody>
-          </Table>
-        </div>
+        <UserSearchTable
+          users={transferableUsers}
+          searchInput={searchInput}
+          inputType="radio"
+          inputName="transfer-owner"
+          isChecked={(userId) => selectedUserId === userId}
+          onChange={setSelectedUserId}
+        />
         <Stack id="transfer-ownership-modal-buttons" className="mt-3" direction="horizontal" gap={1}>
           <Button variant="neutral" className="ms-auto" onClick={handleClose}>
             { t('close') }

--- a/app/javascript/components/rooms/room/shared_access/forms/UserSearchTable.jsx
+++ b/app/javascript/components/rooms/room/shared_access/forms/UserSearchTable.jsx
@@ -1,0 +1,100 @@
+// BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+//
+// Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+//
+// This program is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3.0 of the License, or (at your option) any later
+// version.
+//
+// Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along
+// with Greenlight; if not, see <http://www.gnu.org/licenses/>.
+
+import React from 'react';
+import {
+  Form, Stack, Table,
+} from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+import Avatar from '../../../../users/user/Avatar';
+
+export default function UserSearchTable({
+  users, searchInput, inputType, inputName, isChecked, onChange,
+}) {
+  const { t } = useTranslation();
+
+  if (inputType === 'radio' && !inputName) {
+    console.error('UserSearchTable: inputName is required when inputType is "radio"');
+  }
+
+  return (
+    <div className="table-scrollbar-wrapper">
+      <Table hover responsive className="text-secondary my-3">
+        <thead>
+          <tr className="text-muted small">
+            <th className="fw-normal">{ t('user.name') }</th>
+          </tr>
+        </thead>
+        <tbody className="border-top-0">
+          {
+            (() => {
+              if (searchInput?.length >= 3 && users?.length) {
+                return (
+                  users.map((user) => (
+                    <tr
+                      key={user.id}
+                      className="align-middle"
+                    >
+                      <td>
+                        <Stack direction="horizontal" className="py-2">
+                          <Form.Label className="w-100 mb-0 text-brand">
+                            <Form.Check
+                              id={`${user.id}-${inputType}`}
+                              type={inputType}
+                              name={inputName}
+                              value={user.id}
+                              className="d-inline-block"
+                              checked={isChecked(user.id)}
+                              onChange={() => onChange(user.id)}
+                            />
+                            <Avatar avatar={user.avatar} size="small" className="d-inline-block px-3" />
+                            {user.name}
+                          </Form.Label>
+                        </Stack>
+                      </td>
+                    </tr>
+                  )));
+              } if (searchInput?.length >= 3) {
+                return (<tr className="fw-bold"><td>{ t('user.no_user_found') }</td></tr>);
+              }
+              return (<tr className="fw-bold"><td colSpan="2">{ t('user.type_three_characters') }</td></tr>);
+            })()
+          }
+        </tbody>
+      </Table>
+    </div>
+  );
+}
+
+UserSearchTable.propTypes = {
+  users: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    avatar: PropTypes.string,
+  })),
+  searchInput: PropTypes.string,
+  inputType: PropTypes.oneOf(['checkbox', 'radio']).isRequired,
+  inputName: PropTypes.string,
+  isChecked: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+UserSearchTable.defaultProps = {
+  users: [],
+  searchInput: undefined,
+  inputName: undefined,
+};

--- a/app/javascript/hooks/mutations/rooms/useTransferOwnership.jsx
+++ b/app/javascript/hooks/mutations/rooms/useTransferOwnership.jsx
@@ -1,0 +1,42 @@
+// BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+//
+// Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+//
+// This program is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3.0 of the License, or (at your option) any later
+// version.
+//
+// Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along
+// with Greenlight; if not, see <http://www.gnu.org/licenses/>.
+
+import { useMutation, useQueryClient } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { useTranslation } from 'react-i18next';
+import axios from '../../../helpers/Axios';
+
+export default function useTransferOwnership({ friendlyId, closeModal }) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    (data) => axios.post(`/rooms/${friendlyId}/transfer_ownership.json`, { new_owner_id: data.new_owner_id }),
+    {
+      onSuccess: () => {
+        closeModal();
+        queryClient.invalidateQueries('getRooms');
+        navigate('/rooms');
+        toast.success(t('toast.success.room.ownership_transferred'));
+      },
+      onError: () => {
+        toast.error(t('toast.error.problem_completing_action'));
+      },
+    },
+  );
+}

--- a/app/javascript/hooks/queries/shared_accesses/useTransferableUsers.jsx
+++ b/app/javascript/hooks/queries/shared_accesses/useTransferableUsers.jsx
@@ -1,0 +1,33 @@
+// BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+//
+// Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+//
+// This program is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3.0 of the License, or (at your option) any later
+// version.
+//
+// Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along
+// with Greenlight; if not, see <http://www.gnu.org/licenses/>.
+
+import { useQuery } from 'react-query';
+import axios from '../../../helpers/Axios';
+
+export default function useTransferableUsers(friendlyId, input) {
+  const params = {
+    search: input,
+  };
+
+  return useQuery(
+    ['getTransferableUsers', { ...params }],
+    () => axios.get(`/shared_accesses/${friendlyId}/transferable_users.json`, { params }).then((resp) => resp.data.data),
+    {
+      keepPreviousData: true,
+      enabled: input?.length >= 3,
+    },
+  );
+}

--- a/app/javascript/hooks/queries/shared_accesses/useTransferableUsers.jsx
+++ b/app/javascript/hooks/queries/shared_accesses/useTransferableUsers.jsx
@@ -14,20 +14,8 @@
 // You should have received a copy of the GNU Lesser General Public License along
 // with Greenlight; if not, see <http://www.gnu.org/licenses/>.
 
-import { useQuery } from 'react-query';
-import axios from '../../../helpers/Axios';
+import useUserSearch from './useUserSearch';
 
 export default function useTransferableUsers(friendlyId, input) {
-  const params = {
-    search: input,
-  };
-
-  return useQuery(
-    ['getTransferableUsers', { ...params }],
-    () => axios.get(`/shared_accesses/${friendlyId}/transferable_users.json`, { params }).then((resp) => resp.data.data),
-    {
-      keepPreviousData: true,
-      enabled: input?.length >= 3,
-    },
-  );
+  return useUserSearch(friendlyId, input, { queryKey: 'getTransferableUsers', endpoint: 'transferable_users' });
 }

--- a/app/javascript/hooks/queries/shared_accesses/useUserSearch.jsx
+++ b/app/javascript/hooks/queries/shared_accesses/useUserSearch.jsx
@@ -14,8 +14,20 @@
 // You should have received a copy of the GNU Lesser General Public License along
 // with Greenlight; if not, see <http://www.gnu.org/licenses/>.
 
-import useUserSearch from './useUserSearch';
+import { useQuery } from 'react-query';
+import axios from '../../../helpers/Axios';
 
-export default function useShareableUsers(friendlyId, input) {
-  return useUserSearch(friendlyId, input, { queryKey: 'getShareableUsers', endpoint: 'shareable_users' });
+export default function useUserSearch(friendlyId, input, { queryKey, endpoint }) {
+  const params = {
+    search: input,
+  };
+
+  return useQuery(
+    [queryKey, input],
+    () => axios.get(`/shared_accesses/${friendlyId}/${endpoint}.json`, { params }).then((resp) => resp.data.data),
+    {
+      keepPreviousData: true,
+      enabled: input?.length >= 3,
+    },
+  );
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
           get '/recordings_processing', to: 'rooms#recordings_processing'
           get '/public', to: 'rooms#public_show'
           delete :purge_presentation
+          post '/transfer_ownership', to: 'rooms#transfer_ownership'
         end
       end
       resources :meetings, only: %i[], param: :friendly_id do
@@ -69,6 +70,7 @@ Rails.application.routes.draw do
       resources :shared_accesses, only: %i[create show destroy], param: :friendly_id do
         member do
           get '/shareable_users', to: 'shared_accesses#shareable_users'
+          get '/transferable_users', to: 'shared_accesses#transferable_users'
           post '/unshare_room', to: 'shared_accesses#unshare_room'
         end
       end


### PR DESCRIPTION
Hello dear maintainers, a colleague asked me if we can change the ownser of a room. I saw in https://github.com/bigbluebutton/greenlight/issues/5178#issuecomment-1560787621 that some people are doing this directly in the database. I took a look here and there, and indeed this looks, ower is just a user id, and that's pretty much it. So I started this PR to offer a more user friendly way to do this. To be transparent, I used the help of claude. I also tested this on an internal testing BBB 3 instance. 

- POST /api/v1/rooms/:friendly_id/transfer_ownership endpoint, owner-only
- GET /api/v1/shared_accesses/:friendly_id/transferable_users endpoint
- TransferOwnershipForm with danger alert and radio-button user selection
- "Transfer Ownership" button in Settings panel alongside Delete button
- Navigates back to /rooms on success (owner loses access to transferred room, maybe we could automatically share the room to previous owner?)

Questions for the maintainers could be:
- is this ownership transfer safe? 
- if so, can we have a UI for this? 

Fix https://github.com/bigbluebutton/greenlight/issues/6216 and fix https://github.com/bigbluebutton/greenlight/issues/5178