### PR TITLE
Fix i18n locale loading for regional codes (de-DE, en-US, etc.)

### DIFF
--- a/app/javascript/App.jsx
+++ b/app/javascript/App.jsx
@@ -85,8 +85,13 @@ export default function App() {
   // i18n
   const { i18n } = useTranslation();
   useEffect(() => {
-    i18n.changeLanguage(currentUser?.language);
-  }, [currentUser?.language]);
+    if (currentUser?.language) {
+      i18n.changeLanguage(currentUser.language).catch(() => {
+        // Silently fall back to default language if change fails
+        console.warn(`Failed to load language: ${currentUser.language}`);
+      });
+    }
+  }, [currentUser?.language, i18n]);
 
   // Greenlight V3 brand-color theming
   const { isLoading, data: brandColors } = useSiteSetting(['PrimaryColor', 'PrimaryColorLight']);

--- a/app/javascript/i18n.jsx
+++ b/app/javascript/i18n.jsx
@@ -25,14 +25,7 @@ i18next
     backend: {
       loadPath: `${process.env.RELATIVE_URL_ROOT}/api/v1/locales/{{lng}}.json`,
     },
-    load: 'currentOnly',
-    fallbackLng: (locale) => {
-      const fallbacks = [];
-      if (locale?.indexOf('-') > -1) {
-        fallbacks.push(locale.split('-')[0]);
-      }
-      fallbacks.push('en');
-      return fallbacks;
-    },
+    load: 'languageOnly',
+    fallbackLng: ['en'],
   });
 export default i18next;


### PR DESCRIPTION
- fixes issue #6257
- Switch load strategy from 'currentOnly' to 'languageOnly' to normalize
  regional locale codes (de-DE → de) matching available backend files
- Simplify fallbackLng to static array since normalization is automatic
- Add error handling to i18n.changeLanguage() to prevent crashes on
  locale load failures