### PR TITLE
Add Room ID (friendly_id) update in room settings

### DIFF
--- a/app/assets/locales/en.json
+++ b/app/assets/locales/en.json
@@ -110,6 +110,8 @@
     "room": "Room",
     "rooms": "Rooms",
     "room_name": "Room Name",
+    "room_id": "Room ID",
+    "enter_room_id": "Enter a custom room ID",
     "add_new_room": "+ New Room",
     "create_room": "Create Room",
     "delete_room": "Delete Room",

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -160,7 +160,7 @@ module Api
       end
 
       def room_params
-        params.require(:room).permit(:name, :user_id, :presentation)
+        params.require(:room).permit(:name, :user_id, :presentation, :friendly_id)
       end
     end
   end

--- a/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
+++ b/app/javascript/components/rooms/room/room_settings/RoomSettings.jsx
@@ -31,6 +31,7 @@ import AccessCodeRow from './AccessCodeRow';
 import useUpdateRoomSetting from '../../../../hooks/mutations/room_settings/useUpdateRoomSetting';
 import { useAuth } from '../../../../contexts/auth/AuthProvider';
 import UpdateRoomNameForm from './forms/UpdateRoomNameForm';
+import UpdateRoomFriendlyIdForm from './forms/UpdateRoomFriendlyIdForm';
 import useRoom from '../../../../hooks/queries/rooms/useRoom';
 import UnshareRoom from './UnshareRoom';
 import useServerTags from '../../../../hooks/queries/rooms/useServerTags';
@@ -57,6 +58,7 @@ export default function RoomSettings() {
           <Row>
             <Col className="border-end border-2">
               <UpdateRoomNameForm friendlyId={friendlyId} />
+              <UpdateRoomFriendlyIdForm friendlyId={friendlyId} />
               <AccessCodeRow
                 settingName="glViewerAccessCode"
                 updateMutation={updateMutationWrapper}

--- a/app/javascript/components/rooms/room/room_settings/forms/UpdateRoomFriendlyIdForm.jsx
+++ b/app/javascript/components/rooms/room/room_settings/forms/UpdateRoomFriendlyIdForm.jsx
@@ -1,0 +1,67 @@
+// BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+//
+// Copyright (c) 2022 BigBlueButton Inc. and by respective authors (see below).
+//
+// This program is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3.0 of the License, or (at your option) any later
+// version.
+//
+// Greenlight is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along
+// with Greenlight; if not, see <http://www.gnu.org/licenses/>.
+
+/* eslint-disable react/jsx-props-no-spreading */
+
+import React from 'react';
+import {
+  Button, Row, Stack, Form,
+} from 'react-bootstrap';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+import useRoom from '../../../../../hooks/queries/rooms/useRoom';
+import useUpdateRoom from '../../../../../hooks/mutations/rooms/useUpdateRoom';
+
+export default function UpdateRoomFriendlyIdForm({ friendlyId }) {
+  const { t } = useTranslation();
+  const { register, handleSubmit } = useForm();
+  const { data: room } = useRoom(friendlyId);
+  const updateRoom = useUpdateRoom({ friendlyId });
+  const navigate = useNavigate();
+
+  const submit = (data) => {
+    const newFriendlyId = data.room.friendly_id;
+    updateRoom.mutate(data, {
+      onSuccess: () => navigate(`/rooms/${newFriendlyId}`),
+    });
+  };
+
+  return (
+    <Row className="mt-3">
+      <h6 className="text-brand">{ t('room.room_id') }</h6>
+      <Form onSubmit={handleSubmit(submit)}>
+        <Stack direction="horizontal">
+          <Form.Control
+            type="text"
+            defaultValue={room.friendly_id}
+            {...register('room.friendly_id', {
+              minLength: 3,
+              maxLength: 50,
+              pattern: /^[a-z0-9][a-z0-9-]*[a-z0-9]$/,
+            })}
+          />
+          <Button type="submit" variant="brand" className="ms-3">{ t('update') }</Button>
+        </Stack>
+      </Form>
+    </Row>
+  );
+}
+
+UpdateRoomFriendlyIdForm.propTypes = {
+  friendlyId: PropTypes.string.isRequired,
+};

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -29,6 +29,7 @@ class Room < ApplicationRecord
 
   validates :name, presence: true
   validates :friendly_id, presence: true, uniqueness: true
+  validates :friendly_id, format: { with: /\A[a-z0-9][a-z0-9-]*[a-z0-9]\z/ }, length: { minimum: 3, maximum: 50 }, on: :update
   validates :meeting_id, presence: true, uniqueness: true
   validates :presentation,
             content_type: Rails.configuration.uploads[:presentations][:formats],


### PR DESCRIPTION
Allows room owners to set a custom friendly_id from the settings UI. Validates format (lowercase alphanumeric + hyphens only, no dots), length (3–50 chars), and uniqueness. On success, navigates to the new room URL.

Closes #1106

- I did not tested yet, I will update when done
