### PR TITLE
Allow full hostnames for tenant names

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,9 +85,11 @@ class ApplicationController < ActionController::Base
 
   # Parses the url for the user domain
   def parse_user_domain(hostname)
-    tenant = hostname&.split('.')&.first
-    raise 'Invalid domain' unless Tenant.exists?(name: tenant)
+    return hostname if Tenant.exists?(name: hostname)
 
-    tenant
+    subdomain = hostname&.split('.')&.first
+    raise 'Invalid domain' unless Tenant.exists?(name: subdomain)
+
+    subdomain
   end
 end


### PR DESCRIPTION
This pull request is using the full domain as a tenant name instead only a subdomain.