### PR TITLE
Gemfile: Remove binary platform from lock file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,6 @@ GEM
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ffi (1.17.2)
-    ffi (1.17.2-x86_64-linux-gnu)
     globalid (1.3.0)
       activesupport (>= 6.1)
     google-apis-core (1.0.2)
@@ -290,8 +289,6 @@ GEM
     nkf (0.2.0)
     nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
-    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
@@ -527,7 +524,6 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-linux
 
 DEPENDENCIES
   active_model_serializers (>= 0.10.15)


### PR DESCRIPTION
We have issues packaging Greenlight for Nix and manually need to patch out the custom x86_64 platform https://github.com/NixOS/nixpkgs/pull/550046
If you're not dependent on it, we would be happy for upstreaming this patch :)